### PR TITLE
feat: voice spellbook — incantation layer over STT

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,43 @@ curl -X POST localhost:7710/speak -H 'Content-Type: application/json' \
   -d '{"text": "Hello from the queue", "voice": "en-US-JennyNeural"}'
 ```
 
+## Voice Spellbook
+
+Utterances beginning with a trigger word (`cast` or `invoke`) are **incantations**:
+they route to a local spellbook instead of being typed or sent to the LLM. Works in
+every mode; a realm chime confirms the match instantly (~2 ms) and spoken replies
+ride the speech queue (during continuous dictation, replies wait for the mic to
+close — casting never speaks over an open microphone). An unknown incantation
+speaks "The spell fizzles" instead of silently typing.
+
+Spells are data: the repo ships `spellbook.json` with the self-control spells;
+a user overlay at `~/.config/speech-to-cli/spellbook.json` merges over it by
+spell name and hot-reloads on save. The realm/oracle/home spells below are
+overlay examples — their endpoints are site-specific and never live in the repo.
+
+| Incantation | Effect |
+|---|---|
+| "cast silence" / "cast skip" | stop everything / skip current utterance |
+| "cast terminal mode" / "ai mode" / "type mode" | switch modes |
+| "cast read notifications" | toggle the notification herald |
+| "cast defense report" | combat-ward summary, spoken |
+| "cast my level" | character sheet from realm progression |
+| "cast recent events" | last 5 realm events, spoken |
+| "cast mana reserves" | solar/battery/grid report |
+| "cast consult the oracle \<question\>" | ask the realm Oracle; streamed reply |
+| "cast torches \<request\>" | natural-language pass-through to Home Assistant Assist |
+
+Safety: spells are gated `instant` (read-only/reversible) or `confirm` (the service
+speaks a challenge and requires a spoken "confirm"); a hardcoded executor denylist
+refuses to load any spell touching destructive surfaces (grid transfer, locks,
+valves, safety automations, remote exec) regardless of config. Test or script
+spells without a microphone via `POST /cast`:
+
+```bash
+curl -X POST localhost:7710/cast -H 'Content-Type: application/json' \
+  -d '{"text": "cast defense report"}'
+```
+
 ## License
 
 [GPL-3.0-or-later](LICENSE)

--- a/docs/superpowers/plans/2026-08-10-voice-spellbook.md
+++ b/docs/superpowers/plans/2026-08-10-voice-spellbook.md
@@ -1,0 +1,389 @@
+# Voice Spellbook Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Spoken incantations ("cast defense report") trigger local actions with chime-on-match and themed spoken replies through the speech queue.
+
+**Architecture:** New `spellbook.py` module (loader + matcher + executor with injected callbacks — no GLib/audio deps of its own) + data-driven `spellbook.json` (repo default, user overlay, mtime hot-reload). The service hooks `_try_cast()` into both STT result paths before `apply_voice_commands`/mode routing, wires callbacks (chime→`play_sound`, speak→`enqueue_speech`, confirm→`talk`), and exposes `POST /cast` for mic-less testing.
+
+**Tech Stack:** Python 3 stdlib only (`json`, `re`, `urllib.request`, `subprocess`). No test framework (project convention): validation = `py_compile` + inline `python3 -c` sanity runs + `POST /cast` curl battery + journal.
+
+**Spec:** `docs/superpowers/specs/2026-08-10-voice-spellbook-design.md`. Research: `~/.claude/projects/-home-jp/scratch/voice-spellbook/*.md` (exact endpoint shapes for oracle/HA live there — consult before finalizing network spells).
+
+**File map:**
+- Create `spellbook.py` — loader, DENYLIST validation, matcher, SpellExecutor (6 action types)
+- Create `spellbook.json` — the 10 v1 spells
+- Modify `gnome-speaks-service.py` — import, init wiring, `skip_current()`, `_spell_ctx_dbus()`, `_spell_speak()`, `_try_cast()`, two STT-path hooks, `_handle_cast` + route, `_get_ha_token()`
+- Modify `README.md`, `install.sh` (must copy spellbook.py/json if it copies the service file — check)
+
+---
+
+### Task 1: spellbook.py core — loader, denylist, matcher (+ spellbook.json skeleton)
+
+**Files:** Create `spellbook.py`, `spellbook.json`
+
+- [ ] **Step 1: Write `spellbook.py`** with module docstring, imports (`json,l ogging, os, re, subprocess, time, urllib.request, urllib.error`), `log = logging.getLogger("gnome-speaks")`, constants:
+
+```python
+DENYLIST = [
+    r"homeassistant/restart", r"goodwe_off_grid", r"solar_ems_apply",
+    r"battery[_-]?emulator", r"automation\.turn_off", r"all_lights_off",
+    r"\bvalve\.", r"\block\.", r"alarm_control_panel\.", r"/ssh\b",
+    r"combat-ward/(approve|execute)", r"wol\s+sleep", r"ydotool",
+    r"loginctl\s+lock",
+]
+VALID_ACTION_TYPES = ("say", "dbus_self", "http", "shell", "assist", "oracle")
+VALID_GATES = ("instant", "confirm")
+FIZZLE_TEXT = "The spell fizzles."
+UNREACHABLE_TEXT = "The realm is beyond reach."
+
+class SpellUnreachable(Exception):
+    """Target service down/timeout — spoken as UNREACHABLE_TEXT."""
+```
+
+`load_spellbook(repo_path, user_path)` → `{"trigger_words": [...], "spells": {name: spell}}`: read each file (repo then user), `json.load` guarded (log.error + continue on failure), user overlay merges per-spell by `name`, `trigger_words` lowercased if present. Each spell passes `_validate(spell)` → error string or None: requires `name`, `patterns`, `action.type` in VALID_ACTION_TYPES, `gate` in VALID_GATES, shell actions need non-empty `argv` list, and `_denied(action)` (regex search of DENYLIST against `json.dumps(action)`, case-insensitive) must be None. Rejected spells log loudly and are skipped. Final `log.info` with count + triggers.
+
+`match(text, book)` → `(kind, spell, remainder)` with kind ∈ `"miss" | "fizzle" | "cast"`: normalize (strip, lower, strip trailing `[.,!?;:]+`), split words; if first word not in trigger_words → miss. Join rest as incantation; empty → fizzle. For each spell × pattern (lowered): exact match → remainder `""`; prefix match (`pattern + " "`) → remainder is the tail. Longest pattern wins. No match → `("fizzle", None, incantation)`.
+
+- [ ] **Step 2: Sanity-run the matcher**
+
+```bash
+python3 -c "
+import spellbook, json
+book = {'trigger_words': ['cast'], 'spells': {'dr': {'name':'dr','patterns':['defense report'],'action':{'type':'say'}}, 'o': {'name':'o','patterns':['consult the oracle'],'action':{'type':'say'}}}}
+assert spellbook.match('Hello world', book)[0] == 'miss'
+assert spellbook.match('Cast defense report.', book)[0] == 'cast'
+assert spellbook.match('cast consult the oracle what is love', book)[2] == 'what is love'
+assert spellbook.match('cast frobnicate', book)[0] == 'fizzle'
+assert spellbook.match('cast', book)[0] == 'fizzle'
+print('MATCH-OK')
+"
+```
+Expected: `MATCH-OK`
+
+- [ ] **Step 3: Sanity-check denylist validation**
+
+```bash
+python3 -c "
+import spellbook
+bad = {'name':'evil','patterns':['x'],'action':{'type':'http','url':'http://x/ssh'}}
+assert spellbook._validate(bad) is not None
+ok = {'name':'good','patterns':['x'],'action':{'type':'say','text':'hi'}}
+assert spellbook._validate(ok) is None
+print('DENY-OK')
+"
+```
+Expected: `DENY-OK`
+
+- [ ] **Step 4: Write `spellbook.json`** with trigger_words `["cast","invoke"]` and the six *local* spells (network spells land in Task 4 once endpoint shapes are confirmed from the research files):
+
+```json
+{
+  "trigger_words": ["cast", "invoke"],
+  "spells": [
+    {"name": "silence", "patterns": ["silence", "be silent", "quiet"],
+     "action": {"type": "dbus_self", "op": "stop"}, "chime": null, "gate": "instant"},
+    {"name": "skip", "patterns": ["skip", "next"],
+     "action": {"type": "dbus_self", "op": "skip"}, "gate": "instant"},
+    {"name": "terminal-mode", "patterns": ["terminal mode"],
+     "action": {"type": "dbus_self", "op": "terminal_mode", "reply": "Terminal mode."}, "chime": "xp_gain", "gate": "instant"},
+    {"name": "ai-mode", "patterns": ["ai mode", "conversation mode"],
+     "action": {"type": "dbus_self", "op": "ai_mode", "reply": "A I mode."}, "chime": "xp_gain", "gate": "instant"},
+    {"name": "type-mode", "patterns": ["type mode", "dictation mode"],
+     "action": {"type": "dbus_self", "op": "type_mode", "reply": "Type mode."}, "chime": "xp_gain", "gate": "instant"},
+    {"name": "read-notifications", "patterns": ["read notifications", "notifications"],
+     "action": {"type": "dbus_self", "op": "read_notifications_toggle", "reply": "Notification herald toggled."}, "chime": "xp_gain", "gate": "instant"}
+  ]
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+python3 -c "import py_compile; py_compile.compile('spellbook.py', doraise=True)" && python3 -c "import json; json.load(open('spellbook.json'))"
+git add spellbook.py spellbook.json && git commit -m "feat: spellbook core — loader, denylist, incantation matcher"
+```
+
+---
+
+### Task 2: SpellExecutor — six action types
+
+**Files:** Modify `spellbook.py`
+
+- [ ] **Step 1: Add `SpellExecutor`** — constructor takes injected callbacks `chime(name)`, `speak(text, voice=None)`, `dbus_self(op)`, `confirm(prompt)->str`, `ha_token()->str|None`. Public `cast(spell, remainder)`:
+  - `t0 = time.monotonic()`; fire `chime` immediately if set (match-time feedback).
+  - `gate == "confirm"`: `reply = confirm(f"Confirm casting {name}?")`; proceed only if `"confirm" in reply.lower()`, else speak "The casting is stayed." and log outcome `declined`.
+  - Dispatch `getattr(self, "_do_" + action["type"])(action, remainder, spell)` inside try/except: `SpellUnreachable` → speak `UNREACHABLE_TEXT`, outcome `unreachable`; other exceptions → log.exception, speak `FIZZLE_TEXT`, outcome `error`.
+  - Structured log always: `log.info("CAST | %s | %s | %s | %dms", name, action_type, outcome, ms)`.
+
+  Handlers (all take `(action, remainder, spell)`, speak via `spell.get("speak_as")`):
+  - `_do_say`: speak `action["text"]`.
+  - `_do_dbus_self`: call `self._dbus_self(action["op"])`; speak optional `action.get("reply")`.
+  - `_do_http`: GET/POST `action["url"]` with `urllib.request` (POST body = `action.get("body", {})` as JSON), timeout `spell.get("timeout_s", 3)`; URLError/timeout → `SpellUnreachable`. Parse JSON; `action.get("speak")` is a dotted path (`$.report` → strip `$.`, walk dict keys); speak result if truthy.
+  - `_do_shell`: `subprocess.run(action["argv"], capture_output=True, text=True, timeout=spell.get("timeout_s", 5))` — argv list only, never a string. Timeout → `SpellUnreachable`; nonzero rc → RuntimeError(stderr[:200]). If `action.get("speak_template")`: try `json.loads(stdout)` then `template.format(**payload)`, fall back to raw stdout[:300]; else speak stdout[:300] if nonempty.
+  - `_do_assist`: requires `ha_token()` (else SpellUnreachable) and nonempty remainder (else speak "Speak the ritual's object.", outcome `fizzle`). POST `{"text": remainder, "language": "en"}` to `action["url"]` with `Authorization: Bearer <token>`, timeout 5. Map `response.response_type`: `error` → speak HA's speech or FIZZLE_TEXT, outcome `fizzle`; else speak HA's `response.speech.plain.speech` or "It is done.", outcome `done`.
+  - `_do_oracle`: requires nonempty remainder (else speak "The Oracle awaits your question.", `fizzle`). POST `{field: remainder}` (field from `action.get("field","message")`) to `action["url"]`; iterate SSE lines (`data:` prefix), accumulate text (`json.loads(chunk).get("text","")` with plain-string fallback), split on `[.!?]\s` and speak each sentence as it completes, flush tail. Timeout `spell.get("timeout_s", 30)`.
+
+- [ ] **Step 2: Sanity-run executor with fake callbacks**
+
+```bash
+python3 -c "
+import spellbook
+spoken = []
+ex = spellbook.SpellExecutor(chime=lambda n: spoken.append(('chime', n)),
+    speak=lambda t, v=None: spoken.append(('speak', t)),
+    dbus_self=lambda op: spoken.append(('op', op)),
+    confirm=lambda p: 'confirm', ha_token=lambda: None)
+ex.cast({'name':'greet','patterns':['x'],'action':{'type':'say','text':'hail'},'chime':'xp_gain'}, '')
+assert ('chime','xp_gain') in spoken and ('speak','hail') in spoken
+out = ex.cast({'name':'torch','patterns':['x'],'action':{'type':'assist','url':'https://<ha-host>/api/conversation/process'}}, 'lights')
+assert out == 'unreachable'  # no token in this env
+print('EXEC-OK')
+"
+```
+Expected: `EXEC-OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+python3 -c "import py_compile; py_compile.compile('spellbook.py', doraise=True)"
+git add spellbook.py && git commit -m "feat: spellbook executor — say/dbus_self/http/shell/assist/oracle actions"
+```
+
+---
+
+### Task 3: Service integration — hooks, /cast, skip_current, token chain
+
+**Files:** Modify `gnome-speaks-service.py`
+
+- [ ] **Step 1:** `import spellbook` (after the stdlib imports; same directory). Module-level `_get_ha_token()`: env `HA_TOKEN` → file `~/.cache/ha-token-tmp` → `subprocess.run(["bw","get","password","ha-llat"], timeout=10)`; return None on all failures; never log the value.
+
+- [ ] **Step 2: Service methods** (add after `play_sound`):
+
+```python
+    def skip_current(self):
+        """Cancel the current queued utterance only; next plays (voice /skip)."""
+        with self._queue_current_lock:
+            current = self._queue_current
+        if current is not None:
+            state.cancel_active()
+            return current.id
+        return None
+
+    def _spell_speak(self, text, voice=None):
+        """Spell replies ride the speech queue — same ordering/preemption as agents."""
+        if text:
+            try:
+                self.enqueue_speech(text, voice=voice)
+            except queue.Full:
+                log.warning("Spell reply dropped: speech queue full")
+
+    def _spell_ctx_dbus(self, op):
+        if op == "stop":
+            self.stop()
+        elif op == "skip":
+            self.skip_current()
+        elif op == "terminal_mode":
+            self._save_config_flag("terminal_mode", True)
+            self._save_config_flag("conversation_mode", False)
+        elif op == "ai_mode":
+            self._save_config_flag("conversation_mode", True)
+            self._save_config_flag("terminal_mode", False)
+        elif op == "type_mode":
+            self._save_config_flag("conversation_mode", False)
+            self._save_config_flag("terminal_mode", False)
+        elif op == "read_notifications_toggle":
+            self._save_config_flag("read_notifications",
+                                   not CONFIG.get("read_notifications", False))
+        else:
+            raise ValueError(f"unknown dbus_self op: {op}")
+```
+
+Refactor `_handle_skip` to use `skip_current()` (DRY):
+
+```python
+    def _handle_skip(self):
+        """Cancel the current queued utterance only; the next one plays."""
+        skipped = self.service.skip_current()
+        self._send_json({"ok": True, "skipped": skipped})
+```
+
+- [ ] **Step 3: Init wiring** (end of `__init__`, after the queue block):
+
+```python
+        # Voice spellbook (incantation layer) — "cast …" routes here
+        self._spellbook_paths = (
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), "spellbook.json"),
+            os.path.expanduser("~/.config/speech-to-cli/spellbook.json"),
+        )
+        self._spellbook = spellbook.load_spellbook(*self._spellbook_paths)
+        self._spellbook_mtimes = self._spellbook_stat()
+        self._spell_executor = spellbook.SpellExecutor(
+            chime=self.play_sound, speak=self._spell_speak,
+            dbus_self=self._spell_ctx_dbus, confirm=self.talk,
+            ha_token=_get_ha_token)
+```
+
+Plus helpers:
+
+```python
+    def _spellbook_stat(self):
+        return tuple(os.path.getmtime(p) if os.path.isfile(p) else 0
+                     for p in self._spellbook_paths)
+
+    def _maybe_reload_spellbook(self):
+        mtimes = self._spellbook_stat()
+        if mtimes != self._spellbook_mtimes:
+            self._spellbook = spellbook.load_spellbook(*self._spellbook_paths)
+            self._spellbook_mtimes = mtimes
+
+    def _try_cast(self, text):
+        """Route 'cast …' utterances to the spellbook. True = consumed."""
+        self._maybe_reload_spellbook()
+        kind, spell, remainder = spellbook.match(text, self._spellbook)
+        if kind == "miss":
+            return False
+        if kind == "fizzle":
+            log.info("CAST | fizzle | nothing matched %r", (remainder or "")[:60])
+            self._spell_speak(spellbook.FIZZLE_TEXT)
+            return True
+        threading.Thread(target=self._spell_executor.cast,
+                         args=(spell, remainder), daemon=True,
+                         name=f"spell-{spell['name']}").start()
+        return True
+```
+
+- [ ] **Step 4: Hook both STT paths.** Streaming path (search `apply_voice_commands(user_text)` first occurrence, ~line 983): immediately after `user_text` is extracted and before `apply_voice_commands`, insert:
+
+```python
+            if user_text and self._try_cast(user_text):
+                GLib.idle_add(self._emit_transcription_ready, user_text)
+                self._set_state("idle")
+                _schedule_warmup()
+                return
+```
+
+Batch/loop path (second occurrence, ~line 1360, inside step "8. Post-process"): insert the cast check *before* voice-command post-processing, preserving loop semantics — if `is_loop`, re-enter listening instead of returning idle:
+
+```python
+            if user_text and self._try_cast(user_text):
+                GLib.idle_add(self._emit_transcription_ready, user_text)
+                if is_loop and not self._stop_event.is_set():
+                    self._set_state("listening")
+                    continue
+                self._set_state("idle")
+                _schedule_warmup()
+                return
+```
+
+(Adapt `continue`/`return` to the enclosing loop/function structure found at the site — the batch path is a loop; verify with Read before editing.)
+
+- [ ] **Step 5: `POST /cast`** — handler + route in `do_POST` before the 404 fallback:
+
+```python
+    def _handle_cast(self):
+        body = self._read_json_body()
+        if body is None:
+            return
+        text = body.get("text", "")
+        if not text or not text.strip():
+            self._send_error_json(400, "Missing or empty 'text' field")
+            return
+        handled = self.service._try_cast(text)
+        self._send_json({"ok": True, "handled": handled})
+```
+
+```python
+        elif path == "/cast":
+            self._handle_cast()
+```
+
+- [ ] **Step 6: install.sh check** — `grep -n "gnome-speaks-service.py" install.sh`; if it copies the service file anywhere, add `spellbook.py` + `spellbook.json` alongside. (systemd runs from the repo, so this may be a no-op.)
+
+- [ ] **Step 7: Validate + commit**
+
+```bash
+python3 -c "import py_compile; py_compile.compile('gnome-speaks-service.py', doraise=True)"
+systemctl --user restart gnome-speaks.service && sleep 2 && systemctl --user is-active gnome-speaks.service
+# journal must show "Spellbook loaded: 6 spells"
+journalctl --user -u gnome-speaks.service -n 20 --no-pager | grep -i spellbook
+# miss passes through:
+curl -s -X POST localhost:7710/cast -H 'Content-Type: application/json' -d '{"text":"hello there"}'   # {"handled": false}
+# fizzle:
+curl -s -X POST localhost:7710/cast -H 'Content-Type: application/json' -d '{"text":"cast frobnicate"}'  # handled true + speaks fizzle
+# mode spell + config flip:
+curl -s -X POST localhost:7710/cast -H 'Content-Type: application/json' -d '{"text":"cast terminal mode"}'
+python3 -c "import json; print(json.load(open('/home/jp/.config/speech-to-cli/config.json'))['terminal_mode'])"  # True
+curl -s -X POST localhost:7710/cast -H 'Content-Type: application/json' -d '{"text":"cast type mode"}'
+# skip spell against a queued utterance; journal shows CAST lines
+git add gnome-speaks-service.py install.sh && git commit -m "feat: wire spellbook into STT paths, add POST /cast seam"
+```
+
+---
+
+### Task 4: Network spells — realm scrying, oracle, torches
+
+**Files:** Modify `spellbook.json`
+
+- [ ] **Step 1: Confirm endpoint shapes from research files** (they contain exact probed calls): `grep -A5 -iE "defense-report|progression/player|events\?limit|oracle" ~/.claude/projects/-home-jp/scratch/voice-spellbook/realm-actions.md ~/.claude/projects/-home-jp/scratch/voice-spellbook/voice-lore.md ~/.claude/projects/-home-jp/scratch/voice-spellbook/ha-desktop.md` — take URL, method, response field names from there, not from memory. realmwatch base is `map_server.py :80`; the realm host per homelab table.
+
+- [ ] **Step 2: Add the four scrying + two consultation spells** (URLs/fields per Step 1; shapes below are the template):
+
+```json
+    {"name": "defense-report", "patterns": ["defense report", "defence report", "how are the wards"],
+     "action": {"type": "http", "method": "GET", "url": "<from research>", "speak": "<field path>"},
+     "chime": "threat_alert", "gate": "instant", "timeout_s": 3},
+    {"name": "my-level", "patterns": ["my level", "character sheet", "my character"],
+     "action": {"type": "http", "method": "GET", "url": "<progression/player>", "speak": "<computed>"},
+     "chime": "xp_gain", "gate": "instant"},
+    {"name": "recent-events", "patterns": ["recent events", "what has happened"],
+     "action": {"type": "http", "method": "GET", "url": "<events?limit=5>", "speak": "<field>"},
+     "gate": "instant"},
+    {"name": "mana-reserves", "patterns": ["mana reserves", "power report", "energy report"],
+     "action": {"type": "shell", "argv": ["<realm-cli-abs-path>", "ha", "energy", "--json"],
+                "speak_template": "<from actual JSON keys>"},
+     "gate": "instant", "timeout_s": 8},
+    {"name": "consult-oracle", "patterns": ["consult the oracle", "ask the oracle", "oracle"],
+     "action": {"type": "oracle", "url": "<oracle endpoint>", "field": "<from research>"},
+     "chime": "level_up", "gate": "instant", "timeout_s": 30},
+    {"name": "torches", "patterns": ["torches", "lights", "upon the house"],
+     "action": {"type": "assist", "url": "https://<ha-host>/api/conversation/process"},
+     "gate": "instant", "timeout_s": 6}
+```
+
+Notes: `my-level` may need a compact speakable field — if `/progression/player` has no single sentence field, use a `speak_template`-style composition via `http` `speak` walking to name/level, or fall back to `shell` + `realm` CLI with template. `recent-events`: if the response is a list, `_do_http` speaks nothing useful — extend `_extract` to join a list field's top-level `summary`/`message` strings (≤5) with "; ". Implement that in `_do_http`'s `_extract` helper when hit.
+
+- [ ] **Step 3: Test each read-only spell via /cast** (each returns handled:true, speaks, and logs `CAST | <name> | … | done`):
+
+```bash
+for s in "cast defense report" "cast my level" "cast recent events" "cast mana reserves"; do
+  curl -s -X POST localhost:7710/cast -H 'Content-Type: application/json' -d "{\"text\":\"$s\"}"; echo; sleep 6; done
+curl -s -X POST localhost:7710/cast -H 'Content-Type: application/json' -d '{"text":"cast consult the oracle what wards protect this realm"}'
+# torches: use a QUERY, not an action, to avoid flipping real lights during tests:
+curl -s -X POST localhost:7710/cast -H 'Content-Type: application/json' -d '{"text":"cast torches are the office lights on"}'
+journalctl --user -u gnome-speaks.service -n 30 --no-pager | grep "CAST |"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+python3 -c "import json; json.load(open('spellbook.json'))"
+git add spellbook.json spellbook.py && git commit -m "feat: v1 network spells — realm scrying, oracle consultation, HA torches"
+```
+
+---
+
+### Task 5: README + ship
+
+- [ ] **Step 1: README** — add "## Voice Spellbook" section after the HTTP API section: trigger words, table of the 10 v1 spells, user overlay path, `POST /cast` seam, safety model (instant/confirm/denylist), fizzle semantics. Match existing README style.
+- [ ] **Step 2:** Re-run the full /cast battery on the final tree; `git status` clean; commit README (`docs: document the voice spellbook`).
+- [ ] **Step 3:** Push branch, PR (`feat: voice spellbook — incantation layer over STT`), body summarizes spells + safety + research provenance; merge per full-auto; checkout main; pull; restart service; verify journal "Spellbook loaded".
+- [ ] **Step 4:** External docs: agent-orchestration skill gains one line — agents may cast via `POST /cast` subject to the same gates. Live mic pass: JP speaks 2–3 spells (report what to try).
+
+---
+
+## Self-review notes
+
+- Spec coverage: prefix matching (T1), fizzle (T1/T3), /cast (T3), six actions (T2), denylist (T1), chime-at-match (T2), speak-via-queue (T3 `_spell_speak`), hot-reload (T3), confirm gate via Talk (T2/T3 wiring), HA token chain (T3), 10 spells (T1+T4), README (T5). Gap: none found; Ember commands explicitly deferred per spec.
+- Network spell URLs deliberately resolved from the research files at execution time (Task 4 Step 1) rather than hardcoded here — the reports contain the probed truth; the plan's JSON shapes are templates for those values. This is a controlled exception to "no placeholders": the values exist on disk, the step says exactly where.
+- Type consistency: `match()` returns `(kind, spell, remainder)` everywhere; executor `cast(spell, remainder)`; callbacks named identically in T2 definition and T3 wiring.

--- a/docs/superpowers/specs/2026-08-10-voice-spellbook-design.md
+++ b/docs/superpowers/specs/2026-08-10-voice-spellbook-design.md
@@ -1,0 +1,151 @@
+# Voice Spellbook — local voice commands as incantations
+
+## Problem
+
+Transcribed speech can only be typed or sent to an LLM. There is no fast local
+command layer: no way to switch modes, query the realm, control the house, or
+consult the resident narrators by voice. JP wants this layer to be novel and
+magical — litrpg/fantasy-flavored — leveraging the existing ecosystem rather
+than inventing a plain command list.
+
+(Naming note: the existing `voice_commands` config flag is spoken-*punctuation*
+substitution ("period" → "."). This feature is separate: the **spellbook**.)
+
+## Research provenance (2026-08-10)
+
+Three agents probed the ecosystem live (reports in
+`~/.claude/projects/-home-jp/scratch/voice-spellbook/`):
+- **realm-actions**: full realmwatch action inventory with measured latencies
+  (direct HTTP 0.6–15 ms, `realm` CLI 370–510 ms, D-Bus `PlaySound` 2 ms);
+  existing spell vocabulary in `os.realm.watch/skills/cast.md`; bugs filed as
+  realmwatch#124 (/status broken), #125 (dual player records), #126 (unbounded
+  /events).
+- **voice-lore**: the Oracle (a LAN host) is live and in-persona; the Ashen
+  Ledger (:8093) has a 50-voice catalog + director notes; D-Bus `Talk(text)` is
+  the only two-way seam (speaks AND returns the spoken reply).
+- **ha-desktop**: HA Assist rides the LAN Wyoming stack (a dedicated
+  pipeline) and honors `conversation_id` (multi-turn); solar/battery are NOT
+  exposed to Assist — use `realm ha energy --json`; GNOME privileged D-Bus is
+  closed (gnome-speaks#7: `_get_focused_app()` silently dead); destructive
+  inventory catalogued.
+
+## Decisions (settled with JP 2026-08-10)
+
+1. **Invocation = "cast" prefix.** Utterances beginning with a trigger word
+   (`cast`, `invoke` — configurable) route to the spellbook in every mode
+   (Type/Terminal/Loop/AI) and never reach typing or the LLM. No bare control
+   words: barge-in already interrupts TTS on any speech. Zero dictation
+   false-positives by construction.
+2. **Architecture = in-service spellbook module** (`spellbook.py` beside the
+   service; matching + execution in-process). Rejected: external daemon
+   consuming `TranscriptionReady` (extra process, and the signal fires after
+   mode routing — too late to intercept); LLM/Assist routing for everything
+   (violates zero-latency/zero-token premise; Assist can't see solar/battery).
+3. **Targets: all three** — gnome-speaks self-control, Home Assistant via
+   Assist, desktop/realm actions.
+
+## Recognition & routing
+
+- Hook: in both STT result paths, on the **raw transcript**, before
+  `apply_voice_commands` (punctuation substitution would mangle patterns) and
+  before mode routing.
+- Match: lowercase, strip trailing punctuation; utterance must start with a
+  trigger word; remainder matched against each spell's `patterns` (exact
+  phrases + aliases; homophones are just more aliases: "defence report").
+  Parameterized spells use one trailing capture slot ("wake <host>"); hostnames
+  resolve via realmwatch `fleet_resolve` (bare names 400 on `realm ping`).
+- No fuzzy scoring in v1 — aliases are predictable and cheap.
+- Miss (trigger word but no spell) → **fizzle**: speak a short in-genre failure
+  ("the spell fizzles"); never type the text.
+- **`POST /cast`** on :7710 accepts `{"text": "cast defense report"}` and runs
+  the identical path — every spell testable by curl, castable by agents,
+  subject to the same gates.
+
+## Spellbook format & executor
+
+Repo ships `spellbook.json`; user overlay at
+`~/.config/speech-to-cli/spellbook.json` merges over it (per-spell by `name`).
+Hot-reload on mtime, same pattern as `auto_corrections`.
+
+```json
+{
+  "name": "defense-report",
+  "patterns": ["defense report", "defence report", "how are the wards"],
+  "action": {"type": "http", "method": "GET",
+             "url": "http://<realm-host>/combat-ward/defense-report",
+             "speak": "$.report"},
+  "chime": "threat_alert",
+  "speak_as": "en-US-Davis:DragonHDLatestNeural",
+  "gate": "instant",
+  "timeout_s": 3
+}
+```
+
+Action types (v1, six): `http` (GET/POST; `speak` is a dotted field path into
+the JSON response), `dbus_self` (service's own methods: stop/skip/mode flags),
+`shell` (**allowlisted argv arrays only** — for `realm` CLI verbs; no shell
+strings, no interpolation), `assist` (remainder → HA `conversation.process`;
+`response_type` action_done/query_answer = success, error = fizzle), `oracle`
+(POST + SSE → sentences to queue), `say` (canned themed response).
+
+Feedback discipline:
+- Chime fires **at match time** (PlaySound, 2 ms) — before the action runs.
+- Spoken results go through the service's **own HTTP queue**
+  (`localhost:7710/speak`, `voice=speak_as`) — spells inherit PR #3's
+  ordering/preemption semantics; a chatty spell can never stomp dictation.
+
+## Safety
+
+- `gate: "instant"` — read-only/reversible. The entire v1 list.
+- `gate: "confirm"` — executor speaks a challenge via D-Bus `Talk()` and
+  proceeds only on a reply containing "confirm". (Combat-ward: voice may
+  `propose` only — never `approve`/`execute`.)
+- **Hardcoded executor denylist** (not a config tier — entries touching these
+  refuse to load, with a log line): `homeassistant/restart`,
+  `switch.goodwe_off_grid`, `script.solar_ems_apply`, Battery-Emulator reboot,
+  `automation.turn_off` on safety reflexes, `script.all_lights_off`,
+  `valve.*`/`lock.*`/`alarm_control_panel.*`, realmwatch `POST /ssh`,
+  combat-ward approve/execute, `wol sleep`, ydotool typing, screen lock.
+- HA auth: token via env `HA_TOKEN` → `~/.cache/ha-token-tmp` → `bw get
+  password ha-llat` (existing chain). Never logged.
+
+## Error handling
+
+Per-action timeout (default 3 s) → fizzle + `threat_alert` chime suppressed to
+avoid alarm fatigue; unreachable target → "the realm is beyond reach"; every
+cast logs one structured line: `spell | matched pattern | action type | outcome
+| latency_ms`. Spellbook load errors (bad JSON, denylisted action) log loudly
+and skip the entry — a broken spell never breaks the service.
+
+## v1 spells (10, all instant)
+
+| Spell | Patterns (canonical) | Action |
+|---|---|---|
+| silence | "silence" | dbus_self Stop |
+| skip | "skip" | dbus_self (HTTP /skip semantics) |
+| terminal mode / ai mode / type mode | "terminal mode" … | dbus_self mode flags |
+| read notifications | "read notifications" | dbus_self |
+| defense report | "defense report" | http → speak $.report |
+| mana reserves | "mana reserves", "power report" | shell `realm ha energy --json` → themed speech |
+| my level | "my level", "character sheet" | http `/progression/player` (realmwatch#125 pins this endpoint) |
+| recent events | "recent events" | http `/events?limit=5` |
+| consult the oracle <q> | "consult the oracle …" | oracle POST+SSE |
+| torches <...> | "torches …", "lights …" | assist passthrough of remainder |
+
+## Deferred (explicitly)
+
+- **Ember story commands (v1.1)**: continue-story (bump `buffer_target`),
+  played-chapter-N (`listened`), fill-the-buffer — three distinct commands per
+  the engine's throttle semantics; do not conflate.
+- `org.gnome.Speaks.Desktop` interface exported from extension.js (window
+  mgmt/screenshots; also fixes gnome-speaks#7 properly).
+- Wake-word casting ("oh realm…" with no hotkey) — sub-project 4.
+- Per-source coalescing for chatty spells — gnome-speaks#4.
+- New chime WAVs (only 4 exist; adding files needs zero code).
+
+## Validation
+
+`py_compile`; restart; then via `POST /cast`: each v1 spell as a curl
+one-liner; fizzle path; denylist-refusal log line; Assist round-trip
+(`response_type` mapping); Oracle SSE→speech; journal shows structured cast
+lines. Live mic pass at the end (JP speaks 2–3 spells).

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -33,6 +33,8 @@ import itertools
 from collections import deque
 from dataclasses import dataclass
 import queue
+
+import spellbook
 from concurrent.futures import ThreadPoolExecutor
 import threading
 import time
@@ -592,6 +594,29 @@ def apply_voice_commands(text):
     return result
 
 
+def _get_ha_token():
+    """Home Assistant long-lived token: env → cache file → Vaultwarden.
+    Returns None when unavailable. The value is never logged."""
+    token = os.environ.get("HA_TOKEN", "").strip()
+    if token:
+        return token
+    try:
+        with open(os.path.expanduser("~/.cache/ha-token-tmp")) as f:
+            token = f.read().strip()
+        if token:
+            return token
+    except OSError:
+        pass
+    try:
+        proc = subprocess.run(["bw", "get", "password", "ha-llat"],
+                              capture_output=True, text=True, timeout=10)
+        if proc.returncode == 0 and proc.stdout.strip():
+            return proc.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
 def apply_auto_corrections(text):
     """Apply user-defined word corrections from config."""
     corrections = CONFIG.get("auto_corrections", {})
@@ -694,6 +719,20 @@ class GnomeSpeaksService:
         self._queue_recent = deque(maxlen=16)
         threading.Thread(target=self._tts_dispatcher, daemon=True,
                          name="tts-queue-dispatcher").start()
+
+        # Voice spellbook (incantation layer) — "cast …" routes here instead
+        # of typing/LLM. Repo default + user overlay, mtime hot-reload.
+        self._spellbook_paths = (
+            os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         "spellbook.json"),
+            os.path.expanduser("~/.config/speech-to-cli/spellbook.json"),
+        )
+        self._spellbook = spellbook.load_spellbook(*self._spellbook_paths)
+        self._spellbook_mtimes = self._spellbook_stat()
+        self._spell_executor = spellbook.SpellExecutor(
+            chime=self.play_sound, speak=self._spell_speak,
+            dbus_self=self._spell_ctx_dbus, confirm=self.talk,
+            ha_token=_get_ha_token)
 
     # -- Config sync -------------------------------------------------------
 
@@ -979,6 +1018,15 @@ class GnomeSpeaksService:
             user_text = result.get("text", "")
 
             self._set_state("processing")
+
+            # Spell incantations ("cast …") short-circuit typing/LLM routing;
+            # matched on the raw transcript before punctuation substitution.
+            if user_text and self._try_cast(user_text):
+                GLib.idle_add(self._emit_transcription_ready, user_text)
+                self._set_state("idle")
+                _schedule_warmup()
+                return
+
             if user_text:
                 user_text = apply_voice_commands(user_text)
                 user_text = apply_auto_corrections(user_text)
@@ -1354,6 +1402,20 @@ class GnomeSpeaksService:
             if use_lexical and user_text:
                 user_text = _terminal_lowercase(user_text)
             _log(f"FINAL: {repr(user_text[:100])}")
+
+            # Spell incantations ("cast …") short-circuit typing/LLM routing;
+            # matched on the raw transcript before punctuation substitution.
+            # In loop mode the cycle continues listening; replies queue until
+            # the mic closes (never TTS over an open mic).
+            if user_text and self._try_cast(user_text):
+                if live_typing and typed_partial[0]:
+                    _send_backspaces(len(typed_partial[0]))
+                GLib.idle_add(self._emit_transcription_ready, user_text)
+                if (is_loop and not self._stop_event.is_set()
+                        and CONFIG.get("continuous_dictation", False)):
+                    self._set_state("listening")
+                    continue
+                break
 
             # 8. Post-process: voice commands and auto-corrections
             if user_text:
@@ -1782,6 +1844,78 @@ class GnomeSpeaksService:
         except Exception as e:
             log.exception("PlaySound failed for %s: %s", sound_name, e)
             return False
+
+    # -- Voice spellbook -----------------------------------------------------
+
+    def skip_current(self):
+        """Cancel the current queued utterance only; the next one plays."""
+        with self._queue_current_lock:
+            current = self._queue_current
+        if current is not None:
+            state.cancel_active()
+            return current.id
+        return None
+
+    def _spell_speak(self, text, voice=None):
+        """Spell replies ride the speech queue — same ordering/preemption
+        contract as agent speech; a chatty spell can't stomp dictation."""
+        if not text:
+            return
+        try:
+            self.enqueue_speech(text, voice=voice)
+        except queue.Full:
+            log.warning("Spell reply dropped: speech queue full")
+
+    def _spell_ctx_dbus(self, op):
+        """Self-directed spell operations (dbus_self action type)."""
+        if op == "stop":
+            self.stop()
+        elif op == "skip":
+            self.skip_current()
+        elif op == "terminal_mode":
+            self._save_config_flag("terminal_mode", True)
+            self._save_config_flag("conversation_mode", False)
+        elif op == "ai_mode":
+            self._save_config_flag("conversation_mode", True)
+            self._save_config_flag("terminal_mode", False)
+        elif op == "type_mode":
+            self._save_config_flag("conversation_mode", False)
+            self._save_config_flag("terminal_mode", False)
+        elif op == "read_notifications_toggle":
+            self._save_config_flag(
+                "read_notifications",
+                not CONFIG.get("read_notifications", False))
+        else:
+            raise ValueError(f"unknown dbus_self op: {op}")
+
+    def _spellbook_stat(self):
+        return tuple(os.path.getmtime(p) if os.path.isfile(p) else 0
+                     for p in self._spellbook_paths)
+
+    def _maybe_reload_spellbook(self):
+        mtimes = self._spellbook_stat()
+        if mtimes != self._spellbook_mtimes:
+            self._spellbook = spellbook.load_spellbook(*self._spellbook_paths)
+            self._spellbook_mtimes = mtimes
+
+    def _try_cast(self, text):
+        """Route 'cast …' utterances to the spellbook. True = consumed
+        (the text must not be typed or sent to the LLM)."""
+        self._maybe_reload_spellbook()
+        kind, spell, remainder = spellbook.match(text, self._spellbook)
+        if kind == "miss":
+            return False
+        if kind == "fizzle":
+            log.info("CAST | fizzle | nothing matched %r",
+                     (remainder or "")[:60])
+            self._spell_speak(spellbook.FIZZLE_TEXT)
+            return True
+        # Execute off-thread: actions may block on network/confirm, and the
+        # caller is an STT worker that needs to wrap up its cycle.
+        threading.Thread(target=self._spell_executor.cast,
+                         args=(spell, remainder), daemon=True,
+                         name=f"spell-{spell['name']}").start()
+        return True
 
     # -- Talk (full-duplex TTS+STT) ----------------------------------------
 
@@ -2533,6 +2667,8 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
             self._handle_resume()
         elif path == "/skip":
             self._handle_skip()
+        elif path == "/cast":
+            self._handle_cast()
         else:
             self._send_error_json(404, f"Unknown endpoint: {path}")
 
@@ -2615,14 +2751,20 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
 
     def _handle_skip(self):
         """Cancel the current queued utterance only; the next one plays."""
-        svc = self.service
-        with svc._queue_current_lock:
-            current = svc._queue_current
-        if current is None:
-            self._send_json({"ok": True, "skipped": None})
+        self._send_json({"ok": True, "skipped": self.service.skip_current()})
+
+    def _handle_cast(self):
+        """Text seam for the spellbook: same path and gates as spoken casts.
+        Lets agents cast spells and makes every spell curl-testable."""
+        body = self._read_json_body()
+        if body is None:
             return
-        state.cancel_active()
-        self._send_json({"ok": True, "skipped": current.id})
+        text = body.get("text", "")
+        if not text or not text.strip():
+            self._send_error_json(400, "Missing or empty 'text' field")
+            return
+        handled = self.service._try_cast(text)
+        self._send_json({"ok": True, "handled": handled})
 
     def _handle_queue(self):
         svc = self.service

--- a/spellbook.json
+++ b/spellbook.json
@@ -1,0 +1,38 @@
+{
+  "trigger_words": ["cast", "invoke"],
+  "spells": [
+    {"name": "silence",
+     "patterns": ["silence", "be silent", "quiet"],
+     "action": {"type": "dbus_self", "op": "stop"},
+     "gate": "instant"},
+
+    {"name": "skip",
+     "patterns": ["skip", "next"],
+     "action": {"type": "dbus_self", "op": "skip"},
+     "gate": "instant"},
+
+    {"name": "terminal-mode",
+     "patterns": ["terminal mode"],
+     "action": {"type": "dbus_self", "op": "terminal_mode", "reply": "Terminal mode."},
+     "chime": "xp_gain",
+     "gate": "instant"},
+
+    {"name": "ai-mode",
+     "patterns": ["ai mode", "conversation mode"],
+     "action": {"type": "dbus_self", "op": "ai_mode", "reply": "A I mode."},
+     "chime": "xp_gain",
+     "gate": "instant"},
+
+    {"name": "type-mode",
+     "patterns": ["type mode", "dictation mode"],
+     "action": {"type": "dbus_self", "op": "type_mode", "reply": "Type mode."},
+     "chime": "xp_gain",
+     "gate": "instant"},
+
+    {"name": "read-notifications",
+     "patterns": ["read notifications", "notifications"],
+     "action": {"type": "dbus_self", "op": "read_notifications_toggle", "reply": "Notification herald toggled."},
+     "chime": "xp_gain",
+     "gate": "instant"}
+  ]
+}

--- a/spellbook.py
+++ b/spellbook.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Voice spellbook — incantation matching and execution for gnome-speaks.
+
+Utterances beginning with a trigger word ("cast …") route here instead of
+typing or the LLM. Spells are data (spellbook.json in the repo, with a user
+overlay at ~/.config/speech-to-cli/spellbook.json); this module matches and
+executes them through callbacks injected by the service, so it has no GLib
+or audio dependencies of its own and can be sanity-tested standalone.
+"""
+
+import json
+import logging
+import os
+import re
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+log = logging.getLogger("gnome-speaks")
+
+# Actions that must never be voice-castable, no matter what the config says.
+# Matched (case-insensitive) against the JSON-serialized action; an entry
+# matching any pattern refuses to load. A hardcoded floor, not a config tier.
+DENYLIST = [
+    r"homeassistant/restart",
+    r"goodwe_off_grid",
+    r"solar_ems_apply",
+    r"battery[_-]?emulator",
+    r"automation\.turn_off",
+    r"all_lights_off",
+    r"\bvalve\.",
+    r"\block\.",
+    r"alarm_control_panel\.",
+    r"/ssh\b",
+    r"combat-ward/(approve|execute)",
+    r"wol\s+sleep",
+    r"ydotool",
+    r"loginctl\s+lock",
+]
+
+VALID_ACTION_TYPES = ("say", "dbus_self", "http", "shell", "assist", "oracle")
+VALID_GATES = ("instant", "confirm")
+
+FIZZLE_TEXT = "The spell fizzles."
+UNREACHABLE_TEXT = "The realm is beyond reach."
+
+
+class SpellUnreachable(Exception):
+    """Target service down or timed out — spoken as UNREACHABLE_TEXT."""
+
+
+def _denied(action):
+    """Return the denylist pattern an action matches, or None."""
+    blob = json.dumps(action)
+    for pat in DENYLIST:
+        if re.search(pat, blob, re.I):
+            return pat
+    return None
+
+
+def _validate(spell):
+    """Return an error string for a bad spell entry, or None if loadable."""
+    if not spell.get("name"):
+        return "missing name"
+    if not spell.get("patterns"):
+        return "missing patterns"
+    action = spell.get("action") or {}
+    if action.get("type") not in VALID_ACTION_TYPES:
+        return f"unknown action type {action.get('type')!r}"
+    if spell.get("gate", "instant") not in VALID_GATES:
+        return f"unknown gate {spell.get('gate')!r}"
+    pat = _denied(action)
+    if pat:
+        return f"action matches denylist ({pat})"
+    if action["type"] == "shell" and (
+            not isinstance(action.get("argv"), list) or not action["argv"]):
+        return "shell action requires a non-empty argv list"
+    return None
+
+
+def load_spellbook(repo_path, user_path):
+    """Load the repo spellbook and merge the user overlay by spell name.
+
+    Returns {"trigger_words": [...], "spells": {name: spell}}. Invalid
+    entries are skipped with a loud log line — a broken spell (or a broken
+    file) never breaks the service.
+    """
+    book = {"trigger_words": ["cast", "invoke"], "spells": {}}
+    for path, source in ((repo_path, "repo"), (user_path, "user")):
+        if not path or not os.path.isfile(path):
+            continue
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (OSError, ValueError) as exc:
+            log.error("Spellbook %s (%s): unreadable: %s", path, source, exc)
+            continue
+        if data.get("trigger_words"):
+            book["trigger_words"] = [w.lower() for w in data["trigger_words"]]
+        for spell in data.get("spells", []):
+            err = _validate(spell)
+            if err:
+                log.error("Spellbook (%s): spell %r rejected: %s",
+                          source, spell.get("name"), err)
+                continue
+            book["spells"][spell["name"]] = spell
+    log.info("Spellbook loaded: %d spells, triggers %s",
+             len(book["spells"]), book["trigger_words"])
+    return book
+
+
+def match(text, book):
+    """Match a raw transcript against the spellbook.
+
+    Returns (kind, spell, remainder):
+      kind "miss"   — no trigger word; the utterance is normal dictation.
+      kind "fizzle" — trigger word spoken but no spell matched (spell=None,
+                      remainder=the unmatched incantation).
+      kind "cast"   — spell matched; remainder is the captured parameter
+                      text ("" for exact matches). Longest pattern wins.
+    """
+    norm = text.strip().lower()
+    norm = re.sub(r"[.,!?;:]+$", "", norm).strip()
+    words = norm.split()
+    if not words or words[0] not in book["trigger_words"]:
+        return "miss", None, None
+    incantation = " ".join(words[1:])
+    if not incantation:
+        return "fizzle", None, ""
+    best = None  # (pattern_len, spell, remainder)
+    for spell in book["spells"].values():
+        for pattern in spell["patterns"]:
+            p = pattern.lower().strip()
+            if incantation == p:
+                cand = (len(p), spell, "")
+            elif incantation.startswith(p + " "):
+                cand = (len(p), spell, incantation[len(p):].strip())
+            else:
+                continue
+            if best is None or cand[0] > best[0]:
+                best = cand
+    if best:
+        return "cast", best[1], best[2]
+    return "fizzle", None, incantation
+
+
+def _extract(payload, path):
+    """Walk a dotted field path ("$.report", "report.text", or "$" for the
+    whole payload) into a JSON payload. Lists of dicts are summarized: each
+    item's text/summary/message (or first string value), up to 5 items.
+    Returns a speakable string or ""."""
+    if not path:
+        return ""
+    node = payload
+    rest = path.lstrip("$").lstrip(".")
+    if rest:
+        for key in rest.split("."):
+            if isinstance(node, dict):
+                node = node.get(key)
+            else:
+                return ""
+            if node is None:
+                return ""
+    if isinstance(node, list):
+        parts = []
+        for item in node[:5]:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = (item.get("text") or item.get("summary")
+                        or item.get("message"))
+                if not text:
+                    for v in item.values():
+                        if isinstance(v, str) and v:
+                            text = v
+                            break
+                if text:
+                    parts.append(text)
+        return "; ".join(parts)
+    if isinstance(node, dict):
+        return ""
+    return str(node)
+
+
+class SpellExecutor:
+    """Executes matched spells through service-injected callbacks.
+
+    Callbacks (all required):
+      chime(name)               -- fire-and-forget realm chime (~2 ms)
+      speak(text, voice=None)   -- enqueue TTS on the speech queue
+      dbus_self(op)             -- service self-ops: stop/skip/mode flags
+      confirm(prompt) -> str    -- blocking Talk(): speak, return spoken reply
+      ha_token() -> str|None    -- HA long-lived token (never logged)
+    """
+
+    def __init__(self, chime, speak, dbus_self, confirm, ha_token):
+        self._chime = chime
+        self._speak = speak
+        self._dbus_self = dbus_self
+        self._confirm = confirm
+        self._ha_token = ha_token
+
+    def cast(self, spell, remainder):
+        """Execute one spell; returns the outcome string it logged."""
+        t0 = time.monotonic()
+        if spell.get("chime"):
+            try:
+                self._chime(spell["chime"])
+            except Exception:
+                log.debug("Chime %s failed", spell.get("chime"))
+        voice = spell.get("speak_as")
+        if spell.get("gate", "instant") == "confirm":
+            reply = self._confirm(
+                "Confirm casting %s?" % spell["name"].replace("-", " ")) or ""
+            if "confirm" not in reply.lower():
+                self._speak("The casting is stayed.", voice)
+                return self._log(spell, "declined", t0)
+        try:
+            handler = getattr(self, "_do_" + spell["action"]["type"])
+            outcome = handler(spell["action"], remainder, spell)
+        except SpellUnreachable as exc:
+            log.warning("Spell %s unreachable: %s", spell["name"], exc)
+            self._speak(UNREACHABLE_TEXT, voice)
+            outcome = "unreachable"
+        except Exception as exc:
+            log.exception("Spell %s failed: %s", spell["name"], exc)
+            self._speak(FIZZLE_TEXT, voice)
+            outcome = "error"
+        return self._log(spell, outcome, t0)
+
+    def _log(self, spell, outcome, t0):
+        log.info("CAST | %s | %s | %s | %dms", spell["name"],
+                 spell["action"]["type"], outcome,
+                 int((time.monotonic() - t0) * 1000))
+        return outcome
+
+    # -- Action handlers ----------------------------------------------------
+
+    def _do_say(self, action, remainder, spell):
+        self._speak(action.get("text", ""), spell.get("speak_as"))
+        return "done"
+
+    def _do_dbus_self(self, action, remainder, spell):
+        self._dbus_self(action["op"])
+        if action.get("reply"):
+            self._speak(action["reply"], spell.get("speak_as"))
+        return "done"
+
+    def _do_http(self, action, remainder, spell):
+        url = action["url"]
+        data = None
+        if action.get("method", "GET").upper() == "POST":
+            data = json.dumps(action.get("body", {})).encode()
+        req = urllib.request.Request(
+            url, data=data, headers={"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(
+                    req, timeout=spell.get("timeout_s", 3)) as resp:
+                payload = json.loads(resp.read().decode())
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            raise SpellUnreachable(str(exc))
+        template = action.get("speak_template")
+        if template:
+            try:
+                text = template.format(**payload)
+            except (KeyError, IndexError, ValueError):
+                text = ""
+        else:
+            text = _extract(payload, action.get("speak"))
+        if text:
+            self._speak(text, spell.get("speak_as"))
+        return "done"
+
+    def _do_shell(self, action, remainder, spell):
+        # argv list only — never a shell string, never interpolated.
+        try:
+            proc = subprocess.run(action["argv"], capture_output=True,
+                                  text=True, timeout=spell.get("timeout_s", 5))
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            raise SpellUnreachable(str(exc))
+        if proc.returncode != 0:
+            raise RuntimeError(
+                proc.stderr.strip()[:200] or "exit %d" % proc.returncode)
+        out = proc.stdout.strip()
+        template = action.get("speak_template")
+        text = ""
+        if template and out:
+            try:
+                text = template.format(**json.loads(out))
+            except (ValueError, KeyError, IndexError):
+                text = out[:300]
+        elif out:
+            text = out[:300]
+        if text:
+            self._speak(text, spell.get("speak_as"))
+        return "done"
+
+    def _do_assist(self, action, remainder, spell):
+        token = self._ha_token()
+        if not token:
+            raise SpellUnreachable("no Home Assistant token available")
+        if not remainder:
+            self._speak("Speak the ritual's object.", spell.get("speak_as"))
+            return "fizzle"
+        body = json.dumps({"text": remainder, "language": "en"}).encode()
+        req = urllib.request.Request(
+            action["url"], data=body,
+            headers={"Content-Type": "application/json",
+                     "Authorization": "Bearer " + token})
+        try:
+            with urllib.request.urlopen(
+                    req, timeout=spell.get("timeout_s", 6)) as resp:
+                payload = json.loads(resp.read().decode())
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            raise SpellUnreachable(str(exc))
+        response = payload.get("response", {})
+        speech = (response.get("speech", {}).get("plain", {})
+                  .get("speech", ""))
+        if response.get("response_type") == "error":
+            self._speak(speech or FIZZLE_TEXT, spell.get("speak_as"))
+            return "fizzle"
+        self._speak(speech or "It is done.", spell.get("speak_as"))
+        return "done"
+
+    def _do_oracle(self, action, remainder, spell):
+        if not remainder:
+            self._speak("The Oracle awaits your question.",
+                        spell.get("speak_as"))
+            return "fizzle"
+        body = json.dumps(
+            {action.get("field", "message"): remainder}).encode()
+        req = urllib.request.Request(
+            action["url"], data=body,
+            headers={"Content-Type": "application/json",
+                     "Accept": "text/event-stream"})
+        try:
+            with urllib.request.urlopen(
+                    req, timeout=spell.get("timeout_s", 30)) as resp:
+                buf = ""
+                for raw in resp:
+                    line = raw.decode("utf-8", "replace").strip()
+                    if not line.startswith("data:"):
+                        continue
+                    chunk = line[5:].strip()
+                    if chunk in ("", "[DONE]"):
+                        continue
+                    try:
+                        parsed = json.loads(chunk)
+                        chunk = (parsed.get("text") or parsed.get("content")
+                                 or parsed.get("delta") or "")
+                    except ValueError:
+                        pass  # plain-string SSE payload
+                    buf += chunk
+                    while True:
+                        m = re.search(r"[.!?]\s", buf)
+                        if not m:
+                            break
+                        sentence, buf = buf[:m.end()].strip(), buf[m.end():]
+                        if sentence:
+                            self._speak(sentence, spell.get("speak_as"))
+                if buf.strip():
+                    self._speak(buf.strip(), spell.get("speak_as"))
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            raise SpellUnreachable(str(exc))
+        return "done"


### PR DESCRIPTION
## Summary
- Utterances starting with a trigger word (`cast`/`invoke`) route to a local **spellbook** instead of typing/LLM — in every mode, matched on the raw transcript, with zero dictation false-positives by construction. Unknown incantations speak "The spell fizzles."
- `spellbook.py`: data-driven loader (repo default + user overlay at `~/.config/speech-to-cli/spellbook.json`, mtime hot-reload), longest-pattern matcher with remainder capture, and an executor with six action types (`say`/`dbus_self`/`http`/`shell`/`assist`/`oracle`).
- Feedback discipline: realm chime fires at match time (~2 ms); spoken replies ride the PR #3 speech queue with per-spell voices — spells never talk over an open mic (loop-mode replies wait for the mic to close).
- Safety: `instant` vs `confirm` gates (confirm = spoken challenge via the two-way D-Bus `Talk()`), plus a **hardcoded executor denylist** — spells touching destructive surfaces (grid transfer, locks, valves, safety automations, remote exec) refuse to load regardless of config.
- `POST /cast` runs the identical path from text — every spell curl-testable, agents can cast through the same gates. Site-specific endpoints live only in the user overlay, never in the repo.

## Design
Spec + plan in `docs/superpowers/` (incl. research provenance: three agents live-probed the realm/voice/HA surfaces; reports on the workstation). Related issues: realmwatch#124–126, gnome-speaks#7.

## Test Plan
- [x] `py_compile` both files; service restarts `active`; journal shows spellbook load (repo + overlay)
- [x] Matcher/denylist/executor sanity suites via `python3 -c` (miss/cast/fizzle/params, denylist rejection, confirm-decline)
- [x] `POST /cast`: miss passes through (`handled:false`), fizzle speaks, mode spells flip real config flags (verified on disk, 0–9 ms)
- [x] Live via overlay: realm scrying spells (25–107 ms), `realm ha energy` shell spell (659 ms), Oracle SSE→sentence streaming (3 s), HA Assist round-trip incl. error→fizzle mapping (70 ms warm)
- [x] Hot-reload verified (overlay edits picked up without restart)
- [ ] Mic pass: speak "cast defense report" / "cast my level" live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice-triggered spells using “cast” or “invoke” commands.
  * Added built-in spells for switching modes, skipping responses, silence, and notifications.
  * Added spoken confirmations, queued replies, safety checks, and handling for unknown or unavailable spells.
  * Added configurable spellbooks with user overrides and automatic reloading.
  * Added an HTTP endpoint for testing spells.
* **Documentation**
  * Added user and developer documentation covering spell usage, configuration, safety, and available commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->