### PR TITLE
feat: finishing pass — Spellcraft prefs page, docs overhaul, Pages site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,17 +10,23 @@ Two-process design connected by session D-Bus (`org.gnome.Speaks`):
 | File | Runtime | Role | Lines |
 |------|---------|------|-------|
 | `extension.js` | GNOME Shell (GJS) | UI: badge, panel indicator, subtitle overlay, keybindings, drag | ~1,800 |
-| `gnome-speaks-service.py` | systemd user service (Python) | Audio, STT, TTS, LLM, typing, clipboard, conversation | ~3,000 |
-| `prefs.js` | GNOME Extensions app (GJS/Gtk4) | 9-page preferences window | ~1,600 |
+| `gnome-speaks-service.py` | systemd user service (Python) | Audio, STT, TTS, speech queue, LLM, typing, clipboard, wake watcher | ~3,400 |
+| `spellbook.py` | imported by the service | Incantation matcher + executor ("cast …" → local actions); denylist | ~450 |
+| `spellbook.json` | data | Repo spells (self-control); user overlay at `~/.config/speech-to-cli/spellbook.json` merges + hot-reloads | — |
+| `prefs.js` | GNOME Extensions app (GJS/Gtk4) | 10-page preferences window (incl. Spellcraft) | ~1,750 |
 | `stylesheet.css` | GNOME Shell | Badge states, animations, subtitle overlay | ~350 |
 
 The extension touches **no** network or audio -- all I/O is in the Python service.
+Spoken output serializes through a FIFO **speech queue** (HTTP callers never stomp
+each other; user speech preempts). Transcripts hit the **spellbook** before mode
+routing. A **wake watcher** thread streams mic audio to a LAN Wyoming
+openwakeword server while idle.
 
 ## External Dependencies
 
 Two sibling projects are imported at runtime (not pip packages):
 
-- **speech-to-cli** (`~/Projects/speech-to-cli`, env `SPEECH_ENGINE_PATH`) -- provides `state`, `audio`, `stt`, `speech_tts` modules
+- **speech-to-cli** (`~/Projects/speech-to-cli`, env `SPEECH_ENGINE_PATH`) -- provides `state`, `audio`, `stt`, `speech_tts`, `wyoming` modules. `wyoming` carries the LAN offline fallback (Piper TTS / local STT with a 60s Azure circuit breaker; `SPEECH_FORCE_OFFLINE=1` forces it) and `detect_stream` for the wake word. **Import order gotcha**: these modules are importable only after the `sys.path.insert` for `SPEECH_ENGINE_PATH` (~line 58) — imports above it fail at service start.
 - **cloud-chat-assistant** (`~/Projects/cloud-chat-assistant`, env `CLOUD_CHAT_PATH`) -- optional Bedrock/Azure LLM backend
 
 Config files:
