### PR TITLE
feat(http): speech queue with user preemption

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,28 @@ journalctl --user -u gnome-speaks -f
 systemctl --user restart gnome-speaks
 ```
 
+## HTTP API
+
+A localhost REST API on port `7710` for browser- and agent-driven TTS. Speech
+requests **queue FIFO** — concurrent callers never cut each other off — while
+speech you trigger yourself (keyboard shortcut, D-Bus, AI replies) preempts the
+current utterance immediately and holds the queue until you finish.
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /speak` | Queue text for speech. Body: `text` (required), `voice` (Azure ShortName), `quality` (`fast`/`hd`), `output_file` (save WAV instead of playing), `interrupt` (`true` = flush everything and speak now). Returns `{ok, id, position, state}`; `429` when the queue (depth 32) is full. |
+| `POST /skip` | Cancel the current utterance; the next queued one plays. Returns `{ok, skipped}`. |
+| `POST /stop` | Panic button: stop playback and drain the queue. Returns `{ok, cleared}`. |
+| `POST /pause` / `POST /resume` | Pause/resume current playback. |
+| `GET /queue` | Queue introspection: `{current, pending, depth}`. |
+| `GET /status` | Service state, pause flag, `queue_depth`, playback progress. |
+| `GET /voices` | Available Azure voices (cached 5 min). |
+
+```bash
+curl -X POST localhost:7710/speak -H 'Content-Type: application/json' \
+  -d '{"text": "Hello from the queue", "voice": "en-US-JennyNeural"}'
+```
+
 ## License
 
 [GPL-3.0-or-later](LICENSE)

--- a/README.md
+++ b/README.md
@@ -274,11 +274,11 @@ current utterance immediately and holds the queue until you finish.
 
 | Endpoint | Description |
 |----------|-------------|
-| `POST /speak` | Queue text for speech. Body: `text` (required), `voice` (Azure ShortName), `quality` (`fast`/`hd`), `output_file` (save WAV instead of playing), `interrupt` (`true` = flush everything and speak now). Returns `{ok, id, position, state}`; `429` when the queue (depth 32) is full. |
-| `POST /skip` | Cancel the current utterance; the next queued one plays. Returns `{ok, skipped}`. |
-| `POST /stop` | Panic button: stop playback and drain the queue. Returns `{ok, cleared}`. |
-| `POST /pause` / `POST /resume` | Pause/resume current playback. |
-| `GET /queue` | Queue introspection: `{current, pending, depth}`. |
+| `POST /speak` | Queue text for speech. Body: `text` (required), `voice` (Azure ShortName), `quality` (`fast`/`hd`), `output_file` (save WAV instead of playing), `interrupt` (`true` = flush everything and speak now). Returns `{ok, id, position, state}` — plus `flushed` (how many queued items an interrupt deleted); `429` when the queue (depth 32) is full. |
+| `POST /skip` | Cancel the current utterance; the next queued one plays. Returns `{ok, skipped}`. (SSIP calls this `STOP`.) |
+| `POST /stop` | Panic button: stop playback and drain the queue. Returns `{ok, cleared}`. (SSIP calls this `CANCEL` — note the inverted verbs if you have speech-dispatcher reflexes.) |
+| `POST /pause` / `POST /resume` | Pause/resume. Queue-level: while paused, the next queued item won't start either. |
+| `GET /queue` | Queue introspection: `{current, pending, depth, recent}`. `recent` holds the last 16 terminal outcomes — `done`, `canceled` (dropped before starting), `interrupted` (cut off mid-play), or `error` — so callers can learn the fate of a submitted `id`. |
 | `GET /status` | Service state, pause flag, `queue_depth`, playback progress. |
 | `GET /voices` | Available Azure voices (cached 5 min). |
 

