### PR TITLE
feat: wake word — hands-free activation via Wyoming openwakeword

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,19 @@ overlay examples — their endpoints are site-specific and never live in the rep
 | "cast consult the oracle \<question\>" | ask the realm Oracle; streamed reply |
 | "cast torches \<request\>" | natural-language pass-through to Home Assistant Assist |
 
+### Wake word
+
+With a [Wyoming openwakeword](https://github.com/rhasspy/wyoming-openwakeword)
+server on your LAN, the service can open the mic hands-free. Configure in
+`~/.config/speech-to-cli/config.json`: `wake_word: true`, `wake_word_model`
+(your openwakeword model name — effectively your wake phrase, so keep it out
+of public places), `wyoming_wake_port` (default 10400), plus the same
+`wyoming_host` used by the offline fallback. Armed **only while idle** — never
+during dictation or TTS playback — and a detection behaves exactly like the
+dictation keybinding (chime, current mode applies, "cast …" spells work).
+Toggle by voice with "cast wake word". If the wake server is unreachable the
+watcher backs off quietly and everything else keeps working.
+
 Safety: spells are gated `instant` (read-only/reversible) or `confirm` (the service
 speaks a challenge and requires a spoken "confirm"); a hardcoded executor denylist
 refuses to load any spell touching destructive surfaces (grid transfer, locks,

--- a/docs/superpowers/plans/2026-08-12-wake-word.md
+++ b/docs/superpowers/plans/2026-08-12-wake-word.md
@@ -1,0 +1,207 @@
+# Wake Word Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Speaking the wake phrase while the service is idle opens the mic exactly like the dictation hotkey.
+
+**Architecture:** speech-to-cli's `wyoming.py` gains `detect_stream()` (streams mic chunks to the Wyoming wake server; a reader thread watches for the `detection` event). gnome-speaks gains a `_wake_watcher` daemon thread — armed only while idle and `wake_word` is enabled — plus a `wake_word_toggle` spell op. All identifying values (host, ports, model name = the wake phrase) live in the user config only; repo defaults are off/empty.
+
+**Tech Stack:** Python 3 stdlib. Validation: headless synthetic-phrase pass (Piper-synthesized wake phrase → `detect_stream`), then JP's live mic pass. Sensitive test values are passed via env (`WYOMING_HOST`, `WAKE_MODEL`, `WAKE_PHRASE`), never committed.
+
+**Spec:** `docs/superpowers/specs/2026-08-12-wake-word-design.md`
+
+**File map:**
+- speech-to-cli (branch `feat/wyoming-wake-detect`): Modify `wyoming.py` (+`import threading`, `detect_stream`), `state.py` (whitelist: `wake_word` false, `wake_word_model` "", `wyoming_wake_port` 10400), README offline-fallback table (+wake row).
+- gnome-speaks (branch `feat/wake-word`): Modify `gnome-speaks-service.py` (`_wake_watcher`, init start, `wake_word_toggle` op, `_SYNC_FLAGS`), `spellbook.json` (toggle spell), `README.md`.
+- User config (not git): `wake_word: true`, `wake_word_model: <model>`, `wyoming_wake_port: 10400`.
+
+---
+
+### Task 1 (speech-to-cli): `wyoming.detect_stream`
+
+- [ ] **Step 1:** In `wyoming.py`, add `import threading` to the imports, and append:
+
+```python
+def detect_stream(host, port, model, chunk_iter, timeout=5.0):
+    """Stream mic audio to a Wyoming wake-word server until detection.
+
+    chunk_iter yields raw s16le 16 kHz mono chunks and stops when the caller
+    wants to disarm. A reader thread blocks on server events (select() over a
+    BufferedReader misses buffered events — thread avoids the trap). Returns
+    the detection name, or None if chunk_iter ended first. Raises
+    WyomingError on connect failure.
+    """
+    sock = _connect(host, port, timeout)
+    sock.settimeout(None)  # reader thread blocks indefinitely
+    f = sock.makefile("rb")
+    detected = []
+    done = threading.Event()
+
+    def _reader():
+        try:
+            while not done.is_set():
+                etype, edata, _payload = _read_event(f)
+                if etype == "detection":
+                    detected.append(edata.get("name") or model)
+                    done.set()
+                    return
+        except Exception:
+            done.set()
+
+    reader = threading.Thread(target=_reader, daemon=True,
+                              name="wyoming-wake-reader")
+    try:
+        _send_event(sock, "detect", {"names": [model]})
+        fmt = {"rate": 16000, "width": 2, "channels": 1}
+        _send_event(sock, "audio-start", dict(fmt))
+        reader.start()
+        for chunk in chunk_iter:
+            if done.is_set():
+                break
+            try:
+                _send_event(sock, "audio-chunk", dict(fmt), chunk)
+            except OSError as e:
+                raise WyomingError(f"wake stream write: {e}")
+        # Give an in-flight detection a moment to land after the last chunk
+        done.wait(timeout=0.5)
+        return detected[0] if detected else None
+    finally:
+        done.set()
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        sock.close()
+```
+
+- [ ] **Step 2:** In `state.py` `load_config()`, extend the Wyoming block:
+
+```python
+        "wyoming_wake_port": cfg.get("wyoming_wake_port", 10400),
+        "wake_word": cfg.get("wake_word", False),          # wake watcher on/off
+        "wake_word_model": cfg.get("wake_word_model", ""),  # openwakeword model name
+```
+
+- [ ] **Step 3: Headless detection check.** Synthesize the wake phrase with Piper, resample to 16 kHz, chunk it through `detect_stream` (100 ms chunks + trailing silence). Negative phrase must return None. Values via env; if the custom model doesn't trigger on synthetic voices, record the check as inconclusive (spec allows) and rely on the live pass.
+
+```bash
+cd ~/Projects/speech-to-cli && WYOMING_HOST=<host> WAKE_MODEL=<model> WAKE_PHRASE="<phrase>" python3 -c "
+import os, audioop, wyoming
+host = os.environ['WYOMING_HOST']; model = os.environ['WAKE_MODEL']
+def pcm16(text):
+    r, w, c, pcm = wyoming.synthesize(host, 10200, text)
+    out, _ = audioop.ratecv(pcm, 2, 1, r, 16000, None)
+    return out + b'\x00' * 32000  # 1s silence tail
+def chunks(data, n=3200):
+    for i in range(0, len(data), n):
+        yield data[i:i+n]
+pos = wyoming.detect_stream(host, 10400, model, chunks(pcm16(os.environ['WAKE_PHRASE'])))
+neg = wyoming.detect_stream(host, 10400, model, chunks(pcm16('completely unrelated sentence')))
+print('positive:', pos, '| negative:', neg)
+assert neg is None, 'false positive!'
+print('DETECT-OK' if pos == model else 'INCONCLUSIVE (synthetic voice may not trigger custom model)')
+"
+```
+
+- [ ] **Step 4:** README offline-fallback table: add `wyoming_wake_port` / `wake_word` / `wake_word_model` rows (generic wording, no model names). `py_compile` both files. Commit: `feat: Wyoming wake-word detection stream + config keys`. Push, PR, merge (validated by Step 3 + downstream Task 2).
+
+### Task 2 (gnome-speaks): wake watcher + spell + ship
+
+- [ ] **Step 1:** Service imports: `_build_rec_cmd` is available via the existing `from audio import ...`? Check — the service imports specific names from speech-to-cli modules; add `from audio import _build_rec_cmd` alongside existing audio imports if absent, and `import wyoming as wyoming_mod` (avoid shadowing anything).
+
+- [ ] **Step 2:** `_SYNC_FLAGS` gains `"wake_word", "wake_word_model",` (after `"read_notifications",`).
+
+- [ ] **Step 3:** Add to `GnomeSpeaksService` (near the spellbook methods):
+
+```python
+    def _wake_watcher(self):
+        """Daemon thread: streams mic audio to the Wyoming wake-word server
+        while idle; a detection acts like the dictation hotkey."""
+        last_fail_log = 0.0
+        while True:
+            if (not CONFIG.get("wake_word", False)
+                    or not CONFIG.get("wyoming_host", "")
+                    or not CONFIG.get("wake_word_model", "")
+                    or self.current_state != "idle"):
+                time.sleep(0.5)
+                continue
+            host = CONFIG.get("wyoming_host", "")
+            port = int(CONFIG.get("wyoming_wake_port", 10400))
+            model = CONFIG.get("wake_word_model", "")
+            proc = None
+            try:
+                proc = subprocess.Popen(_build_rec_cmd(),
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.DEVNULL)
+
+                def _chunks():
+                    while (CONFIG.get("wake_word", False)
+                           and self.current_state == "idle"):
+                        data = proc.stdout.read(3200)  # ~100 ms @ 16 kHz s16
+                        if not data:
+                            return
+                        yield data
+
+                name = wyoming_mod.detect_stream(host, port, model, _chunks())
+                if name and self.current_state == "idle":
+                    log.info("Wake word detected (%s) — opening mic", name)
+                    GLib.idle_add(lambda: (self.start_listening(quick=True),
+                                           False)[-1])
+                    time.sleep(2.0)  # cooldown; state flips to listening anyway
+            except wyoming_mod.WyomingError as e:
+                now = time.time()
+                if now - last_fail_log > 300:
+                    log.warning("Wake watcher: %s (retrying every 60s)", e)
+                    last_fail_log = now
+                time.sleep(60)
+            except Exception:
+                log.exception("Wake watcher error")
+                time.sleep(10)
+            finally:
+                if proc is not None:
+                    proc.kill()  # pw-record ignores SIGTERM
+                    try:
+                        proc.wait(timeout=1)
+                    except Exception:
+                        pass
+```
+
+Start it at the end of `__init__` (after the spellbook block):
+
+```python
+        # Wake word watcher (idle-only; no-op until wake_word is enabled)
+        threading.Thread(target=self._wake_watcher, daemon=True,
+                         name="wake-watcher").start()
+```
+
+- [ ] **Step 4:** `_spell_ctx_dbus` gains:
+
+```python
+        elif op == "wake_word_toggle":
+            self._save_config_flag("wake_word",
+                                   not CONFIG.get("wake_word", False))
+```
+
+`spellbook.json` gains:
+
+```json
+    {"name": "wake-word",
+     "patterns": ["wake word", "waking watch"],
+     "action": {"type": "dbus_self", "op": "wake_word_toggle", "reply": "The waking watch is toggled."},
+     "chime": "xp_gain",
+     "gate": "instant"}
+```
+
+- [ ] **Step 5:** User config gains `wake_word: true`, `wake_word_model: <model>`, `wyoming_wake_port: 10400` (python json merge, values from env — never in the repo).
+
+- [ ] **Step 6: Validate.** `py_compile`; restart; journal shows no wake errors; `curl POST /cast '{"text":"cast wake word"}'` toggles the flag on disk both ways; with the flag on, bogus port test (`wyoming_wake_port: 1` in user config temporarily) → single backoff WARNING in journal, service stays active, restore port. **Live pass (JP):** speak the wake phrase while idle → chime + badge listening; speak it during TTS → nothing; "cast wake word" disarms.
+
+- [ ] **Step 7:** README: "Wake word" subsection under Voice Spellbook (generic: any openwakeword model; config keys; idle-only semantics). Leak scan full branch history (no hosts/model names). Commit `feat: wake word watcher — hands-free activation via Wyoming openwakeword`, README commit, push, PR, merge, main, restart, update global CLAUDE.md speech-to-cli bullet (+wake word) and agent-orchestration if needed.
+
+---
+
+## Self-review notes
+
+- Spec coverage: detect_stream + reader thread (T1S1), whitelist keys (T1S2), headless synthetic check incl. inconclusive path (T1S3), watcher with idle gate/cooldown/backoff/SIGKILL (T2S3), _SYNC_FLAGS (T2S2), toggle op + spell (T2S4), user-config-only values (T2S5), validation battery + live pass (T2S6), docs + leak scan (T1S4, T2S7). No gaps.
+- No hostnames, ports-only-with-generic-hosts, no model names committed anywhere; test commands parameterized via env.
+- Type consistency: `detect_stream(host, port, model, chunk_iter)` matches watcher call; `wake_word`/`wake_word_model`/`wyoming_wake_port` names identical across state.py, watcher, spell op, config.

--- a/docs/superpowers/specs/2026-08-12-wake-word-design.md
+++ b/docs/superpowers/specs/2026-08-12-wake-word-design.md
@@ -1,0 +1,87 @@
+# Wake word — hands-free activation via LAN openwakeword
+
+## Problem
+
+Every voice interaction starts with a keyboard shortcut. A wake word makes the
+whole stack hands-free: say the word, the mic opens, dictate or cast spells.
+A Wyoming openwakeword server already runs on the LAN with JP's custom-trained
+model loaded (name lives in the user config) — verified live via a `describe` handshake.
+
+## Decisions (JP, 2026-08-12)
+
+1. **Model: JP's custom openwakeword model** (already loaded on the server; its name — effectively the wake phrase — stays in the user config, not in this public repo).
+2. **Idle-only arming (v1).** Detection is honored only when the service is
+   idle — no dictation running, no TTS playing. Wake-word barge-in during
+   speech is explicitly deferred (echo story first).
+3. **Detection = the dictation hotkey.** `start_listening(quick=True)`, chime
+   included — identical to pressing the keybinding. Whatever mode is active
+   (Type/Terminal/AI) applies, and "cast …" spells work.
+4. **Split as in the Wyoming fallback:** protocol in speech-to-cli
+   (`wyoming.detect_stream`), lifecycle in gnome-speaks (watcher thread).
+   Config keys in the user config only; repo defaults leave the feature off
+   and the model name empty (both repos are public).
+
+## Components
+
+### `wyoming.detect_stream(host, port, model, chunk_iter, timeout=5.0)` (speech-to-cli)
+
+Streams raw s16le 16 kHz mono chunks from `chunk_iter` as `audio-chunk`
+events after a `detect` (names=[model]) + `audio-start` handshake. A reader
+thread blocks on server events (avoids the select-vs-buffered-reader trap);
+a `detection` event sets a flag and the function returns the detection name.
+`chunk_iter` ending (caller disarms) returns None. Socket errors raise
+`WyomingError`. Config whitelist gains `wake_word` (false), `wake_word_model`
+(""), `wyoming_wake_port` (10400).
+
+### Wake watcher thread (gnome-speaks service)
+
+Daemon thread started at init. Each cycle:
+- Sleep-poll (0.5 s) until `CONFIG["wake_word"]` is true, `wyoming_host` and
+  `wake_word_model` are set, and state == idle.
+- Spawn its own recorder (`_build_rec_cmd()` — pw-record 16 kHz s16 mono to
+  stdout; PipeWire supports concurrent capture with the prewarmed STT
+  recorder).
+- Feed a generator into `detect_stream` that stops yielding the moment the
+  flag turns off or state leaves idle (socket closes, cycle restarts).
+- On detection while still idle: log, `GLib.idle_add(start_listening,
+  quick=True)`, 2 s cooldown.
+- `WyomingError` (wake server down): 60 s backoff, log at most every 5 min.
+- Recorder always killed with SIGKILL (pw-record ignores SIGTERM — known
+  gotcha).
+
+`_SYNC_FLAGS` gains `wake_word` and `wake_word_model` so config edits (prefs,
+spell) propagate live into the running service.
+
+### Toggle spell
+
+New `dbus_self` op `wake_word_toggle`; repo `spellbook.json` gains:
+patterns "wake word" / "waking watch" → toggles the flag, replies "The waking
+watch is toggled.", `xp_gain` chime.
+
+## Error handling
+
+Watcher failures never crash the service (broad catch → 10 s pause). The wake server going
+down degrades to no-wake-word with periodic retry; everything else unaffected.
+Detection while state changed mid-flight (race between event and idle check)
+is dropped — the 0.5 s poll re-arms.
+
+## Validation
+
+1. Headless: synthesize the wake phrase with Piper (and Azure
+   voices if Piper doesn't trigger), resample to 16 kHz, feed through
+   `detect_stream` → expect the detection name. Negative phrase → None.
+   (A custom model may only trigger reliably on JP's voice — if synthetic
+   audio can't trigger it, the headless check is skipped as inconclusive,
+   not failed.)
+2. Live: enable `wake_word` in config, speak the wake phrase near the mic → chime +
+   badge listening; dictation lands. Speak it during TTS playback → nothing
+   (idle-only). "cast wake word" toggles the watcher off and on.
+3. Journal shows arming/detection/backoff lines; service stays `active`
+   with the wake server unreachable (simulated by a bogus
+   `wyoming_wake_port`).
+
+## Deferred
+
+Wake-word barge-in during TTS; multiple wake words with per-word actions
+(one model → dictation, a second → AI mode); on-katana openwakeword
+fallback when the LAN wake server is down.

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -78,6 +78,7 @@ else:
 
 import state  # noqa: E402
 from state import CONFIG, HAS_VAD, HAS_WS, HAS_WHISPER, FRAME_BYTES, FRAME_MS, SAMPLE_RATE  # noqa: E402
+import wyoming as wyoming_mod  # noqa: E402  (speech-to-cli engine module)
 from audio import (  # noqa: E402
     _take_prewarmed_rec, _build_rec_cmd, calibrate_noise,
     is_speech_energy, rms_energy, _schedule_warmup, _prewarm_recorder,
@@ -734,6 +735,10 @@ class GnomeSpeaksService:
             dbus_self=self._spell_ctx_dbus, confirm=self.talk,
             ha_token=_get_ha_token)
 
+        # Wake word watcher (idle-only; no-op until wake_word is enabled)
+        threading.Thread(target=self._wake_watcher, daemon=True,
+                         name="wake-watcher").start()
+
     # -- Config sync -------------------------------------------------------
 
     # Boolean flags that prefs.js can change on disk while the service runs.
@@ -741,6 +746,7 @@ class GnomeSpeaksService:
         # Mode flags
         "conversation_mode", "continuous_dictation", "dictation_mode",
         "terminal_mode", "skip_final_paste", "read_notifications",
+        "wake_word", "wake_word_model",
         # LLM provider config
         "llm_provider", "llm_model", "llm_api_key", "llm_system_prompt",
         # Chimes
@@ -1885,8 +1891,62 @@ class GnomeSpeaksService:
             self._save_config_flag(
                 "read_notifications",
                 not CONFIG.get("read_notifications", False))
+        elif op == "wake_word_toggle":
+            self._save_config_flag("wake_word",
+                                   not CONFIG.get("wake_word", False))
         else:
             raise ValueError(f"unknown dbus_self op: {op}")
+
+    def _wake_watcher(self):
+        """Daemon thread: streams mic audio to the Wyoming wake-word server
+        while idle; a detection acts like the dictation hotkey."""
+        last_fail_log = 0.0
+        while True:
+            if (not CONFIG.get("wake_word", False)
+                    or not CONFIG.get("wyoming_host", "")
+                    or not CONFIG.get("wake_word_model", "")
+                    or self.current_state != "idle"):
+                time.sleep(0.5)
+                continue
+            host = CONFIG.get("wyoming_host", "")
+            port = int(CONFIG.get("wyoming_wake_port", 10400))
+            model = CONFIG.get("wake_word_model", "")
+            proc = None
+            try:
+                proc = subprocess.Popen(_build_rec_cmd(),
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.DEVNULL)
+
+                def _chunks():
+                    while (CONFIG.get("wake_word", False)
+                           and self.current_state == "idle"):
+                        data = proc.stdout.read(3200)  # ~100 ms @ 16 kHz s16
+                        if not data:
+                            return
+                        yield data
+
+                name = wyoming_mod.detect_stream(host, port, model, _chunks())
+                if name and self.current_state == "idle":
+                    log.info("Wake word detected (%s) — opening mic", name)
+                    GLib.idle_add(lambda: (self.start_listening(quick=True),
+                                           False)[-1])
+                    time.sleep(2.0)  # cooldown; state flips to listening anyway
+            except wyoming_mod.WyomingError as e:
+                now = time.time()
+                if now - last_fail_log > 300:
+                    log.warning("Wake watcher: %s (retrying every 60s)", e)
+                    last_fail_log = now
+                time.sleep(60)
+            except Exception:
+                log.exception("Wake watcher error")
+                time.sleep(10)
+            finally:
+                if proc is not None:
+                    proc.kill()  # pw-record ignores SIGTERM
+                    try:
+                        proc.wait(timeout=1)
+                    except Exception:
+                        pass
 
     def _spellbook_stat(self):
         return tuple(os.path.getmtime(p) if os.path.isfile(p) else 0

--- a/spellbook.json
+++ b/spellbook.json
@@ -33,6 +33,12 @@
      "patterns": ["read notifications", "notifications"],
      "action": {"type": "dbus_self", "op": "read_notifications_toggle", "reply": "Notification herald toggled."},
      "chime": "xp_gain",
+     "gate": "instant"},
+
+    {"name": "wake-word",
+     "patterns": ["wake word", "waking watch"],
+     "action": {"type": "dbus_self", "op": "wake_word_toggle", "reply": "The waking watch is toggled."},
+     "chime": "xp_gain",
      "gate": "instant"}
   ]
 }


### PR DESCRIPTION
## Summary
- Idle-only wake watcher thread: streams 16 kHz mic audio (own pw-record; PipeWire handles concurrent capture) to a LAN wyoming-openwakeword server via `wyoming.detect_stream` (speech-to-cli PR #11). A detection acts exactly like the dictation keybinding — chime, current mode, spells all apply.
- Armed only while the service is idle; never during dictation or TTS (verified: wake phrase played during playback does not trigger). 2 s post-detection cooldown; server-down → 60 s backoff with rate-limited logging; recorder killed with SIGKILL per the pw-record gotcha.
- `wake_word`/`wake_word_model` join `_SYNC_FLAGS` (live toggle), new `wake_word_toggle` spell op + "cast wake word" spell. Model name (= the wake phrase) and host live only in the user config — this repo stays generic.

## Test Plan
- [x] End-to-end without a human: TTS-synthesized wake phrase played through the speakers → real mic → watcher → LAN detection → `State idle -> listening` in the journal
- [x] Headless protocol check: synthetic positive triggers, unrelated phrase does not (speech-to-cli PR #11)
- [x] Idle-only gate: wake phrase during TTS playback → zero detections
- [x] "cast wake word" flips the flag on disk both ways; watcher obeys live
- [x] Unreachable wake server: single rate-limited WARNING, 60 s backoff, service stays active
- [x] `py_compile` clean; leak scan on patch history: no hosts/model names
- [ ] JP's live voice pass (synthetic path already proves the loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)