@@ -51,7 +57,10 @@ systemctl --user restart gnome-speaks.service
 journalctl --user -u gnome-speaks.service -f    # live logs
 ```
 
-HTTP REST API on `localhost:7710` for browser-based TTS control.
+HTTP REST API on `localhost:7710`: `POST /speak` (queues FIFO; `interrupt:true`
+flushes), `/skip`, `/stop` (drains queue), `/pause`, `/resume`, `/cast` (text
+seam into the spellbook — same gates as spoken casts), `GET /status`, `/queue`
+(pending + per-item outcomes: done/canceled/interrupted/error), `/voices`.
 
 ## D-Bus Interface
 
@@ -83,6 +92,8 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
 | Terminal | Lowercase, no punctuation, lexical output |
 | Talk | D-Bus API for external apps (blocking call) |
 | Half/Full Duplex | Auto-detected speaker vs headphone routing |
+| Wake word | Idle-only mic stream to LAN openwakeword; detection = dictation hotkey. Toggle: "cast wake word" |
+| Spellbook | "cast …"/"invoke …" transcripts run local spells (never typed/LLM'd); `POST /cast` is the text seam |
 
 ## Coding Conventions
 
@@ -100,6 +111,10 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
 - **Schema compilation**: After editing the `.gschema.xml`, must run `glib-compile-schemas` on the install directory.
 - **Disposed notification sources**: During shell init/restart, `MessageTray` `source-added` can fire with already-disposed `FdoNotificationDaemonSource` objects. Any signal connection on them crashes the shell. Always wrap `source.connect()` in try-catch and listen for `source-removed` to drop references before GC disposes them.
 - **Azure content filter**: Avoid `[SYSTEM:]` prefix in system prompts -- Azure GPT content filter blocks it.
+- **speech-to-cli `load_config()` whitelists keys**: unknown config.json keys are silently dropped. Adding a config key means adding it to the whitelist in `state.py` too, or the feature reads a default forever.
+- **`Shell.Eval` is dead** (returns `(false,'')`; Introspect/Screenshot are AccessDenied) -- `_get_focused_app()` is silently a no-op (#7). Desktop actuation needs D-Bus methods exported from extension.js.
+- **Public repo**: LAN hostnames/IPs, the HA domain, and the wake-word model name (it's the wake phrase) never enter git -- they live in `~/.config/speech-to-cli/config.json` and the user spellbook overlay. Scan patch history before pushing.
+- **Speech-queue state ownership**: `_speak_token` fences playback cleanup -- a preempted worker must not reset state it no longer owns. Keep the token claims when adding new speech paths.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GNOME Speaks
 
-A GNOME Shell extension that adds voice interaction to your desktop — speech-to-text dictation and text-to-speech readback — powered by [Azure Speech Services](https://azure.microsoft.com/en-us/products/ai-services/speech-services).
+A GNOME Shell extension that adds voice interaction to your desktop — speech-to-text dictation, text-to-speech readback, hands-free wake-word activation, and a spoken command "spellbook" — powered by [Azure Speech Services](https://azure.microsoft.com/en-us/products/ai-services/speech-services), with automatic offline fallback to a LAN [Wyoming](https://github.com/rhasspy/wyoming) server (Piper + local STT) when the cloud is unreachable.
 
 ## Ecosystem
 
@@ -41,6 +41,10 @@ GNOME Speaks preferences can configure all four projects from one unified settin
 ## Features
 
 - **Floating voice badge** — glassmorphism-styled status indicator with pulse animations
+- **Wake word** — hands-free activation via a LAN openwakeword server; speaking your wake phrase opens the mic like the keyboard shortcut (idle-only, never over TTS)
+- **Voice spellbook** — "cast …" utterances run local spells instead of being typed: mode switching, status reports spoken back in themed voices, home-automation rituals, oracle consultations — with confirmation gates and a hardcoded denylist for anything destructive
+- **Speech queue** — the HTTP API queues utterances FIFO so concurrent callers (agents, scripts, browsers) never cut each other off; your own speech always preempts
+- **Offline fallback** — network-class Azure failures automatically reroute STT/TTS to a Wyoming server on your LAN (Piper voice, local transcription) behind a circuit breaker
 - **Panel menu** — quick access to all voice actions from the top bar
 - **Speech-to-text** — real-time streaming transcription via Azure WebSocket STT
 - **Live typing** — partial transcriptions appear in the text field as you speak, replaced by the final text when done
@@ -62,18 +66,23 @@ GNOME Speaks preferences can configure all four projects from one unified settin
 
 ```
 GNOME Shell process                    Background service