--- a/docs/superpowers/plans/2026-08-10-http-speech-queue.md
+++ b/docs/superpowers/plans/2026-08-10-http-speech-queue.md
@@ -1,0 +1,523 @@
+# HTTP Speech Queue Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `POST /speak` queue FIFO instead of interrupting, with user preemption, `/skip`, `/stop`-drains-all, and `GET /queue` introspection.
+
+**Architecture:** One `queue.Queue(maxsize=32)` + one daemon dispatcher thread in `gnome-speaks-service.py` that plays HTTP items serially through a parameterized `_speak_worker`. User speech paths (D-Bus `Speak`/`Talk`, clipboard, selection, AI streaming) set a `_user_speech_active` event that holds the dispatcher; they preempt via `stop(drain_queue=False)`. Per-item payload (voice/quality/output_file) replaces the racy service-global overrides.
+
+**Tech Stack:** Python 3 stdlib only (`queue`, `threading`, `dataclasses`, `itertools`). No test framework (project convention) — validation is `py_compile` + service restart + curl/dbus-send live checks. Spec: `docs/superpowers/specs/2026-08-10-http-speech-queue-design.md`.
+
+**Context facts** (verified 2026-08-10):
+- systemd runs the repo file directly: `ExecStart=/home/jp/Projects/gnome-speaks/gnome-speaks-service.py`. Service changes need only `systemctl --user restart gnome-speaks.service`. No extension.js changes in this plan → no shell restart needed.
+- `import queue` exists (line ~32). `itertools` and `dataclasses` do NOT — Task 1 adds them.
+- A post-commit hook auto-deploys to the extensions dir (harmless here; docs+service only).
+- Line numbers below are from commit `c62bcb0`; they shift as tasks land — anchor by symbol name.
+
+---
+
+### Task 1: Queue foundation — dataclass, service fields, drain helper, parameterized worker, preemption wiring
+
+Behavior-neutral: the queue exists but nothing enqueues yet. HTTP still calls `speak()` (changed in Task 3).
+
+**Files:**
+- Modify: `gnome-speaks-service.py` — imports (~line 22-36), new `TTSQueueItem` before `class GnomeSpeaksService` (~line 600), `__init__` (~line 611), `speak()` (~line 1452), `_speak_worker()` (~line 1536), `talk()` (~line 1647), `stop()` (~line 2251)
+
+- [ ] **Step 1: Add imports**
+
+After `import sys` in the import block, add:
+
+```python
+import itertools
+from dataclasses import dataclass
+```
+
+- [ ] **Step 2: Add `TTSQueueItem` dataclass immediately above `class GnomeSpeaksService`**
+
+```python
+@dataclass
+class TTSQueueItem:
+    """One queued HTTP speech request. Per-item overrides travel with the
+    item so overlapping HTTP requests can't race on service globals."""
+    id: int
+    text: str
+    voice: str | None = None        # Azure ShortName override
+    quality: str | None = None      # "fast" | "hd" | None = service default
+    output_file: str | None = None  # save-to-disk instead of playback
+    enqueued_at: float = 0.0
+```
+
+- [ ] **Step 3: Add queue fields to `GnomeSpeaksService.__init__`**
+
+After the `self._http_progress_lock = threading.Lock()` line, add:
+
+```python
+        # HTTP speech queue — agents on :7710 queue FIFO instead of stomping
+        # each other. User speech paths set _user_speech_active to hold the
+        # dispatcher (user outranks agents).
+        self._tts_queue = queue.Queue(maxsize=32)
+        self._tts_queue_seq = itertools.count(1)  # next() is atomic in CPython
+        self._queue_current = None                # TTSQueueItem now playing
+        self._queue_current_lock = threading.Lock()
+        self._user_speech_active = threading.Event()
+        threading.Thread(target=self._tts_dispatcher, daemon=True,
+                         name="tts-queue-dispatcher").start()
+```
+
+- [ ] **Step 4: Add `enqueue_speech`, `_drain_tts_queue`, `_tts_dispatcher` methods**
+
+Add these three methods to `GnomeSpeaksService`, directly above `def speak(`:
+
+```python
+    def enqueue_speech(self, text, voice=None, quality=None, output_file=None):
+        """Create and enqueue an HTTP speech item for serial playback.
+
+        Returns (item_id, position) where position is the number of items
+        ahead (0 = will play next). Raises queue.Full at capacity.
+        """
+        item = TTSQueueItem(
+            id=next(self._tts_queue_seq),
+            text=text.strip(),
+            voice=voice,
+            quality=quality,
+            output_file=output_file,
+            enqueued_at=time.time(),
+        )
+        with self._queue_current_lock:
+            busy = self._queue_current is not None
+        position = self._tts_queue.qsize() + (1 if busy else 0)
+        self._tts_queue.put_nowait(item)
+        return item.id, position
+
+    def _drain_tts_queue(self):
+        """Remove all pending speech-queue items. Returns the count cleared."""
+        cleared = 0
+        while True:
+            try:
+                self._tts_queue.get_nowait()
+                cleared += 1
+            except queue.Empty:
+                if cleared:
+                    log.info("Drained %d queued speech item(s)", cleared)
+                return cleared
+
+    def _tts_dispatcher(self):
+        """Daemon thread: plays queued HTTP speech items serially.
+
+        Holds while user speech is active or the mic/LLM is busy. Its own
+        'speaking' state between back-to-back items does NOT hold it (the
+        idle flap is suppressed via suppress_idle to avoid badge flicker).
+        """
+        while True:
+            item = self._tts_queue.get()
+            while (self._user_speech_active.is_set()
+                   or self.current_state in ("listening", "processing")):
+                time.sleep(0.2)
+            with self._queue_current_lock:
+                self._queue_current = item
+            try:
+                if self.current_state != "speaking":
+                    self._set_state("speaking")
+                has_next = not self._tts_queue.empty()
+                # Runs synchronously in this thread — playback is the wait.
+                self._speak_worker(item.text, voice=item.voice,
+                                   quality=item.quality,
+                                   output_file=item.output_file,
+                                   user_initiated=False,
+                                   suppress_idle=has_next)
+            except Exception:
+                log.exception("Speech queue: item %d failed, continuing", item.id)
+            finally:
+                with self._queue_current_lock:
+                    self._queue_current = None
+```
+
+- [ ] **Step 5: Parameterize `_speak_worker`**
+
+Change the signature from `def _speak_worker(self, text, voice=None):` to:
+
+```python
+    def _speak_worker(self, text, voice=None, quality=None, output_file=None,
+                      user_initiated=True, suppress_idle=False):
+```
+
+Inside, apply these exact changes:
+
+a) Replace both quality reads with a local. After `state._cancel_event.clear()` add `q = quality or self._voice_quality`, then change:
+- `speed_factor = 22.0 if self._voice_quality == "fast" else 15.0` → `speed_factor = 22.0 if q == "fast" else 15.0`
+- `result = speech_tts.tts(text, quality=self._voice_quality, ...` → `result = speech_tts.tts(text, quality=q, ...`
+
+b) Replace the output_file global with the parameter:
+- `output_file=getattr(self, '_pending_output_file', None))` → `output_file=output_file)`
+- Delete the line `self._pending_output_file = None` and its comment `# Clear one-shot output file after use`.
+
+c) In the `finally:` block, guard the idle transition and hands-free restart, and release the user hold. Change:
+
+```python
+            if still_speaking:
+                self._set_state("idle")
+            _schedule_warmup()
+```
+
+to:
+
+```python
+            if still_speaking and not suppress_idle:
+                self._set_state("idle")
+            _schedule_warmup()
+            if user_initiated:
+                self._user_speech_active.clear()
+```
+
+and change the hands-free condition `if (CONFIG.get("continuous_dictation", False)` to `if (user_initiated and CONFIG.get("continuous_dictation", False)` — queued agent chatter must not re-open the mic.
+
+- [ ] **Step 6: Wire preemption into `speak()`**
+
+In `speak()`, replace:
+
+```python
+        # Stop outside lock to prevent deadlock (stop() acquires multiple locks)
+        if self.current_state not in ("idle",):
+            self.stop()
+
+        if not CONFIG.get("key"):
+            GLib.idle_add(self._emit_error, "Azure Speech key not configured")
+            return False
+```
+
+with:
+
+```python
+        # Hold the queue dispatcher before preempting (user outranks agents).
+        # The worker's finally clears this; early exits must clear it here.
+        self._user_speech_active.set()
+
+        # Stop outside lock to prevent deadlock (stop() acquires multiple locks)
+        # drain_queue=False: user preemption drops only the current utterance,
+        # the agent backlog survives and resumes after user speech.
+        if self.current_state not in ("idle",):
+            self.stop(drain_queue=False)
+
+        if not CONFIG.get("key"):
+            GLib.idle_add(self._emit_error, "Azure Speech key not configured")
+            self._user_speech_active.clear()
+            return False
+```
+
+- [ ] **Step 7: Wire preemption into `talk()`**
+
+`talk()` blocks until done, so a try/finally in the method covers all exits. Replace:
+
+```python
+        if not text or not text.strip():
+            return "error: no text provided"
+
+        with self._talk_lock:
+            if self.current_state not in ("idle",):
+                self.stop()
+```
+
+with:
+
+```python
+        if not text or not text.strip():
+            return "error: no text provided"
+
+        self._user_speech_active.set()
+        try:
+            with self._talk_lock:
+                if self.current_state not in ("idle",):
+                    self.stop(drain_queue=False)
+```
+
+Indent the rest of the `with self._talk_lock:` body one level, and after the block (aligned with `try:`) add:
+
+```python
+        finally:
+            self._user_speech_active.clear()
+```
+
+- [ ] **Step 8: Add `drain_queue` parameter to `stop()`**
+
+Change `def stop(self):` and the docstring to:
+
+```python
+    def stop(self, drain_queue=True):
+        """Stop any current operation and return to idle.
+
+        drain_queue: also flush pending HTTP speech-queue items (panic stop —
+        D-Bus Stop and POST /stop). User preemption passes False so the agent
+        backlog survives and resumes afterwards.
+        """
+        log.info("Stop requested (current state: %s)", self.current_state)
+        if drain_queue:
+            self._drain_tts_queue()
+```
+
+(then the existing body continues with `self._stop_event.set()`).
+
+- [ ] **Step 9: Syntax check + restart + regression check**
+
+Run: `python3 -c "import py_compile; py_compile.compile('gnome-speaks-service.py', doraise=True)" && systemctl --user restart gnome-speaks.service && sleep 2 && systemctl --user is-active gnome-speaks.service`
+Expected: `active`
+
+Run: `dbus-send --session --dest=org.gnome.Speaks --print-reply /org/gnome/Speaks org.gnome.Speaks.GetState`
+Expected: reply with `string "idle"`
+
+Run: `curl -s -X POST localhost:7710/speak -H 'Content-Type: application/json' -d '{"text":"Task one regression check."}'`
+Expected: `{"ok": true, "state": "speaking"}` (old response — HTTP not switched yet), speech audible, `journalctl --user -u gnome-speaks.service -n 20` shows no tracebacks.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add gnome-speaks-service.py
+git commit -m "feat: add TTS queue foundation — dispatcher, per-item payload, user preemption"
+```
+
+---
+
+### Task 2: Hold the dispatcher during AI streaming replies
+
+AI conversation replies stream sentence-by-sentence through their own TTS path; without this, queued agent items can play over an in-progress AI reply (dispatcher only holds on listening/processing, and streaming happens in "speaking").
+
+**Files:**
+- Modify: `gnome-speaks-service.py` — `_stream_conversation_worker()` (~line 2047)
+
+- [ ] **Step 1: Set the hold at worker start, clear in a new `finally`**
+
+At the top of `_stream_conversation_worker(self, user_text)`, immediately after the docstring, add:
+
+```python
+        # AI replies are user-initiated speech: hold the agent speech queue
+        # for the whole turn (LLM streaming + sentence TTS).
+        self._user_speech_active.set()
+```
+
+The method body is one big `try: ... except Exception as exc: ...`. Append a `finally:` clause to that same try statement (after the except block, same indentation as `try:`):
+
+```python
+        finally:
+            self._user_speech_active.clear()
+```
+
+- [ ] **Step 2: Syntax check + restart**
+
+Run: `python3 -c "import py_compile; py_compile.compile('gnome-speaks-service.py', doraise=True)" && systemctl --user restart gnome-speaks.service && sleep 2 && systemctl --user is-active gnome-speaks.service`
+Expected: `active`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add gnome-speaks-service.py
+git commit -m "feat: hold speech queue during AI streaming replies"
+```
+
+---
+
+### Task 3: Switch HTTP endpoints to the queue
+
+Activates the feature: `/speak` enqueues (+`interrupt` flag, 429 on full), `/skip` and `GET /queue` added, `/stop` reports cleared count, `/status` gains `queue_depth`. Removes the racy `_voice_quality` swap and `_pending_output_file` global.
+
+**Files:**
+- Modify: `gnome-speaks-service.py` — `do_GET` (~line 2349), `do_POST` (~line 2358), `_handle_speak` (~line 2387), `_handle_stop` (~line 2420), `_handle_status` (~line 2444), new `_handle_skip` + `_handle_queue`
+
+- [ ] **Step 1: Replace `_handle_speak` entirely**
+
+```python
+    def _handle_speak(self):
+        body = self._read_json_body()
+        if body is None:
+            return  # error already sent
+        text = body.get("text", "")
+        if not text or not text.strip():
+            self._send_error_json(400, "Missing or empty 'text' field")
+            return
+
+        svc = self.service
+        quality = body.get("quality") if body.get("quality") in ("fast", "hd") else None
+        voice = body.get("voice") or None
+        output_file = body.get("output_file") or None
+
+        # interrupt: true — flush everything and speak now (panic + speak)
+        if body.get("interrupt"):
+            svc._drain_tts_queue()
+            svc.stop(drain_queue=False)
+
+        try:
+            item_id, position = svc.enqueue_speech(
+                text, voice=voice, quality=quality, output_file=output_file)
+        except queue.Full:
+            self._send_error_json(429, "queue full")
+            return
+
+        state_str = ("speaking" if position == 0
+                     and svc.current_state == "idle" else "queued")
+        self._send_json({"ok": True, "id": item_id,
+                         "position": position, "state": state_str})
+```
+
+- [ ] **Step 2: Replace `_handle_stop`, add `_handle_skip` and `_handle_queue`**
+
+Replace `_handle_stop` with:
+
+```python
+    def _handle_stop(self):
+        svc = self.service
+        cleared = svc._drain_tts_queue()
+        svc.stop(drain_queue=False)
+        self._send_json({"ok": True, "state": "idle", "cleared": cleared})
+
+    def _handle_skip(self):
+        """Cancel the current queued utterance only; the next one plays."""
+        svc = self.service
+        with svc._queue_current_lock:
+            current = svc._queue_current
+        if current is None:
+            self._send_json({"ok": True, "skipped": None})
+            return
+        state.cancel_active()
+        self._send_json({"ok": True, "skipped": current.id})
+
+    def _handle_queue(self):
+        svc = self.service
+        with svc._queue_current_lock:
+            cur = svc._queue_current
+        current = None
+        if cur is not None:
+            current = {"id": cur.id, "text": cur.text[:80], "voice": cur.voice,
+                       "enqueued_at": cur.enqueued_at}
+        with svc._tts_queue.mutex:
+            items = list(svc._tts_queue.queue)
+        pending = [{"id": i.id, "text": i.text[:80], "voice": i.voice,
+                    "enqueued_at": i.enqueued_at} for i in items]
+        self._send_json({"current": current, "pending": pending,
+                         "depth": len(pending)})
+```
+
+- [ ] **Step 3: Route the new endpoints**
+
+In `do_GET`, add before the 404 fallback:
+
+```python
+        elif path == "/queue":
+            self._handle_queue()
+```
+
+In `do_POST`, add before the 404 fallback:
+
+```python
+        elif path == "/skip":
+            self._handle_skip()
+```
+
+- [ ] **Step 4: Add `queue_depth` to `_handle_status`**
+
+In `_handle_status`, change:
+
+```python
+        result = {"state": current, "paused": paused}
+```
+
+to:
+
+```python
+        result = {"state": current, "paused": paused,
+                  "queue_depth": svc._tts_queue.qsize()}
+```
+
+- [ ] **Step 5: Syntax check + restart**
+
+Run: `python3 -c "import py_compile; py_compile.compile('gnome-speaks-service.py', doraise=True)" && systemctl --user restart gnome-speaks.service && sleep 2 && systemctl --user is-active gnome-speaks.service`
+Expected: `active`
+
+- [ ] **Step 6: Live validation battery**
+
+```bash
+# Serial playback: enqueue two, second must report queued/position 1
+curl -s -X POST localhost:7710/speak -H 'Content-Type: application/json' -d '{"text":"Queue test one. This sentence takes a few seconds to say."}'
+curl -s -X POST localhost:7710/speak -H 'Content-Type: application/json' -d '{"text":"Queue test two."}'
+curl -s localhost:7710/queue
+```
+Expected: first → `{"ok":true,"id":1,"position":0,"state":"speaking"}`; second → `"position":1,"state":"queued"`; `/queue` shows `current` set and one pending. Then journalctl shows both played sequentially.
+
+```bash
+# Skip: 3 items, skip current, verify next plays and one remains
+for i in one two three; do curl -s -X POST localhost:7710/speak -H 'Content-Type: application/json' -d "{\"text\":\"Skip test $i. Padding words to lengthen playback.\"}"; done
+curl -s -X POST localhost:7710/skip
+curl -s localhost:7710/queue
+```
+Expected: `/skip` → `{"ok":true,"skipped":<id>}`; `/queue` shows the later items still pending/playing.
+
+```bash
+# Stop drains: enqueue 3, stop, verify cleared count and empty queue
+for i in a b c; do curl -s -X POST localhost:7710/speak -H 'Content-Type: application/json' -d "{\"text\":\"Stop test $i with some padding words here.\"}"; done
+curl -s -X POST localhost:7710/stop
+curl -s localhost:7710/queue; curl -s localhost:7710/status
+```
+Expected: `/stop` → `cleared` ≥ 1; `/queue` → `{"current":null,"pending":[],"depth":0}`; status `queue_depth: 0`.
+
+```bash
+# Interrupt flag: enqueue 2, interrupt-speak, verify queue flushed
+curl -s -X POST localhost:7710/speak -H 'Content-Type: application/json' -d '{"text":"Interrupt victim one, long enough to still be playing."}'
+curl -s -X POST localhost:7710/speak -H 'Content-Type: application/json' -d '{"text":"Interrupt victim two."}'
+curl -s -X POST localhost:7710/speak -H 'Content-Type: application/json' -d '{"text":"I interrupted everything.","interrupt":true}'
+curl -s localhost:7710/queue
+```
+Expected: last call → `position 0`; `/queue` → only the interrupting item.
+
+```bash
+# User preemption: agent speech playing, D-Bus Speak preempts, queue resumes
+curl -s -X POST localhost:7710/speak -H 'Content-Type: application/json' -d '{"text":"Agent one speaking a fairly long sentence for preemption testing."}'
+curl -s -X POST localhost:7710/speak -H 'Content-Type: application/json' -d '{"text":"Agent two waits its turn."}'
+dbus-send --session --dest=org.gnome.Speaks --print-reply /org/gnome/Speaks org.gnome.Speaks.Speak string:"User speech preempts now"
+sleep 1; curl -s localhost:7710/queue
+```
+Expected: agent-one playback dies immediately, user speech plays, `/queue` still holds agent two, which plays after. Verify order in `journalctl --user -u gnome-speaks.service -n 40`.
+
+```bash
+# Voice override still works per-item (regression for PR #2)
+curl -s -X POST localhost:7710/speak -H 'Content-Type: application/json' -d '{"text":"Voice override check.","voice":"en-US-JennyNeural"}'
+```
+Expected: plays in Jenny voice; no errors in journal.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add gnome-speaks-service.py
+git commit -m "feat(http): queue speech by default — /skip, /queue, stop drains, 429 on full"
+```
+
+---
+
+### Task 4: README documentation
+
+**Files:**
+- Modify: `README.md` — the HTTP REST API section (locate with `grep -n "7710" README.md`)
+
+- [ ] **Step 1: Update the HTTP API docs**
+
+Rewrite the endpoint list in the existing style to document: queue-by-default `/speak` (body: `text`, optional `voice`, `quality`, `output_file`, `interrupt`), response `{ok, id, position, state}`, 429 on full (depth 32); `POST /skip`; `POST /stop` (drains, returns `cleared`); `GET /queue`; `GET /status` `queue_depth` field; user speech preempts and holds the queue. Match the README's existing formatting conventions — check before writing.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document HTTP speech queue API"
+```
+
+---
+
+### Task 5: Ship + external docs ripple
+
+- [ ] **Step 1: Final verification** — re-run the full Task 3 Step 6 battery on the final tree; `git log --oneline` shows the 4 commits; working tree clean.
+- [ ] **Step 2: Push branch, open PR** (repo: techempower-org/gnome-speaks; branch `feat/http-speech-queue`; conventional PR title `feat(http): speech queue with user preemption`).
+- [ ] **Step 3: External docs (post-merge):** update `~/.claude/CLAUDE.md` speech-to-cli MCP note ("interrupts any in-progress speech — it is not a queue" → queue semantics + `/skip`/`/queue`), and the agent-orchestration skill's voice contract.
+- [ ] **Step 4: Return to `main`** (per CLAUDE.md branch hygiene).
+
+---
+
+## Self-review notes
+
+- Spec coverage: queue-by-default+interrupt (T3S1), preemption+hold (T1S6-7, T2), /skip+/stop (T3S2), GET /queue + status depth (T3S2/S4), race fix via per-item payload (T1S5, T3S1), badge flap suppression (T1S4 `suppress_idle`), listening hold (T1S4 wait loop), error isolation per item (T1S4 try/except), 429 (T3S1), docs (T4, T5S3). No gaps found.
+- Known accepted race: the dispatcher's hold check is a 0.2s poll — a mic open racing the check can collide for <0.2s; barge-in/half-duplex logic already tolerates this class of overlap. Not worth a mutex redesign.
+- Semantic change beyond spec (deliberate, documented): hands-free auto-restart after TTS now fires only for user-initiated speech — queued agent chatter must not re-open the mic mid-conversation-loop.

