### PR TITLE
fix: focused-app context via org.gnome.Speaks.Desktop (extension-side D-Bus)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -124,6 +124,19 @@ const DBUS_XML = `
 
 const GnomeSpeaksProxy = Gio.DBusProxy.makeProxyWrapper(DBUS_XML);
 
+// Exported BY the extension (the service owns org.gnome.Speaks; this name is
+// ours). GNOME locked down Shell.Eval/Introspect, so the Python service can
+// no longer ask the compositor anything — this interface runs inside the
+// Shell and answers on its behalf (gnome-speaks#7).
+const DESKTOP_DBUS_XML = `<node>
+  <interface name="org.gnome.Speaks.Desktop">
+    <method name="GetFocusedApp">
+      <arg direction="out" type="s" name="wm_class"/>
+      <arg direction="out" type="s" name="title"/>
+    </method>
+  </interface>
+</node>`;
+
 const States = {
     IDLE: 'idle',
     LISTENING: 'listening',
@@ -220,6 +233,7 @@ export default class GnomeSpeaksExtension extends Extension {
         this._registerKeybindings();
         this._initProxy();
         this._connectNotificationReader();
+        this._exportDesktopInterface();
 
         // Watch for service restarts — re-sync state when the bus name reappears
         this._busWatchId = Gio.bus_watch_name(
@@ -253,6 +267,8 @@ export default class GnomeSpeaksExtension extends Extension {
     _disable() {
         this._destroyed = true;
 
+        this._unexportDesktopInterface();
+
         if (this._busWatchId) {
             Gio.bus_unwatch_name(this._busWatchId);
             this._busWatchId = 0;
@@ -278,6 +294,46 @@ export default class GnomeSpeaksExtension extends Extension {
         this._state = null;
         this._proxyReady = false;
         this._settings = null;
+    }
+
+    // -- Desktop D-Bus export ------------------------------------------------
+
+    _exportDesktopInterface() {
+        try {
+            this._desktopDbus = Gio.DBusExportedObject.wrapJSObject(
+                DESKTOP_DBUS_XML, this);
+            this._desktopDbus.export(Gio.DBus.session,
+                '/org/gnome/Speaks/Desktop');
+            this._desktopNameId = Gio.DBus.session.own_name(
+                'org.gnome.Speaks.Desktop',
+                Gio.BusNameOwnerFlags.NONE, null, null);
+        } catch (e) {
+            log(`[GNOME Speaks] Desktop D-Bus export failed: ${e.message}`);
+            this._desktopDbus = null;
+            this._desktopNameId = 0;
+        }
+    }
+
+    _unexportDesktopInterface() {
+        if (this._desktopNameId) {
+            Gio.bus_unown_name(this._desktopNameId);
+            this._desktopNameId = 0;
+        }
+        if (this._desktopDbus) {
+            try {
+                this._desktopDbus.unexport();
+            } catch (e) {
+                // already gone — fine
+            }
+            this._desktopDbus = null;
+        }
+    }
+
+    GetFocusedApp() {
+        const win = global.display.get_focus_window();
+        if (!win)
+            return ['', ''];
+        return [win.get_wm_class() || '', win.get_title() || ''];
     }
 
     // -- Keyboard shortcuts ------------------------------------------------

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -2256,19 +2256,25 @@ class GnomeSpeaksService:
         return [k for k, pat in self._INTENT_PATTERNS.items() if pat.search(text)]
 
     def _get_focused_app(self):
-        """Get the focused window's WM_CLASS via GNOME Shell eval."""
+        """Focused window WM_CLASS (+ title) via the extension's
+        org.gnome.Speaks.Desktop interface. GNOME locked down Shell.Eval
+        (gnome-speaks#7), so the extension answers from inside the Shell.
+        Returns None when the extension isn't loaded — headless still works."""
         try:
             result = subprocess.run(
                 ["gdbus", "call", "--session",
-                 "--dest", "org.gnome.Shell",
-                 "--object-path", "/org/gnome/Shell",
-                 "--method", "org.gnome.Shell.Eval",
-                 "global.display.get_focus_window()?.get_wm_class() || ''"],
-                capture_output=True, text=True, timeout=1,
+                 "--dest", "org.gnome.Speaks.Desktop",
+                 "--object-path", "/org/gnome/Speaks/Desktop",
+                 "--method", "org.gnome.Speaks.Desktop.GetFocusedApp"],
+                capture_output=True, text=True, timeout=2,
             )
             if result.returncode == 0:
-                m = self._GDBUS_EVAL_RE.search(result.stdout)
-                return m.group(1) if m and m.group(1) else None
+                parts = re.findall(r"'((?:[^'\\]|\\.)*)'", result.stdout)
+                wm_class = parts[0] if parts else ""
+                title = parts[1] if len(parts) > 1 else ""
+                if wm_class and title:
+                    return f"{wm_class} — {title}"
+                return wm_class or None
         except Exception as exc:
             log.debug("Failed to get focused app: %s", exc)
         return None


### PR DESCRIPTION
## Summary
- GNOME's lockdown of `Shell.Eval`/`Introspect` silently killed `_get_focused_app()` — the smart-LLM-context feature lost its focused-app signal with no error (#7).
- extension.js now exports its first D-Bus interface, `org.gnome.Speaks.Desktop` (`GetFocusedApp → (wm_class, title)`), owned by the extension (the service owns `org.gnome.Speaks`; no collision), exported in enable() and cleanly unexported in disable().
- The service queries it via gdbus with a 2 s timeout and returns None gracefully when the extension isn't loaded — headless operation unaffected.

## Test Plan
- [x] `node --check` extension.js; `py_compile` service
- [x] Nested Wayland shell (`dbus-run-session -- gnome-shell --nested --wayland`): extension state ACTIVE, `gdbus call … GetFocusedApp` → `('gjs', 'Desktop Icons 1')` (the nested shell's real focus window)
- [x] Main session (old extension still loaded): name absent → service falls back to None, no errors, service `active`
- [ ] After next login (new extension loads in the real Shell): focused-app context resumes flowing to AI mode

Fixes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)