-┌─────────────────┐     D-Bus IPC     ┌──────────────────────┐
-│  extension.js   │◄──────────────────►│ gnome-speaks-service │
-│  (UI only)      │   org.gnome.Speaks │  (Python)            │
-│  - badge        │                    │  - PipeWire capture  │
-│  - panel menu   │                    │  - Azure STT (WS)    │
-│  - keybindings  │                    │  - Azure TTS (REST)  │
-│  - settings     │                    │  - ydotool live type │
-│  - bus watcher  │                    │  - LLM integration   │
-└─────────────────┘                    └──────────────────────┘
+┌─────────────────┐     D-Bus IPC     ┌────────────────────────────┐
+│  extension.js   │◄──────────────────►│ gnome-speaks-service.py    │
+│  (UI only)      │   org.gnome.Speaks │  - PipeWire capture        │
+│  - badge        │                    │  - Azure STT (WS) + TTS    │
+│  - panel menu   │                    │  - speech queue + HTTP API │
+│  - keybindings  │                    │  - spellbook.py dispatch   │
+│  - settings     │                    │  - wake-word watcher       │
+│  - bus watcher  │                    │  - ydotool live typing     │
+└─────────────────┘                    │  - LLM integration         │
+                                       └──────────┬─────────────────┘
+                                                  │ Wyoming (LAN, optional)
+                                       ┌──────────▼─────────────────┐
+                                       │ openwakeword · Piper · STT │
+                                       └────────────────────────────┘
 ```
 
-The extension runs inside GNOME Shell's process and handles only UI. All network calls, audio I/O, and speech processing happen in a separate Python service communicating over the session D-Bus. Live typing uses ydotool (or xdotool) to inject keystrokes via `/dev/uinput`, bypassing Wayland's input restrictions.
+The extension runs inside GNOME Shell's process and handles only UI. All network calls, audio I/O, and speech processing happen in a separate Python service communicating over the session D-Bus. Live typing uses ydotool (or xdotool) to inject keystrokes via `/dev/uinput`, bypassing Wayland's input restrictions. Spoken output is serialized through a FIFO speech queue (see [HTTP API](#http-api)); transcripts pass through the [spellbook](#voice-spellbook) before mode routing; and an optional LAN Wyoming stack provides the wake word and offline STT/TTS.
 
 ## Modes
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>GNOME Speaks — voice for your desktop</title>
+<meta name="description" content="A GNOME Shell extension for desktop voice interaction: dictation, AI conversation, a spoken-command spellbook, wake word, and offline fallback.">
+<link rel="icon" href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><circle cx="32" cy="32" r="30" fill="%2312141c"/><g stroke="%23e8a33d" stroke-width="4" stroke-linecap="round"><line x1="16" y1="26" x2="16" y2="38"/><line x1="26" y1="18" x2="26" y2="46"/><line x1="36" y1="24" x2="36" y2="40"/><line x1="46" y1="14" x2="46" y2="50"/></g></svg>'>
+<style>
+:root {
+  --bg: #12141c;
+  --bg-raise: #1a1d28;
+  --ink: #e9e4d8;
+  --ink-dim: #a49e8f;
+  --amber: #e8a33d;
+  --amber-soft: rgba(232, 163, 61, 0.14);
+  --phosphor: #9fd4ae;
+  --rule: rgba(232, 163, 61, 0.25);
+  --card-line: rgba(233, 228, 216, 0.08);
+  --shadow: rgba(0, 0, 0, 0.5);
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f6f1e7;
+    --bg-raise: #fffdf7;
+    --ink: #2b2620;
+    --ink-dim: #6f675a;
+    --amber: #a05e10;
+    --amber-soft: rgba(160, 94, 16, 0.10);
+    --phosphor: #2c6e45;
+    --rule: rgba(160, 94, 16, 0.35);
+    --card-line: rgba(43, 38, 32, 0.12);
+    --shadow: rgba(90, 70, 40, 0.18);
+  }
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font: 17px/1.65 "Iowan Old Style", "Palatino Linotype", Palatino, "URW Palladio L", Georgia, serif;
+  -webkit-font-smoothing: antialiased;
+  background-image:
+    radial-gradient(ellipse 80% 50% at 50% -10%, var(--amber-soft), transparent 70%),
+    repeating-linear-gradient(0deg, transparent 0 2px, rgba(127,127,127,0.012) 2px 4px);
+}
+code, pre, .mono {
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", ui-monospace, "DejaVu Sans Mono", monospace;
+  font-size: 0.86em;
+}
+a { color: var(--amber); text-decoration: none; }
+a:hover { text-decoration: underline; text-underline-offset: 3px; }
+.wrap { max-width: 980px; margin: 0 auto; padding: 0 24px; }
+
+/* ── Manuscript rule at the very top ── */
+.rule-top {
+  height: 6px;
+  background:
+    linear-gradient(90deg, transparent, var(--amber) 20%, var(--amber) 80%, transparent);
+  opacity: 0.65;
+}
+
+/* ── Hero ── */
+header { padding: 88px 0 64px; text-align: center; }
+.sigil {
+  display: inline-flex; gap: 7px; align-items: center; height: 64px; margin-bottom: 28px;
+}
+.sigil span {
+  width: 7px; border-radius: 4px; background: var(--amber);
+  animation: chant 1.5s ease-in-out infinite;
+  box-shadow: 0 0 18px var(--amber-soft);
+}
+.sigil span:nth-child(1) { height: 22px; animation-delay: 0s; }
+.sigil span:nth-child(2) { height: 48px; animation-delay: .18s; }
+.sigil span:nth-child(3) { height: 30px; animation-delay: .36s; }
+.sigil span:nth-child(4) { height: 58px; animation-delay: .54s; }
+.sigil span:nth-child(5) { height: 26px; animation-delay: .72s; }
+@keyframes chant {
+  0%, 100% { transform: scaleY(0.55); opacity: .7; }
+  50% { transform: scaleY(1); opacity: 1; }
+}
+h1 {
+  font-size: clamp(2.6rem, 7vw, 4.2rem);
+  font-weight: 600; letter-spacing: -0.015em; line-height: 1.05;
+}
+h1 .accent { color: var(--amber); font-style: italic; }
+.tagline {
+  margin: 20px auto 0; max-width: 620px;
+  font-size: 1.18rem; color: var(--ink-dim); font-style: italic;
+}
+.cta { margin-top: 36px; display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
+.btn {
+  display: inline-block; padding: 12px 26px; border-radius: 10px;
+  border: 1px solid var(--rule); font-size: 1rem;
+  transition: transform .15s ease, box-shadow .15s ease;
+}
+.btn:hover { transform: translateY(-2px); text-decoration: none; box-shadow: 0 8px 24px var(--shadow); }
+.btn-primary { background: var(--amber); color: var(--bg); border-color: transparent; font-weight: 600; }
+.btn-ghost { color: var(--ink); }
+header > * { animation: rise .7s ease both; }
+header .tagline { animation-delay: .12s; }
+header .cta { animation-delay: .24s; }
+@keyframes rise { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: none; } }
+
+/* ── Incantation demo ── */
+.incant {
+  margin: 8px auto 72px; max-width: 720px;
+  background: var(--bg-raise); border: 1px solid var(--card-line);
+  border-radius: 14px; padding: 26px 30px; text-align: left;
+  box-shadow: 0 18px 50px var(--shadow);
+}
+.incant .line { display: block; margin: 6px 0; }
+.incant .you { color: var(--amber); }
+.incant .realm { color: var(--phosphor); }
+.incant .dim { color: var(--ink-dim); }
+
+/* ── Sections ── */
+section { padding: 30px 0 54px; }
+h2 {
+  font-size: 1.9rem; font-weight: 600; margin-bottom: 8px;
+}
+h2 .numeral {
+  color: var(--amber); font-style: italic; margin-right: 14px; font-weight: 400;
+}
+.sub { color: var(--ink-dim); margin-bottom: 34px; max-width: 640px; }
+h2::after {
+  content: ""; display: block; width: 72px; height: 2px; margin-top: 14px;
+  background: linear-gradient(90deg, var(--amber), transparent);
+}
+
+/* ── Feature grid ── */
+.grid {
+  display: grid; gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+.card {
+  background: var(--bg-raise); border: 1px solid var(--card-line);
+  border-radius: 14px; padding: 26px;
+  transition: transform .18s ease, border-color .18s ease, box-shadow .18s ease;
+}
+.card:hover {
+  transform: translateY(-4px);
+  border-color: var(--rule);
+  box-shadow: 0 14px 36px var(--shadow);
+}
+.card .glyph { font-size: 1.5rem; }
+.card h3 { margin: 10px 0 8px; font-size: 1.16rem; font-weight: 600; }
+.card p { color: var(--ink-dim); font-size: 0.98rem; }
+.card code { color: var(--phosphor); }
+
+/* ── Quickstart ── */
+pre.block {
+  background: var(--bg-raise); border: 1px solid var(--card-line);
+  border-left: 3px solid var(--amber);
+  border-radius: 10px; padding: 22px 26px; overflow-x: auto;
+  line-height: 1.8; color: var(--ink);
+}
+pre.block .c { color: var(--ink-dim); }
+
+/* ── Footer ── */
+footer {
+  border-top: 1px solid var(--card-line);
+  margin-top: 40px; padding: 44px 0 60px;
+  color: var(--ink-dim); font-size: 0.95rem;
+}
+.footcols { display: flex; gap: 48px; flex-wrap: wrap; justify-content: space-between; }
+.footcols h4 { color: var(--ink); font-size: 1rem; margin-bottom: 10px; font-weight: 600; }
+.footcols ul { list-style: none; }
+.footcols li { margin: 6px 0; }
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; }
+}
+</style>
+</head>
+<body>
+<div class="rule-top"></div>
+
+<header class="wrap">
+  <div class="sigil" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span></div>
+  <h1>GNOME <span class="accent">Speaks</span></h1>
+  <p class="tagline">Voice for your desktop — dictate anywhere, converse with an AI, and command your machine with spoken incantations. Works even when the cloud doesn't.</p>
+  <div class="cta">
+    <a class="btn btn-primary" href="https://github.com/techempower-org/gnome-speaks">View on GitHub</a>
+    <a class="btn btn-ghost" href="#quickstart">Quickstart</a>
+  </div>
+</header>
+
+<div class="wrap">
+  <div class="incant mono" role="img" aria-label="Example voice session transcript">
+    <span class="line dim"># say your wake word — the mic opens, no hands</span>
+    <span class="line you">“cast defense report”</span>
+    <span class="line realm">“Two wards await your approval, one stands executed. No threats in the last day.”</span>
+    <span class="line you">“cast torches — dim the office lights”</span>
+    <span class="line realm">“It is done.”</span>
+    <span class="line dim"># unknown incantations fizzle — nothing is ever typed by accident</span>
+  </div>
+</div>
+
+<section class="wrap" id="features">
+  <h2><span class="numeral">I.</span>What it does</h2>
+  <p class="sub">One floating badge, six ways to talk to your machine. The GNOME Shell extension handles only UI — audio, speech, and network live in a background service on the session bus.</p>
+  <div class="grid">
+    <div class="card">
+      <div class="glyph">⌨️</div>
+      <h3>Dictation, anywhere</h3>
+      <p>Streaming speech-to-text typed live at your cursor — Wayland or X11 — with terminal mode, spoken punctuation, and custom auto-corrections.</p>
+    </div>
+    <div class="card">
+      <div class="glyph">🗣️</div>
+      <h3>AI conversation</h3>
+      <p>Voice in, streamed voice out: replies start speaking at the first complete sentence. Anthropic, OpenAI, Azure, Google, Bedrock, and more.</p>
+    </div>
+    <div class="card">
+      <div class="glyph">📖</div>
+      <h3>The spellbook</h3>
+      <p>Utterances starting with <code>cast</code> run local commands instead of being typed — mode switches, status reports spoken back, home rituals. JSON-defined, hot-reloaded, with confirm gates and a hardcoded denylist for anything dangerous.</p>
+    </div>
+    <div class="card">
+      <div class="glyph">🌙</div>
+      <h3>Wake word</h3>
+      <p>Speak your own openwakeword model's phrase and the mic opens — armed only while idle, never over playback. Your wake phrase stays in your config, not in this repo.</p>
+    </div>
+    <div class="card">
+      <div class="glyph">🕯️</div>
+      <h3>Offline fallback</h3>
+      <p>If the cloud is unreachable, speech reroutes to a Wyoming server on your LAN — Piper speaks, local models transcribe — behind a circuit breaker that skips dead timeouts.</p>
+    </div>
+    <div class="card">
+      <div class="glyph">🎼</div>
+      <h3>A queue, not a shouting match</h3>
+      <p>The local HTTP API serializes speech FIFO with per-utterance voices and outcome reporting — scripts and agents never cut each other off, and you always preempt.</p>
+    </div>
+  </div>
+</section>
+
+<section class="wrap" id="quickstart">
+  <h2><span class="numeral">II.</span>Quickstart</h2>
+  <p class="sub">GNOME Shell 46–48. Azure Speech key required for cloud voices; the sibling <a href="https://github.com/techempower-org/speech-to-cli">speech-to-cli</a> engine provides audio and STT/TTS.</p>
+  <pre class="block"><span class="c"># clone the extension and its engine side by side</span>
+git clone https://github.com/techempower-org/gnome-speaks
+git clone https://github.com/techempower-org/speech-to-cli
+
+<span class="c"># install: copies the extension, compiles schemas, starts the service</span>
+cd gnome-speaks &amp;&amp; ./install.sh
+
+<span class="c"># talk to it</span>
+curl -X POST localhost:7710/speak -H 'Content-Type: application/json' \
+  -d '{"text": "The realm endures."}'</pre>
+</section>
+
+<section class="wrap" id="learn">
+  <h2><span class="numeral">III.</span>Go deeper</h2>
+  <p class="sub">The README covers every mode, endpoint, and safety gate; design docs for each subsystem live in the repo.</p>
+  <div class="grid">
+    <div class="card">
+      <h3><a href="https://github.com/techempower-org/gnome-speaks#http-api">HTTP API</a></h3>
+      <p>Queue, skip, pause, cast — a localhost REST surface for browsers, scripts, and AI agents.</p>
+    </div>
+    <div class="card">
+      <h3><a href="https://github.com/techempower-org/gnome-speaks#voice-spellbook">Spellbook reference</a></h3>
+      <p>Spell schema, action types, gates, and the fizzle. Write your own overlay in JSON.</p>
+    </div>
+    <div class="card">
+      <h3><a href="https://github.com/techempower-org/gnome-speaks/tree/main/docs/superpowers/specs">Design documents</a></h3>
+      <p>The specs behind the speech queue, spellbook, offline fallback, and wake word.</p>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap footcols">
+    <div>
+      <h4>GNOME Speaks</h4>
+      <p>GPL-3.0-or-later.<br>Built for GNOME Shell 46–48.</p>
+    </div>
+    <div>
+      <h4>Ecosystem</h4>
+      <ul>
+        <li><a href="https://github.com/techempower-org/speech-to-cli">speech-to-cli</a> — audio engine</li>
+        <li><a href="https://github.com/techempower-org/cloud-chat-assistant">cloud-chat-assistant</a> — LLM providers</li>
+        <li><a href="https://github.com/techempower-org/the-oracle">the-oracle</a> — web frontend</li>
+      </ul>
+    </div>
+    <div>
+      <h4>Project</h4>
+      <ul>
+        <li><a href="https://github.com/techempower-org/gnome-speaks">Source</a></li>
+        <li><a href="https://github.com/techempower-org/gnome-speaks/issues">Issues</a></li>
+        <li><a href="https://github.com/techempower-org/gnome-speaks#readme">README</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>
+</body>
+</html>

--- a/prefs.js
+++ b/prefs.js
@@ -87,6 +87,7 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         this._addVoicePage(window);
         this._addListeningPage(window);
         this._addAudioPage(window);
+        this._addSpellcraftPage(window);
         this._addFeedbackPage(window);
         this._addExtensionPage(window);
         this._addAdvancedPage(window);
@@ -737,6 +738,84 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         } catch (e) {
             return false;
         }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Page — Spellcraft (wake word, spellbook, offline fallback)
+    // ═══════════════════════════════════════════════════════════════════
+    _addSpellcraftPage(window) {
+        const page = new Adw.PreferencesPage({
+            title: 'Spellcraft',
+            icon_name: 'weather-clear-night-symbolic',
+        });
+
+        // ── Wake Word ──
+        const wakeGroup = new Adw.PreferencesGroup({
+            title: 'Wake Word',
+            description: 'Hands-free activation via a Wyoming openwakeword server on your LAN. ' +
+                'Speaking your wake phrase while idle opens the mic exactly like the keyboard shortcut. ' +
+                'Never armed during dictation or TTS playback.',
+        });
+        page.add(wakeGroup);
+
+        this._addSwitchRow(wakeGroup, 'Enable Wake Word',
+            'Stream mic audio to the wake server while idle ("cast wake word" toggles this by voice)',
+            'wake_word', false);
+
+        this._addEntryRow(wakeGroup, 'Wake Model', 'wake_word_model', '',
+            'openwakeword model name — effectively your wake phrase; treat it as private');
+
+        this._addSpinRow(wakeGroup, 'Wake Server Port', 'wyoming_wake_port',
+            1, 65535, 1, 0, 10400,
+            'Wyoming openwakeword port on the fallback host below');
+
+        // ── Voice Spellbook ──
+        const spellGroup = new Adw.PreferencesGroup({
+            title: 'Voice Spellbook',
+            description: 'Utterances starting with "cast" or "invoke" run local spells instead of ' +
+                'being typed or sent to the LLM: mode switching, realm scrying, home rituals, oracle ' +
+                'consultations. Spells are JSON — the extension ships the self-control set; add your ' +
+                'own in the overlay below (hot-reloads on save). Test without a mic: ' +
+                'POST /cast on localhost:7710.',
+        });
+        page.add(spellGroup);
+
+        const overlayRow = new Adw.ActionRow({
+            title: 'User Spell Overlay',
+            subtitle: '~/.config/speech-to-cli/spellbook.json',
+        });
+        overlayRow.add_suffix(new Gtk.Image({ icon_name: 'document-edit-symbolic' }));
+        overlayRow.activatable = true;
+        overlayRow.connect('activated', () => {
+            const path = GLib.get_home_dir() + '/.config/speech-to-cli/spellbook.json';
+            Gio.AppInfo.launch_default_for_uri(`file://${path}`, null);
+        });
+        spellGroup.add(overlayRow);
+
+        // ── Offline Fallback ──
+        const offlineGroup = new Adw.PreferencesGroup({
+            title: 'Offline Fallback',
+            description: 'When Azure is unreachable, speech falls back to a Wyoming server on your ' +
+                'LAN (Piper TTS + local STT). A 60-second circuit breaker skips Azure while it is ' +
+                'down. Leave the host empty to disable.',
+        });
+        page.add(offlineGroup);
+
+        this._addEntryRow(offlineGroup, 'Wyoming Host', 'wyoming_host', '',
+            'LAN hostname or IP of the Wyoming server (empty = feature off)');
+
+        this._addSpinRow(offlineGroup, 'TTS Port', 'wyoming_tts_port',
+            1, 65535, 1, 0, 10200,
+            'Wyoming TTS service (e.g. wyoming-piper)');
+
+        this._addSpinRow(offlineGroup, 'STT Port', 'wyoming_stt_port',
+            1, 65535, 1, 0, 10300,
+            'Wyoming STT service (e.g. wyoming-onnx-asr)');
+
+        this._addEntryRow(offlineGroup, 'Offline Voice', 'wyoming_tts_voice', '',
+            'Piper voice name (empty = server default)');
+
+        window.add(page);
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/prefs.js
+++ b/prefs.js
@@ -812,7 +812,7 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
             1, 65535, 1, 0, 10300,
             'Wyoming STT service (e.g. wyoming-onnx-asr)');
 