--- a/docs/superpowers/specs/2026-08-10-http-speech-queue-design.md
+++ b/docs/superpowers/specs/2026-08-10-http-speech-queue-design.md
@@ -74,6 +74,35 @@ naturally blocked while an item plays.
    - D-Bus `Speak` mid-queue → preempts; queue resumes after.
    - Start dictation with non-empty queue → queue holds until idle.
 
+## Post-research amendments (2026-08-10, same day)
+
+Three prior-art research agents (speech-dispatcher/SSIP, Project Spiel + Ubuntu,
+cross-platform API survey — reports in
+`~/.claude/projects/-home-jp/scratch/speech-queue-prior-art/`) drove four changes:
+
+1. **`/pause` is queue-level** — the dispatcher's hold predicate includes the pause
+   event. Unanimous prior art (Web Speech, .NET, Apple): a paused service must not
+   start the next item. Without this, pausing at an item boundary let the next
+   agent utterance play into a "paused" room.
+2. **`interrupt` reports blast radius** — response gains `flushed: <n>`, and drained
+   item ids log at INFO. (Android structurally forbids flushing other apps' speech;
+   we allow it but make it leave a trace.)
+3. **Per-item outcomes** — `GET /queue` gains `recent`: ring buffer (16) of
+   `{id, outcome}` with `done` / `canceled` (never started) / `interrupted`
+   (cut off mid-play) / `error`. One terminal outcome per item, vocabulary borrowed
+   from Web Speech + Android. 5/5 surveyed APIs have completion reporting.
+4. **SSIP verb mapping documented** — our `/skip`≈SSIP `STOP`, `/stop`≈SSIP `CANCEL`
+   (inverted verbs); README notes it rather than renaming.
+
+Deliberately deferred (filed as follow-up): per-source coalescing keys and a
+`progress`-style drop-intermediate-keep-final class (SSIP's best ideas — real design
+work, separate cycle), id-scoped `/skip` (1/5 precedent).
+
+Also: "Ubuntu looking into it" = **Myna**, Canonical's speech-to-TEXT project
+(17 Jun 2026, Ubuntu 26.10) — relevant to Type mode, not this queue. Spiel is a
+per-app synthesis API with no cross-app arbitration — aligning with it would
+recreate the stomping problem; not a fit.
+
 ## Docs Ripple (at ship time)
 
 - README HTTP API section.

