### PR TITLE
feat: add DigitalOcean as streaming LLM provider

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -1862,6 +1862,33 @@ class GnomeSpeaksService:
                 resp.raise_for_status()
                 token_iter = self._iter_openai_tokens(resp)  # Azure uses OpenAI SSE format
 
+            elif provider == "digitalocean":
+                do_key = api_key or self._load_cca_config().get("do_api_key", "")
+                if not do_key:
+                    GLib.idle_add(self._emit_error, "No DigitalOcean API key configured")
+                    self._set_state("idle")
+                    return
+                msgs = [{"role": "system", "content": system_prompt}]
+                msgs.extend(history)
+                msgs.append({"role": "user", "content": user_text})
+                resp = http_requests.post(
+                    "https://inference.do-ai.run/v1/chat/completions",
+                    headers={
+                        "Authorization": f"Bearer {do_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "model": model,
+                        "messages": msgs,
+                        "max_completion_tokens": max(256, 1024),
+                        "stream": True,
+                    },
+                    timeout=60,
+                    stream=True,
+                )
+                resp.raise_for_status()
+                token_iter = self._iter_openai_tokens(resp)
+
             elif provider == "google":
                 cca_config = self._load_cca_config()
                 google_key = cca_config.get("google_api_key", "")
@@ -2111,7 +2138,7 @@ class GnomeSpeaksService:
         # Streaming is supported for direct API providers.
         # cloud-chat-assistant/bedrock use an async call_llm that doesn't
         # support streaming, so fall back to the synchronous path.
-        if provider in ("anthropic", "openai", "azure", "google"):
+        if provider in ("anthropic", "openai", "azure", "google", "digitalocean"):
             return self._stream_conversation_worker(user_text)
 
         # --- Synchronous fallback for cloud-chat-assistant / bedrock ---

--- a/prefs.js
+++ b/prefs.js
@@ -141,6 +141,7 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         this._addComboRow(aiGroup, 'LLM Provider', 'llm_provider', [
             ['anthropic', 'Anthropic (Claude)'],
             ['openai', 'OpenAI (GPT)'],
+            ['digitalocean', 'DigitalOcean'],
             ['azure', 'Azure AI Foundry'],
             ['bedrock', 'AWS Bedrock'],
             ['google', 'Google Vertex AI'],
@@ -148,16 +149,29 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         ], 'anthropic');
 
         this._addComboRow(aiGroup, 'LLM Model', 'llm_model', [
+            // Anthropic direct
             ['claude-opus-4-6', 'Claude Opus 4.6'],
             ['claude-sonnet-4-6', 'Claude Sonnet 4.6'],
             ['claude-haiku-4-5-20251001', 'Claude Haiku 4.5'],
+            // OpenAI direct
             ['gpt-4o', 'GPT-4o'],
             ['gpt-4o-mini', 'GPT-4o Mini'],
             ['o4-mini', 'o4-mini'],
             ['gpt-5.3-chat', 'GPT-5.3 Chat'],
+            // DigitalOcean
+            ['anthropic-claude-opus-4.6', 'DO: Claude Opus 4.6'],
+            ['anthropic-claude-4.6-sonnet', 'DO: Claude Sonnet 4.6'],
+            ['anthropic-claude-haiku-4.5', 'DO: Claude Haiku 4.5'],
+            ['openai-gpt-4o', 'DO: GPT-4o'],
+            ['openai-gpt-4o-mini', 'DO: GPT-4o Mini'],
+            ['openai-o3-mini', 'DO: o3-mini'],
+            ['llama3.3-70b-instruct', 'DO: Llama 3.3 70B'],
+            ['deepseek-r1-distill-llama-70b', 'DO: DeepSeek R1 70B'],
+            // Azure AI Foundry
             ['grok-3', 'Grok-3'],
             ['DeepSeek-R1', 'DeepSeek R1'],
             ['Llama-3.3-70B-Instruct', 'Llama 3.3 70B'],
+            // Google
             ['gemini-2.5-flash', 'Gemini 2.5 Flash'],
             ['gemini-2.5-pro', 'Gemini 2.5 Pro'],
         ], 'claude-opus-4-6');


### PR DESCRIPTION
## Summary
- Add DigitalOcean as a first-class streaming LLM provider in the service, using its OpenAI-compatible SSE endpoint (`inference.do-ai.run/v1`)
- Add DigitalOcean provider option and DO-prefixed models (Claude, GPT, Llama, DeepSeek) to the extension preferences UI
- Falls back to `do_api_key` from cloud-chat-assistant config if no key set in `llm_api_key`

## Test plan
- [ ] Set LLM Provider to DigitalOcean and select a DO model in extension prefs
- [ ] Enable AI mode and speak — verify streaming LLM response is spoken aloud
- [ ] Verify fallback reads `do_api_key` from cloud-chat-assistant config when `llm_api_key` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)