-        this._addEntryRow(offlineGroup, 'Offline Voice', 'wyoming_tts_voice', '',
+        this._addEntryRow(offlineGroup, 'Offline Voice', 'wyoming_tts_voice', 'en_GB-cori-high',
             'Piper voice name (empty = server default)');
 
         window.add(page);


### PR DESCRIPTION
## Summary
- **prefs.js**: new Spellcraft page — wake word (toggle/model/port), spellbook overlay shortcut (opens the user JSON), offline fallback (Wyoming host/ports/voice, Cori default). Verified live: prefs window opens clean.
- **README**: intro/features/architecture rewritten to integrate the speech queue, spellbook, wake word, and offline fallback (previously appended piecemeal).
- **CLAUDE.md**: architecture table (+spellbook.py, +wake watcher), HTTP endpoint list, new gotchas (load_config whitelist, dead Shell.Eval, public-repo leak discipline, speech-token ownership, import-order for engine modules).
- **docs/index.html**: self-contained GitHub Pages landing page — dark/light via prefers-color-scheme, SVG favicon, animated waveform sigil, reduced-motion respected. Enable Pages from main:/docs after merge.

## Test Plan
- [x] `node --check` prefs.js; `gnome-extensions prefs` opens without errors
- [x] README/CLAUDE.md anchors verified
- [x] Page opened locally in browser; both themes render
- [x] Leak scan on patch history: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Spellcraft preferences page for wake-word activation, voice spell overlays, and offline Wyoming speech services.
  - Added a responsive documentation and marketing landing page with themes, quickstart guidance, feature highlights, and accessibility support.

- **Documentation**
  - Expanded project documentation covering voice commands, wake-word activation, speech queuing, HTTP APIs, and offline fallback.
  - Documented configuration options and operational considerations for speech and desktop interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->