--- a/docs/superpowers/specs/2026-08-10-http-speech-queue-design.md
+++ b/docs/superpowers/specs/2026-08-10-http-speech-queue-design.md
@@ -1,0 +1,82 @@
+# HTTP Speech Queue
+
+## Problem
+
+`POST /speak` interrupts any in-progress speech — it is not a queue. Multiple agents
+speaking through `localhost:7710` stomp each other mid-sentence. Additionally, the
+per-request overrides are racy: `_handle_speak` swaps `svc._voice_quality` on the shared
+service object and restores it in `finally` immediately after `speak()` returns, but the
+worker thread reads `self._voice_quality` later — overlapping requests can read the wrong
+value. `_pending_output_file` has the same one-shot-global race.
+
+## Decisions (settled with JP 2026-08-10)
+
+1. **Queue by default.** `POST /speak` appends; playback is FIFO. `"interrupt": true`
+   flushes current + queue and speaks immediately. Breaking change to the documented
+   interrupt semantics — docs updated at ship time.
+2. **User preempts, queue holds.** User-initiated speech (D-Bus `Speak`, clipboard,
+   selection, AI-mode replies) interrupts the current queued utterance immediately. The
+   interrupted item is dropped; the rest of the queue pauses and resumes after user
+   speech finishes.
+3. **`/stop` flushes everything; new `/skip` cancels current item only.**
+
+## Architecture (Approach A — dispatcher thread)
+
+All changes in `gnome-speaks-service.py`. No new files, no D-Bus interface changes, no
+changes to the AI streaming sentence pipeline or `speak()`'s public signature.
+
+- **`TTSQueueItem`** dataclass: `id` (monotonic counter), `text`, `voice`, `quality`,
+  `output_file`, `enqueued_at`. Per-utterance overrides travel with the item, retiring
+  the `_voice_quality` swap and `_pending_output_file` global (race fix).
+- **`self._tts_queue = queue.Queue(maxsize=32)`** — HTTP `/speak` enqueues; full → 429.
+- **Dispatcher thread** (daemon, started at service init):
+  `queue.get()` → wait until clear (no `_user_speech_active`, state not
+  `listening`/`processing` — its own `speaking` state during back-to-back playback
+  does not block) → play synchronously via `_speak_item(item)` → next. `_speak_item` is the current
+  `_speak_worker` body refactored to read the item instead of service globals.
+- **Preemption wiring:** the user path (`speak()`) sets a `_user_speech_active` event on
+  entry, clears it on completion. Its existing `stop()` call kills in-flight playback via
+  the cancel event; the dispatcher drops the dead item and blocks on the event.
+- **Listening interplay:** dispatcher holds while state is `listening`/`processing` —
+  queued speech never plays over an open mic. Half-duplex drain applies unchanged
+  (playback still goes through `speech_tts.tts()`).
+- **State machine:** states unchanged. When more items are pending, the dispatcher skips
+  the `speaking → idle → speaking` flap between items (no badge flicker).
+
+## API Contract (localhost:7710)
+
+| Endpoint | Change | Response |
+|----------|--------|----------|
+| `POST /speak` | Queues by default; optional `"interrupt": true` = flush all + speak now | `{ok, id, position, state}` — `position: 0` = playing now, `state` ∈ `"speaking"`,`"queued"`; `429 {ok:false, error:"queue full"}` |
+| `POST /skip` | New — cancel current utterance, next plays | `{ok, skipped: <id\|null>}` |
+| `POST /stop` | Also drains queue (panic button) | `{ok, cleared: <n>}` |
+| `GET /queue` | New — introspection | `{current, pending: [{id, text≤80ch, voice, enqueued_at}], depth}` |
+| `GET /status` | Gains `queue_depth` | existing shape + one field |
+
+`/pause` and `/resume` unchanged — they act on current playback; the dispatcher is
+naturally blocked while an item plays.
+
+## Error Handling
+
+- TTS failure on an item: log, emit D-Bus `Error` signal, continue to the next item.
+  One bad utterance never wedges the queue.
+- Queue full: HTTP 429. Empty text: 400 (existing).
+- Queue is in-memory; lost on service restart. Correct for ephemeral voice chatter.
+
+## Validation (no test framework — live checks per project convention)
+
+1. `python3 -c "import py_compile; py_compile.compile('gnome-speaks-service.py', doraise=True)"`
+2. `systemctl --user restart gnome-speaks.service`, then:
+   - Two rapid `POST /speak` → both play, serially.
+   - `/speak` ×3 + `/skip` → only current dropped; rest play.
+   - `/speak` ×3 + `/stop` → silence; `GET /queue` shows depth 0.
+   - `"interrupt": true` → flushes and speaks immediately.
+   - D-Bus `Speak` mid-queue → preempts; queue resumes after.
+   - Start dictation with non-empty queue → queue holds until idle.
+
+## Docs Ripple (at ship time)
+
+- README HTTP API section.
+- Outside this repo: global `~/.claude/CLAUDE.md` line "interrupts any in-progress
+  speech — it is not a queue" and the agent-orchestration skill's voice contract both
+  become stale when this lands.

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -2156,6 +2156,9 @@ class GnomeSpeaksService:
 
         Uses the unified llm_stream library for all providers (including bedrock).
         """
+        # AI replies are user-initiated speech: hold the agent speech queue
+        # for the whole turn (LLM streaming + sentence TTS).
+        self._user_speech_active.set()
         try:
             provider = CONFIG.get("llm_provider", "anthropic")
             model = CONFIG.get("llm_model", "claude-opus-4.6")
@@ -2328,6 +2331,8 @@ class GnomeSpeaksService:
                     if not self._stop_event.is_set()
                     else False
                 ))
+        finally:
+            self._user_speech_active.clear()
 
     # -- Conversation worker ------------------------------------------------
 

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -29,6 +29,8 @@ import shutil
 import signal
 import subprocess
 import sys
+import itertools
+from dataclasses import dataclass
 import queue
 from concurrent.futures import ThreadPoolExecutor
 import threading
@@ -603,6 +605,18 @@ def apply_auto_corrections(text):
 # Service implementation
 # ---------------------------------------------------------------------------
 
+@dataclass
+class TTSQueueItem:
+    """One queued HTTP speech request. Per-item overrides travel with the
+    item so overlapping HTTP requests can't race on service globals."""
+    id: int
+    text: str
+    voice: str | None = None        # Azure ShortName override
+    quality: str | None = None      # "fast" | "hd" | None = service default
+    output_file: str | None = None  # save-to-disk instead of playback
+    enqueued_at: float = 0.0
+
+
 class GnomeSpeaksService:
     """Core service logic using speech-to-cli building blocks."""
 
@@ -661,6 +675,17 @@ class GnomeSpeaksService:
             "pause_accumulated": 0.0, "pause_started": 0.0,
         }
         self._http_progress_lock = threading.Lock()
+
+        # HTTP speech queue — agents on :7710 queue FIFO instead of stomping
+        # each other. User speech paths set _user_speech_active to hold the
+        # dispatcher (user outranks agents).
+        self._tts_queue = queue.Queue(maxsize=32)
+        self._tts_queue_seq = itertools.count(1)  # next() is atomic in CPython
+        self._queue_current = None                # TTSQueueItem now playing
+        self._queue_current_lock = threading.Lock()
+        self._user_speech_active = threading.Event()
+        threading.Thread(target=self._tts_dispatcher, daemon=True,
+                         name="tts-queue-dispatcher").start()
 
     # -- Config sync -------------------------------------------------------
 
@@ -1449,6 +1474,68 @@ class GnomeSpeaksService:
 
     # -- TTS: Using speech_tts.tts() directly ------------------------------
 
+    def enqueue_speech(self, text, voice=None, quality=None, output_file=None):
+        """Create and enqueue an HTTP speech item for serial playback.
+
+        Returns (item_id, position) where position is the number of items
+        ahead (0 = will play next). Raises queue.Full at capacity.
+        """
+        item = TTSQueueItem(
+            id=next(self._tts_queue_seq),
+            text=text.strip(),
+            voice=voice,
+            quality=quality,
+            output_file=output_file,
+            enqueued_at=time.time(),
+        )
+        with self._queue_current_lock:
+            busy = self._queue_current is not None
+        position = self._tts_queue.qsize() + (1 if busy else 0)
+        self._tts_queue.put_nowait(item)
+        return item.id, position
+
+    def _drain_tts_queue(self):
+        """Remove all pending speech-queue items. Returns the count cleared."""
+        cleared = 0
+        while True:
+            try:
+                self._tts_queue.get_nowait()
+                cleared += 1
+            except queue.Empty:
+                if cleared:
+                    log.info("Drained %d queued speech item(s)", cleared)
+                return cleared
+
+    def _tts_dispatcher(self):
+        """Daemon thread: plays queued HTTP speech items serially.
+
+        Holds while user speech is active or the mic/LLM is busy. Its own
+        'speaking' state between back-to-back items does NOT hold it (the
+        idle flap is suppressed via suppress_idle to avoid badge flicker).
+        """
+        while True:
+            item = self._tts_queue.get()
+            while (self._user_speech_active.is_set()
+                   or self.current_state in ("listening", "processing")):
+                time.sleep(0.2)
+            with self._queue_current_lock:
+                self._queue_current = item
+            try:
+                if self.current_state != "speaking":
+                    self._set_state("speaking")
+                has_next = not self._tts_queue.empty()
+                # Runs synchronously in this thread — playback is the wait.
+                self._speak_worker(item.text, voice=item.voice,
+                                   quality=item.quality,
+                                   output_file=item.output_file,
+                                   user_initiated=False,
+                                   suppress_idle=has_next)
+            except Exception:
+                log.exception("Speech queue: item %d failed, continuing", item.id)
+            finally:
+                with self._queue_current_lock:
+                    self._queue_current = None
+
     def speak(self, text, voice=None):
         """Synthesize and play text via speech_tts.tts(). Returns True on success.
 
@@ -1464,12 +1551,19 @@ class GnomeSpeaksService:
         if not text or not text.strip():
             return False
 
+        # Hold the queue dispatcher before preempting (user outranks agents).
+        # The worker's finally clears this; early exits must clear it here.
+        self._user_speech_active.set()
+
         # Stop outside lock to prevent deadlock (stop() acquires multiple locks)
+        # drain_queue=False: user preemption drops only the current utterance,
+        # the agent backlog survives and resumes after user speech.
         if self.current_state not in ("idle",):
-            self.stop()
+            self.stop(drain_queue=False)
 
         if not CONFIG.get("key"):
             GLib.idle_add(self._emit_error, "Azure Speech key not configured")
+            self._user_speech_active.clear()
             return False
 
         with self._speak_lock:
@@ -1533,10 +1627,16 @@ class GnomeSpeaksService:
             text, estimated_duration, stop_event = item
             self._run_subtitle_progress(text, estimated_duration, stop_event)
 
-    def _speak_worker(self, text, voice=None):
-        """Background thread: TTS using speech_tts.tts()."""
+    def _speak_worker(self, text, voice=None, quality=None, output_file=None,
+                      user_initiated=True, suppress_idle=False):
+        """TTS using speech_tts.tts().
+
+        Runs as a background thread for user speech (speak()) and
+        synchronously inside the queue dispatcher for HTTP items.
+        """
         try:
             state._cancel_event.clear()
+            q = quality or self._voice_quality
             # Update HTTP progress tracking
             with self._http_progress_lock:
                 self._http_progress["text"] = text[:80]
@@ -1548,7 +1648,7 @@ class GnomeSpeaksService:
             GLib.idle_add(self._emit_partial_transcription, text)
 
             # Start subtitle progress thread for progressive reveal
-            speed_factor = 22.0 if self._voice_quality == "fast" else 15.0
+            speed_factor = 22.0 if q == "fast" else 15.0
             est_dur = max(1.0, len(text) / speed_factor)
             sub_stop = threading.Event()
             sub_thread = threading.Thread(
@@ -1559,13 +1659,10 @@ class GnomeSpeaksService:
             sub_thread.start()
 
             try:
-                result = speech_tts.tts(text, quality=self._voice_quality, progress_token=None,
+                result = speech_tts.tts(text, quality=q, progress_token=None,
                                         voice=voice,
                                         audio_level_cb=self._tts_level_cb,
-                                        output_file=getattr(self, '_pending_output_file', None))
-                # Clear one-shot output file after use
-                self._pending_output_file = None
-
+                                        output_file=output_file)
                 if result.get("error"):
                     GLib.idle_add(self._emit_error, result["error"])
             finally:
@@ -1587,13 +1684,17 @@ class GnomeSpeaksService:
             # Read state under lock, then call _set_state outside (it acquires its own lock).
             with self._state_lock:
                 still_speaking = self._state == "speaking"
-            if still_speaking:
+            if still_speaking and not suppress_idle:
                 self._set_state("idle")
             _schedule_warmup()
+            if user_initiated:
+                self._user_speech_active.clear()
 
             # Hands-free loop: after TTS finishes in conversation mode,
-            # automatically restart listening if continuous_dictation is enabled
-            if (CONFIG.get("continuous_dictation", False)
+            # automatically restart listening if continuous_dictation is enabled.
+            # user_initiated guard: queued agent chatter must not re-open the mic.
+            if (user_initiated
+                    and CONFIG.get("continuous_dictation", False)
                     and CONFIG.get("conversation_mode", False)
                     and not self._stop_event.is_set()):
                 log.info("Hands-free: auto-restarting listening after TTS")
@@ -1653,31 +1754,37 @@ class GnomeSpeaksService:
         if not text or not text.strip():
             return "error: no text provided"
 
-        with self._talk_lock:
-            if self.current_state not in ("idle",):
-                self.stop()
+        # Talk blocks until the exchange completes, so one try/finally holds
+        # the speech queue for the whole call (user outranks agents).
+        self._user_speech_active.set()
+        try:
+            with self._talk_lock:
+                if self.current_state not in ("idle",):
+                    self.stop(drain_queue=False)
 
-            if not CONFIG.get("key"):
-                GLib.idle_add(self._emit_error, "Azure Speech key not configured")
-                return "error: no API key"
+                if not CONFIG.get("key"):
+                    GLib.idle_add(self._emit_error, "Azure Speech key not configured")
+                    return "error: no API key"
 
-            self._stop_event.clear()
-            self._set_state("speaking")
+                self._stop_event.clear()
+                self._set_state("speaking")
 
-            # Use an event to pass the result back from the worker thread
-            result_holder = {"reply": ""}
-            done_event = threading.Event()
+                # Use an event to pass the result back from the worker thread
+                result_holder = {"reply": ""}
+                done_event = threading.Event()
 
-            self._talk_thread = threading.Thread(
-                target=self._talk_worker,
-                args=(text.strip(), result_holder, done_event),
-                daemon=True,
-            )
-            self._talk_thread.start()
+                self._talk_thread = threading.Thread(
+                    target=self._talk_worker,
+                    args=(text.strip(), result_holder, done_event),
+                    daemon=True,
+                )
+                self._talk_thread.start()
 
-            # Wait for the worker to complete (blocks the D-Bus call)
-            done_event.wait()
-            return result_holder["reply"]
+                # Wait for the worker to complete (blocks the D-Bus call)
+                done_event.wait()
+                return result_holder["reply"]
+        finally:
+            self._user_speech_active.clear()
 
     def _talk_worker(self, text, result_holder, done_event):
         """Background thread: full-duplex TTS+STT via speech_tts.talk_fullduplex()."""
@@ -2248,9 +2355,16 @@ class GnomeSpeaksService:
 
     # -- Stop --------------------------------------------------------------
 
-    def stop(self):
-        """Stop any current operation and return to idle."""
+    def stop(self, drain_queue=True):
+        """Stop any current operation and return to idle.
+
+        drain_queue: also flush pending HTTP speech-queue items (panic stop —
+        D-Bus Stop and POST /stop). User preemption passes False so the agent
+        backlog survives and resumes afterwards.
+        """
         log.info("Stop requested (current state: %s)", self.current_state)
+        if drain_queue:
+            self._drain_tts_queue()
 
         # Signal our stop event for the STT sender loop
         self._stop_event.set()

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -684,6 +684,9 @@ class GnomeSpeaksService:
         self._queue_current = None                # TTSQueueItem now playing
         self._queue_current_lock = threading.Lock()
         self._user_speech_active = threading.Event()
+        # Playback ownership token: each playback claims a fresh object();
+        # a preempted worker's cleanup must not reset state it no longer owns.
+        self._speak_token = None
         threading.Thread(target=self._tts_dispatcher, daemon=True,
                          name="tts-queue-dispatcher").start()
 
@@ -1514,22 +1517,30 @@ class GnomeSpeaksService:
         idle flap is suppressed via suppress_idle to avoid badge flicker).
         """
         while True:
-            item = self._tts_queue.get()
+            # Wait until clear BEFORE dequeuing, so held items stay visible
+            # in GET /queue and remain drainable by /stop during user speech.
             while (self._user_speech_active.is_set()
                    or self.current_state in ("listening", "processing")):
                 time.sleep(0.2)
+            try:
+                item = self._tts_queue.get(timeout=0.2)
+            except queue.Empty:
+                continue
             with self._queue_current_lock:
                 self._queue_current = item
             try:
                 if self.current_state != "speaking":
                     self._set_state("speaking")
+                token = object()
+                self._speak_token = token
                 has_next = not self._tts_queue.empty()
                 # Runs synchronously in this thread — playback is the wait.
                 self._speak_worker(item.text, voice=item.voice,
                                    quality=item.quality,
                                    output_file=item.output_file,
                                    user_initiated=False,
-                                   suppress_idle=has_next)
+                                   suppress_idle=has_next,
+                                   owner_token=token)
             except Exception:
                 log.exception("Speech queue: item %d failed, continuing", item.id)
             finally:
@@ -1568,9 +1579,12 @@ class GnomeSpeaksService:
 
         with self._speak_lock:
             self._set_state("speaking")
+            token = object()
+            self._speak_token = token
             self._speak_thread = threading.Thread(
                 target=self._speak_worker,
                 args=(text.strip(), voice),
+                kwargs={"owner_token": token},
                 daemon=True,
             )
             self._speak_thread.start()
@@ -1628,7 +1642,8 @@ class GnomeSpeaksService:
             self._run_subtitle_progress(text, estimated_duration, stop_event)
 
     def _speak_worker(self, text, voice=None, quality=None, output_file=None,
-                      user_initiated=True, suppress_idle=False):
+                      user_initiated=True, suppress_idle=False,
+                      owner_token=None):
         """TTS using speech_tts.tts().
 
         Runs as a background thread for user speech (speak()) and
@@ -1684,7 +1699,8 @@ class GnomeSpeaksService:
             # Read state under lock, then call _set_state outside (it acquires its own lock).
             with self._state_lock:
                 still_speaking = self._state == "speaking"
-            if still_speaking and not suppress_idle:
+            if (still_speaking and not suppress_idle
+                    and self._speak_token is owner_token):
                 self._set_state("idle")
             _schedule_warmup()
             if user_initiated:
@@ -1768,6 +1784,9 @@ class GnomeSpeaksService:
 
                 self._stop_event.clear()
                 self._set_state("speaking")
+                # Claim playback ownership so a preempted queue worker's
+                # cleanup can't reset our speaking state.
+                self._speak_token = object()
 
                 # Use an event to pass the result back from the worker thread
                 result_holder = {"reply": ""}
@@ -2249,6 +2268,7 @@ class GnomeSpeaksService:
                     if first_sentence:
                         # Transition to speaking state on first sentence
                         self._set_state("speaking")
+                        self._speak_token = object()  # claim playback ownership
                         state._cancel_event.clear()
                         # On headphones, prewarm recorder during TTS
                         if not CONFIG.get("half_duplex", False):
@@ -2274,6 +2294,7 @@ class GnomeSpeaksService:
             if remainder and not self._stop_event.is_set():
                 if first_sentence:
                     self._set_state("speaking")
+                    self._speak_token = object()  # claim playback ownership
                     state._cancel_event.clear()
                     if not CONFIG.get("half_duplex", False):
                         _schedule_warmup()
@@ -2471,6 +2492,8 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
             self._handle_status()
         elif path == "/voices":
             self._handle_voices()
+        elif path == "/queue":
+            self._handle_queue()
         else:
             self._send_error_json(404, f"Unknown endpoint: {path}")
 
@@ -2484,6 +2507,8 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
             self._handle_pause()
         elif path == "/resume":
             self._handle_resume()
+        elif path == "/skip":
+            self._handle_skip()
         else:
             self._send_error_json(404, f"Unknown endpoint: {path}")
 
@@ -2513,32 +2538,69 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
             return
 
         svc = self.service
+        # Per-item overrides travel inside the TTSQueueItem — no service-global
+        # swaps, so overlapping requests can't race. Voice is an Azure ShortName
+        # (e.g. en-US-JennyNeural), sanitized downstream in _prepare_tts.
+        quality = body.get("quality") if body.get("quality") in ("fast", "hd") else None
+        voice = body.get("voice") or None
+        output_file = body.get("output_file") or None
 
-        # Temporarily override voice/quality/speed if provided
-        original_quality = None
-        if body.get("quality") and body["quality"] in ("fast", "hd"):
-            original_quality = svc._voice_quality
-            svc._voice_quality = body["quality"]
-
-        # Per-utterance voice override (Azure ShortName like en-US-JennyNeural).
-        # Forwarded to speech_tts.tts() which falls back to CONFIG's fast/HD
-        # voice when None. Sanitized downstream in _prepare_tts.
-        voice_override = body.get("voice") or None
-
-        # Set output file for save-to-disk (one-shot, cleared after use)
-        if body.get("output_file"):
-            svc._pending_output_file = body["output_file"]
+        # interrupt: true — flush everything and speak now (panic + speak)
+        if body.get("interrupt"):
+            svc._drain_tts_queue()
+            svc.stop(drain_queue=False)
+            # The dispatcher clears _queue_current moments after the cancel;
+            # wait briefly so position/state in the response reflect the flush.
+            deadline = time.time() + 1.0
+            while time.time() < deadline:
+                with svc._queue_current_lock:
+                    if svc._queue_current is None:
+                        break
+                time.sleep(0.02)
 
         try:
-            svc.speak(text, voice=voice_override)
-            self._send_json({"ok": True, "state": "speaking"})
-        finally:
-            if original_quality is not None:
-                svc._voice_quality = original_quality
+            item_id, position = svc.enqueue_speech(
+                text, voice=voice, quality=quality, output_file=output_file)
+        except queue.Full:
+            self._send_error_json(429, "queue full")
+            return
+
+        state_str = ("speaking" if position == 0
+                     and svc.current_state == "idle" else "queued")
+        self._send_json({"ok": True, "id": item_id,
+                         "position": position, "state": state_str})
 
     def _handle_stop(self):
-        self.service.stop()
-        self._send_json({"ok": True, "state": "idle"})
+        svc = self.service
+        cleared = svc._drain_tts_queue()
+        svc.stop(drain_queue=False)
+        self._send_json({"ok": True, "state": "idle", "cleared": cleared})
+
+    def _handle_skip(self):
+        """Cancel the current queued utterance only; the next one plays."""
+        svc = self.service
+        with svc._queue_current_lock:
+            current = svc._queue_current
+        if current is None:
+            self._send_json({"ok": True, "skipped": None})
+            return
+        state.cancel_active()
+        self._send_json({"ok": True, "skipped": current.id})
+
+    def _handle_queue(self):
+        svc = self.service
+        with svc._queue_current_lock:
+            cur = svc._queue_current
+        current = None
+        if cur is not None:
+            current = {"id": cur.id, "text": cur.text[:80], "voice": cur.voice,
+                       "enqueued_at": cur.enqueued_at}
+        with svc._tts_queue.mutex:
+            items = list(svc._tts_queue.queue)
+        pending = [{"id": i.id, "text": i.text[:80], "voice": i.voice,
+                    "enqueued_at": i.enqueued_at} for i in items]
+        self._send_json({"current": current, "pending": pending,
+                         "depth": len(pending)})
 
     def _handle_pause(self):
         svc = self.service
@@ -2584,7 +2646,8 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
                     "text": p["text"],
                 }
 
-        result = {"state": current, "paused": paused}
+        result = {"state": current, "paused": paused,
+                  "queue_depth": svc._tts_queue.qsize()}
         if progress is not None:
             result["progress"] = progress
         self._send_json(result)

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -30,6 +30,7 @@ import signal
 import subprocess
 import sys
 import itertools
+from collections import deque
 from dataclasses import dataclass
 import queue
 from concurrent.futures import ThreadPoolExecutor
@@ -687,6 +688,10 @@ class GnomeSpeaksService:
         # Playback ownership token: each playback claims a fresh object();
         # a preempted worker's cleanup must not reset state it no longer owns.
         self._speak_token = None
+        # Terminal outcome per queue item (done/canceled/interrupted/error),
+        # exposed on GET /queue so the /speak id isn't write-only. Exactly one
+        # terminal outcome per item (Android-style invariant).
+        self._queue_recent = deque(maxlen=16)
         threading.Thread(target=self._tts_dispatcher, daemon=True,
                          name="tts-queue-dispatcher").start()
 
@@ -1500,13 +1505,19 @@ class GnomeSpeaksService:
     def _drain_tts_queue(self):
         """Remove all pending speech-queue items. Returns the count cleared."""
         cleared = 0
+        ids = []
         while True:
             try:
-                self._tts_queue.get_nowait()
+                item = self._tts_queue.get_nowait()
+                ids.append(item.id)
+                self._queue_recent.append({"id": item.id, "outcome": "canceled"})
                 cleared += 1
             except queue.Empty:
                 if cleared:
-                    log.info("Drained %d queued speech item(s)", cleared)
+                    # Blast-radius trace: when two agents fight over the
+                    # voice, this line is the whole debugging story.
+                    log.info("Drained %d queued speech item(s): ids %s",
+                             cleared, ids)
                 return cleared
 
     def _tts_dispatcher(self):
@@ -1519,7 +1530,10 @@ class GnomeSpeaksService:
         while True:
             # Wait until clear BEFORE dequeuing, so held items stay visible
             # in GET /queue and remain drainable by /stop during user speech.
+            # Pause is queue-level (unanimous across Web Speech/.NET/Apple):
+            # a paused service must not start the next item either.
             while (self._user_speech_active.is_set()
+                   or state._pause_event.is_set()
                    or self.current_state in ("listening", "processing")):
                 time.sleep(0.2)
             try:
@@ -1535,14 +1549,19 @@ class GnomeSpeaksService:
                 self._speak_token = token
                 has_next = not self._tts_queue.empty()
                 # Runs synchronously in this thread — playback is the wait.
-                self._speak_worker(item.text, voice=item.voice,
-                                   quality=item.quality,
-                                   output_file=item.output_file,
-                                   user_initiated=False,
-                                   suppress_idle=has_next,
-                                   owner_token=token)
+                outcome = self._speak_worker(item.text, voice=item.voice,
+                                             quality=item.quality,
+                                             output_file=item.output_file,
+                                             user_initiated=False,
+                                             suppress_idle=has_next,
+                                             owner_token=token)
+                if state._cancel_event.is_set():
+                    outcome = "interrupted"  # killed mid-play (skip/stop/preempt)
+                self._queue_recent.append({"id": item.id,
+                                           "outcome": outcome or "done"})
             except Exception:
                 log.exception("Speech queue: item %d failed, continuing", item.id)
+                self._queue_recent.append({"id": item.id, "outcome": "error"})
             finally:
                 with self._queue_current_lock:
                     self._queue_current = None
@@ -1648,7 +1667,9 @@ class GnomeSpeaksService:
 
         Runs as a background thread for user speech (speak()) and
         synchronously inside the queue dispatcher for HTTP items.
+        Returns "done" or "error" (the dispatcher records per-item outcomes).
         """
+        outcome = "done"
         try:
             state._cancel_event.clear()
             q = quality or self._voice_quality
@@ -1680,6 +1701,7 @@ class GnomeSpeaksService:
                                         output_file=output_file)
                 if result.get("error"):
                     GLib.idle_add(self._emit_error, result["error"])
+                    outcome = "error"
             finally:
                 # Always stop subtitle thread, even if TTS raises
                 sub_stop.set()
@@ -1687,6 +1709,7 @@ class GnomeSpeaksService:
         except Exception as exc:
             log.exception("Speak failed: %s", exc)
             GLib.idle_add(self._emit_error, f"Speak failed: {exc}")
+            outcome = "error"
         finally:
             # Clear HTTP progress to idle state
             with self._http_progress_lock:
@@ -1719,6 +1742,7 @@ class GnomeSpeaksService:
                                   and CONFIG.get("conversation_mode", False)
                                   and not self._stop_event.is_set())
                               else False)
+        return outcome
 
     def speak_clipboard(self):
         """Read clipboard and speak its contents."""
@@ -2545,9 +2569,13 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
         voice = body.get("voice") or None
         output_file = body.get("output_file") or None
 
-        # interrupt: true — flush everything and speak now (panic + speak)
+        # interrupt: true — flush everything and speak now (panic + speak).
+        # flushed reports the blast radius: this deletes OTHER callers'
+        # queued speech (Android hides this ability entirely; we expose it
+        # but make it leave a trace).
+        flushed = None
         if body.get("interrupt"):
-            svc._drain_tts_queue()
+            flushed = svc._drain_tts_queue()
             svc.stop(drain_queue=False)
             # The dispatcher clears _queue_current moments after the cancel;
             # wait briefly so position/state in the response reflect the flush.
@@ -2567,8 +2595,11 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
 
         state_str = ("speaking" if position == 0
                      and svc.current_state == "idle" else "queued")
-        self._send_json({"ok": True, "id": item_id,
-                         "position": position, "state": state_str})
+        resp = {"ok": True, "id": item_id,
+                "position": position, "state": state_str}
+        if flushed is not None:
+            resp["flushed"] = flushed
+        self._send_json(resp)
 
     def _handle_stop(self):
         svc = self.service
@@ -2600,7 +2631,8 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
         pending = [{"id": i.id, "text": i.text[:80], "voice": i.voice,
                     "enqueued_at": i.enqueued_at} for i in items]
         self._send_json({"current": current, "pending": pending,
-                         "depth": len(pending)})
+                         "depth": len(pending),
+                         "recent": list(svc._queue_recent)})
 
     def _handle_pause(self):
         svc = self.service


### PR DESCRIPTION
## Summary
- `POST /speak` now **queues FIFO** instead of interrupting — concurrent agents on :7710 no longer stomp each other. `"interrupt": true` keeps the old flush-and-speak-now behavior and reports its blast radius (`flushed: n`).
- **User speech outranks agents**: D-Bus `Speak`/`Talk`, clipboard/selection reading, and AI streaming replies preempt the current utterance and hold the queue until finished; the backlog then resumes.
- New endpoints: `POST /skip` (drop current, play next) and `GET /queue` (current, pending, depth, and a 16-deep `recent` ring of per-item outcomes: `done`/`canceled`/`interrupted`/`error`). `POST /stop` drains everything and returns `cleared`. `/pause` is queue-level. `GET /status` gains `queue_depth`.
- Fixes two pre-existing races: per-request `quality`/`output_file` overrides now travel inside the queue item instead of being swapped on shared service state.

## Design
Spec: `docs/superpowers/specs/2026-08-10-http-speech-queue-design.md` (incl. post-research amendments) · Plan: `docs/superpowers/plans/2026-08-10-http-speech-queue.md`. Contract cross-checked by a 3-agent prior-art sweep (speech-dispatcher/SSIP, Project Spiel, Web Speech/Android/Apple/Windows survey).

## Test Plan
- [x] `py_compile` clean; service restarts `active`
- [x] Two `/speak` play serially; second returns `position: 1, state: queued`
- [x] `/skip` drops only the current item (`skipped: <id>`, next plays)
- [x] `/stop` drains (`cleared` count) and silences; `/queue` empty after
- [x] `interrupt: true` flushes (`flushed: 2` observed), plays immediately
- [x] D-Bus `Speak` mid-queue preempts; queue holds (item visible in `/queue`) and resumes after
- [x] `/pause` at item boundary holds the next item; resume drains through
- [x] Outcomes recorded correctly: `done`/`canceled`/`interrupted` verified live
- [x] PR #2 regression: per-call `voice` override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FIFO speech request queuing with a capacity of 32 items.
  * Added controls to pause, resume, skip, stop, and interrupt speech playback.
  * Added queue and status inspection, voice listing, and queue depth reporting.
  * Added support for per-request voice, quality, and output-file options.
  * User-priority speech now takes precedence while preserving pending requests.

* **Documentation**
  * Added HTTP API documentation, request states, limits, behaviors, and example commands.
  * Added design and implementation specifications for speech queue functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->