### PR TITLE
feat(queue): per-source coalescing + id-scoped /skip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,12 @@ journalctl --user -u gnome-speaks.service -f    # live logs
 ```
 
 HTTP REST API on `localhost:7710`: `POST /speak` (queues FIFO; `interrupt:true`
-flushes), `/skip`, `/stop` (drains queue), `/pause`, `/resume`, `/cast` (text
-seam into the spellbook — same gates as spoken casts), `GET /status`, `/queue`
-(pending + per-item outcomes: done/canceled/interrupted/error), `/voices`.
+flushes; `source` + `coalesce`/`kind:"progress"` drops that source's own
+unspoken backlog so agents never narrate stale status), `/skip` (optional
+`{"id":N}` scopes it to that item), `/stop` (drains queue), `/pause`,
+`/resume`, `/cast` (text seam into the spellbook — same gates as spoken casts),
+`GET /status`, `/queue` (pending + `source` + per-item outcomes:
+done/canceled/interrupted/error), `/voices`.
 
 ## D-Bus Interface
 

--- a/README.md
+++ b/README.md
@@ -283,11 +283,11 @@ current utterance immediately and holds the queue until you finish.
 
 | Endpoint | Description |
 |----------|-------------|
-| `POST /speak` | Queue text for speech. Body: `text` (required), `voice` (Azure ShortName), `quality` (`fast`/`hd`), `output_file` (save WAV instead of playing), `interrupt` (`true` = flush everything and speak now). Returns `{ok, id, position, state}` — plus `flushed` (how many queued items an interrupt deleted); `429` when the queue (depth 32) is full. |
-| `POST /skip` | Cancel the current utterance; the next queued one plays. Returns `{ok, skipped}`. (SSIP calls this `STOP`.) |
+| `POST /speak` | Queue text for speech. Body: `text` (required), `voice` (Azure ShortName), `quality` (`fast`/`hd`), `output_file` (save WAV instead of playing), `interrupt` (`true` = flush everything and speak now), `source` + `coalesce`/`kind` (see [coalescing](#coalescing-only-my-latest-matters)). Returns `{ok, id, position, state}` — plus `flushed` (how many queued items an interrupt deleted) and `coalesced` (ids your own coalesce dropped); `429` when the queue (depth 32) is full. |
+| `POST /skip` | Cancel the current utterance; the next queued one plays. Returns `{ok, skipped}` — the id that was skipped, or `null`. Optional body `{"id": N}` skips **only if** item `N` is the one playing, so a late "skip mine" can't kill somebody else's utterance. (SSIP calls this `STOP`.) |
 | `POST /stop` | Panic button: stop playback and drain the queue. Returns `{ok, cleared}`. (SSIP calls this `CANCEL` — note the inverted verbs if you have speech-dispatcher reflexes.) |
 | `POST /pause` / `POST /resume` | Pause/resume. Queue-level: while paused, the next queued item won't start either. |
-| `GET /queue` | Queue introspection: `{current, pending, depth, recent}`. `recent` holds the last 16 terminal outcomes — `done`, `canceled` (dropped before starting), `interrupted` (cut off mid-play), or `error` — so callers can learn the fate of a submitted `id`. |
+| `GET /queue` | Queue introspection: `{current, pending, depth, recent}`. Each entry carries its `source` (`null` when unset). `recent` holds the last 16 terminal outcomes — `done`, `canceled` (dropped before starting), `interrupted` (cut off mid-play), or `error` — so callers can learn the fate of a submitted `id`. |
 | `GET /status` | Service state, pause flag, `queue_depth`, playback progress. |
 | `GET /voices` | Available Azure voices (cached 5 min). |
 
@@ -295,6 +295,37 @@ current utterance immediately and holds the queue until you finish.
 curl -X POST localhost:7710/speak -H 'Content-Type: application/json' \
   -d '{"text": "Hello from the queue", "voice": "en-US-JennyNeural"}'
 ```
+
+### Coalescing: "only my latest matters"
+
+With several agents narrating at once, a deep FIFO guarantees you hear **stale**
+speech — forty queued *still working…* before the *done* you actually wanted.
+Tag your requests with a `source` and set `coalesce: true`, and each new request
+drops that source's own **unspoken** backlog:
+
+```bash
+curl -X POST localhost:7710/speak -H 'Content-Type: application/json' \
+  -d '{"text": "Build 80 percent", "source": "ci", "coalesce": true}'
+# -> {"ok":true,"id":7,"position":0,"state":"queued","coalesced":[5,6]}
+```
+
+Coalescing is deliberately narrow, so it is safe to use without coordinating
+with anyone:
+
+- It only ever drops items sharing **your** `source` — never another caller's.
+- It never cuts off the utterance that is **already playing**; use `/skip` or
+  `interrupt` for that.
+- Dropped items are reported in `coalesced`, land in `GET /queue`'s `recent`
+  ring as `canceled`, and log one INFO line with the ids.
+- `coalesce`/`kind` without a `source` is a `400` — silently coalescing nothing
+  would be worse than failing loudly.
+
+`kind: "progress"` is accepted as an alias. Speech Dispatcher's SSIP protocol has
+a dedicated `progress` class that drops intermediate updates but promotes the
+*last* message of a burst so the final "100%" is always heard. In a strict FIFO
+that promotion is free — dropping older same-source items always leaves the
+newest, and the newest always gets spoken — so `kind: "progress"` is the same
+machinery under a name that reads better at the call site.
 
 ## Voice Spellbook
 

--- a/docs/superpowers/specs/2026-08-10-http-speech-queue-design.md
+++ b/docs/superpowers/specs/2026-08-10-http-speech-queue-design.md
@@ -97,6 +97,7 @@ cross-platform API survey — reports in
 Deliberately deferred (filed as follow-up): per-source coalescing keys and a
 `progress`-style drop-intermediate-keep-final class (SSIP's best ideas — real design
 work, separate cycle), id-scoped `/skip` (1/5 precedent).
+**Both landed 2026-08-12 — see "Coalescing + id-scoped skip" below.**
 
 **Overflow policy — explicit decision (post-research):** the queue keeps
 reject-newest (429) rather than drop-oldest. The SSIP thesis ("fresh speech beats
@@ -114,6 +115,52 @@ Also: "Ubuntu looking into it" = **Myna**, Canonical's speech-to-TEXT project
 (17 Jun 2026, Ubuntu 26.10) — relevant to Type mode, not this queue. Spiel is a
 per-app synthesis API with no cross-app arbitration — aligning with it would
 recreate the stomping problem; not a fit.
+
+## Coalescing + id-scoped skip (2026-08-12, issues #4 / #5)
+
+The two deferred items above, implemented. Decisions worth recording:
+
+1. **Coalescing is opt-in and source-scoped.** `POST /speak` takes `source`
+   (string, truncated to 64 chars) and `coalesce: true`; enqueueing drops that
+   source's own **unspoken** items and returns their ids as `coalesced`. It can
+   never touch another caller's speech, which is what makes it safe to use
+   without coordination — unlike `interrupt`, it needs no blast-radius warning.
+2. **The playing item is never coalesced.** Only queued-but-unstarted items are
+   dropped. Killing audio mid-word is `/skip`'s job, and conflating the two
+   would make "post my latest status" occasionally chop a sentence in half.
+3. **`kind: "progress"` is an alias, not a second mechanism.** SSIP's `progress`
+   class drops intermediates but promotes the *last* of a burst so the final
+   "100%" is always heard. Under our strict FIFO that promotion is free:
+   drop-older-same-source always leaves the newest, and the newest is always
+   spoken. Documented as equivalent rather than built twice (YAGNI).
+4. **`coalesce`/`kind` without `source` is a 400.** Consistent with the 429
+   reasoning: give the producer a synchronous, actionable failure instead of
+   silently doing nothing.
+5. **Overflow policy unchanged.** Reject-newest (429) stays. Coalescing is now
+   the recommended fix for backlog pressure — it removes staleness at the root,
+   so the overflow victim question mostly stops arising.
+6. **`/skip` id scoping closes the race properly.** The id check and
+   `cancel_active()` happen together under `_queue_current_lock`; the dispatcher
+   takes that same lock to claim and clear the current item, so a verified item
+   cannot be swapped out from under the cancel. Bodyless `/skip` keeps the old
+   positional behaviour — when a human says "move on", positional is correct.
+
+Concurrency notes: coalescing edits the `queue.Queue`'s underlying deque under
+its `mutex` (the access pattern `GET /queue` already used). Safe because every
+producer uses `put_nowait` (no blocked putter to wake) and `qsize()`/`maxsize`
+read `len(queue)` live, so freed slots are real — verified by a test that fills
+to 32, confirms `Full`, coalesces, and successfully puts again. A new
+`_enqueue_lock` serializes coalesce-then-put so two concurrent same-source
+bursts can't interleave into two survivors. Lock order is always
+`_enqueue_lock → _tts_queue.mutex`.
+
+Validation: `py_compile`, plus 60 assertions in
+`~/.claude/projects/-home-jp/scratch/queue-coalescing/test_queue_logic.py`,
+which AST-extracts the real `enqueue_speech` / `_coalesce_source` /
+`skip_current` / `_handle_speak` / `_handle_skip` / `_handle_queue` bodies from
+the service and execs them against stubs — the service itself can't be imported
+(module-level `gi`/D-Bus/Azure side effects, hyphenated filename). Live curl
+battery run at merge time.
 
 ## Docs Ripple (at ship time)
 

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -646,6 +646,7 @@ class TTSQueueItem:
     quality: str | None = None      # "fast" | "hd" | None = service default
     output_file: str | None = None  # save-to-disk instead of playback
     enqueued_at: float = 0.0
+    source: str | None = None       # coalescing key: "only my latest matters"
 
 
 class GnomeSpeaksService:
@@ -722,6 +723,11 @@ class GnomeSpeaksService:
         # exposed on GET /queue so the /speak id isn't write-only. Exactly one
         # terminal outcome per item (Android-style invariant).
         self._queue_recent = deque(maxlen=16)
+        # Serializes coalesce-then-put so two concurrent bursts from the same
+        # source can't interleave (drop, drop, put, put would leave two items
+        # where the caller asked for one). Order is always _enqueue_lock ->
+        # _tts_queue.mutex; never the reverse.
+        self._enqueue_lock = threading.Lock()
         threading.Thread(target=self._tts_dispatcher, daemon=True,
                          name="tts-queue-dispatcher").start()
 
@@ -1562,11 +1568,20 @@ class GnomeSpeaksService:
 
     # -- TTS: Using speech_tts.tts() directly ------------------------------
 
-    def enqueue_speech(self, text, voice=None, quality=None, output_file=None):
+    def enqueue_speech(self, text, voice=None, quality=None, output_file=None,
+                       source=None, coalesce=False):
         """Create and enqueue an HTTP speech item for serial playback.
 
-        Returns (item_id, position) where position is the number of items
-        ahead (0 = will play next). Raises queue.Full at capacity.
+        Args:
+            source: optional key identifying the producer, so it can coalesce
+                its own backlog without touching anyone else's speech.
+            coalesce: when True (requires source), drop this source's older
+                UNSPOKEN items first — the newest status wins. The item that
+                is currently PLAYING is never killed by coalescing; use /skip
+                or interrupt for that.
+
+        Returns (item_id, position, dropped_ids) where position is the number
+        of items ahead (0 = will play next). Raises queue.Full at capacity.
         """
         item = TTSQueueItem(
             id=next(self._tts_queue_seq),
@@ -1575,12 +1590,49 @@ class GnomeSpeaksService:
             quality=quality,
             output_file=output_file,
             enqueued_at=time.time(),
+            source=source,
         )
-        with self._queue_current_lock:
-            busy = self._queue_current is not None
-        position = self._tts_queue.qsize() + (1 if busy else 0)
-        self._tts_queue.put_nowait(item)
-        return item.id, position
+        with self._enqueue_lock:
+            dropped = (self._coalesce_source(source)
+                       if coalesce and source else [])
+            with self._queue_current_lock:
+                busy = self._queue_current is not None
+            position = self._tts_queue.qsize() + (1 if busy else 0)
+            self._tts_queue.put_nowait(item)
+        return item.id, position, dropped
+
+    def _coalesce_source(self, source):
+        """Drop this source's not-yet-started items. Returns the dropped ids.
+
+        Removes from the middle of the Queue, which has no public API for it,
+        so we edit the underlying deque under the Queue's own mutex — the same
+        access pattern GET /queue already uses for a snapshot. Safe because
+        every producer here uses put_nowait (no blocked putter needs waking)
+        and qsize()/maxsize read len(queue) live, so freed slots are real.
+        (unfinished_tasks goes stale, which is inert: nothing calls
+        task_done()/join() on this queue.)
+        """
+        dropped = []
+        with self._tts_queue.mutex:
+            keep = deque()
+            for item in self._tts_queue.queue:
+                if item.source == source:
+                    dropped.append(item.id)
+                else:
+                    keep.append(item)
+            if dropped:
+                # clear()+extend() keeps the deque identity that Queue's own
+                # methods close over — do not rebind self._tts_queue.queue.
+                self._tts_queue.queue.clear()
+                self._tts_queue.queue.extend(keep)
+        for dropped_id in dropped:
+            # Same terminal vocabulary as /stop's drain: never started.
+            self._queue_recent.append({"id": dropped_id,
+                                       "outcome": "canceled"})
+        if dropped:
+            log.info("Coalesced source %r: dropped %d unspoken item(s): ids %s",
+                     source, len(dropped), dropped)
+        return dropped
 
     def _drain_tts_queue(self):
         """Remove all pending speech-queue items. Returns the count cleared."""
@@ -1865,14 +1917,29 @@ class GnomeSpeaksService:
 
     # -- Voice spellbook -----------------------------------------------------
 
-    def skip_current(self):
-        """Cancel the current queued utterance only; the next one plays."""
+    def skip_current(self, item_id=None):
+        """Cancel the current queued utterance only; the next one plays.
+
+        item_id: when given, skip ONLY if that id is the item actually
+            playing, else no-op returning None. Closes the positional race:
+            agent A posts /skip meaning "kill mine", but by arrival A's item
+            has finished and B's is playing — unscoped, A silently kills B.
+
+        The id check and the cancel happen under _queue_current_lock together.
+        The dispatcher takes that same lock to claim and to clear the current
+        item, so holding it here means the item we verified cannot be swapped
+        out from under the cancel. cancel_active() only sets an event and
+        signals tracked subprocesses — it never takes this lock, so there is
+        no deadlock path.
+        """
         with self._queue_current_lock:
             current = self._queue_current
-        if current is not None:
+            if current is None:
+                return None
+            if item_id is not None and current.id != item_id:
+                return None
             state.cancel_active()
             return current.id
-        return None
 
     def _spell_speak(self, text, voice=None):
         """Spell replies ride the speech queue — same ordering/preemption
@@ -2847,6 +2914,25 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
         voice = body.get("voice") or None
         output_file = body.get("output_file") or None
 
+        # Per-source coalescing: "only my latest status matters". With N agents
+        # narrating, a deep FIFO guarantees you hear STALE speech; dropping a
+        # source's own unspoken backlog fixes that at the root instead of
+        # choosing an overflow victim.
+        source = body.get("source") or None
+        if source is not None:
+            source = str(source)[:64]  # bound the key; it lands in logs
+        kind = body.get("kind") or None
+        # kind:"progress" is coalescing plus SSIP's end-of-burst guarantee
+        # ("Completed 100%" must always be heard). In a strict FIFO that
+        # guarantee is free: dropping older same-source items always leaves
+        # the newest, and the newest is always spoken. So it is the same
+        # machinery — documented equivalence, no separate class to maintain.
+        coalesce = bool(body.get("coalesce")) or kind == "progress"
+        if coalesce and not source:
+            self._send_error_json(
+                400, "'coalesce'/'kind' requires a 'source' key")
+            return
+
         # interrupt: true — flush everything and speak now (panic + speak).
         # flushed reports the blast radius: this deletes OTHER callers'
         # queued speech (Android hides this ability entirely; we expose it
@@ -2865,8 +2951,9 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
                 time.sleep(0.02)
 
         try:
-            item_id, position = svc.enqueue_speech(
-                text, voice=voice, quality=quality, output_file=output_file)
+            item_id, position, dropped = svc.enqueue_speech(
+                text, voice=voice, quality=quality, output_file=output_file,
+                source=source, coalesce=coalesce)
         except queue.Full:
             self._send_error_json(429, "queue full")
             return
@@ -2877,6 +2964,10 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
                 "position": position, "state": state_str}
         if flushed is not None:
             resp["flushed"] = flushed
+        if coalesce:
+            # Blast radius, same spirit as interrupt's `flushed` — but scoped
+            # to the caller's own source, so it can never surprise a peer.
+            resp["coalesced"] = dropped
         self._send_json(resp)
 
     def _handle_stop(self):
@@ -2886,8 +2977,24 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
         self._send_json({"ok": True, "state": "idle", "cleared": cleared})
 
     def _handle_skip(self):
-        """Cancel the current queued utterance only; the next one plays."""
-        self._send_json({"ok": True, "skipped": self.service.skip_current()})
+        """Cancel the current queued utterance only; the next one plays.
+
+        Optional {"id": N} scopes the skip to that item — a no-op if it is not
+        the one playing. Bodyless /skip keeps the old positional behaviour
+        ("move on" is inherently positional when a human says it).
+        """
+        body = self._read_json_body()
+        if body is None:
+            return  # error already sent
+        item_id = body.get("id")
+        if item_id is not None:
+            try:
+                item_id = int(item_id)
+            except (TypeError, ValueError):
+                self._send_error_json(400, "'id' must be an integer")
+                return
+        self._send_json({"ok": True,
+                         "skipped": self.service.skip_current(item_id)})
 
     def _handle_cast(self):
         """Text seam for the spellbook: same path and gates as spoken casts.
@@ -2909,11 +3016,12 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
         current = None
         if cur is not None:
             current = {"id": cur.id, "text": cur.text[:80], "voice": cur.voice,
-                       "enqueued_at": cur.enqueued_at}
+                       "source": cur.source, "enqueued_at": cur.enqueued_at}
         with svc._tts_queue.mutex:
             items = list(svc._tts_queue.queue)
         pending = [{"id": i.id, "text": i.text[:80], "voice": i.voice,
-                    "enqueued_at": i.enqueued_at} for i in items]
+                    "source": i.source, "enqueued_at": i.enqueued_at}
+                   for i in items]
         self._send_json({"current": current, "pending": pending,
                          "depth": len(pending),
                          "recent": list(svc._queue_recent)})


### PR DESCRIPTION
Implements #4 (per-source coalescing + progress class) and #5 (id-scoped `/skip`) — the two items the speech-queue spec deliberately deferred, both drawn from the SSIP prior-art sweep in PR #3.

## #4 — per-source coalescing

`POST /speak` accepts `source` (string, truncated to 64 chars) plus `coalesce: true`. Enqueueing drops that source's own **unspoken** items, so N narrating agents can't make you sit through stale status:

```bash
curl -X POST localhost:7710/speak -H 'Content-Type: application/json' \
  -d '{"text": "Build 80 percent", "source": "ci", "coalesce": true}'
# -> {"ok":true,"id":7,"position":0,"state":"queued","coalesced":[5,6]}
```

Deliberately narrow, so it is safe to use without coordinating with other callers:

- Only ever drops items sharing the caller's **own** `source` — never a peer's.
- **Never** cuts off the utterance already playing; that stays `/skip`'s job.
- Dropped ids come back as `coalesced`, land in `GET /queue`'s `recent` ring as `canceled`, and log one INFO line.
- `coalesce`/`kind` without a `source` is a **400** rather than a silent no-op — same reasoning as the existing 429.

`kind: "progress"` is an **alias, not a second mechanism**. SSIP's `progress` class drops intermediates but promotes the *last* message of a burst so the final "100%" is always heard. Under a strict FIFO that promotion is free — dropping older same-source items always leaves the newest, and the newest is always spoken. Documented as equivalent rather than built twice.

This is also the real fix behind the recorded 429-vs-drop-oldest decision: coalescing removes the backlog at the root instead of choosing an overflow victim. Overflow policy itself is unchanged.

## #5 — id-scoped `/skip`

`POST /skip` accepts optional `{"id": N}`: skip only if item `N` is the one actually playing, else no-op with `skipped: null`. Closes the positional race where agent A's late "skip mine" silently killed B's utterance.

The id check and `cancel_active()` now happen **together** under `_queue_current_lock` — the dispatcher takes that same lock to claim and to clear the current item, so a verified item cannot be swapped out from under the cancel. Bodyless `/skip` keeps the old positional behaviour, which is correct when a human says "move on".

## Concurrency notes

Coalescing edits the `queue.Queue`'s underlying deque under its `mutex` — the access pattern `GET /queue` already used. Safe because every producer uses `put_nowait` (no blocked putter to wake) and `qsize()`/`maxsize` read `len(queue)` live, so freed slots are real. A test fills to 32, confirms `Full`, coalesces, and successfully puts again. A new `_enqueue_lock` serializes coalesce-then-put so two concurrent same-source bursts can't interleave into two survivors; lock order is always `_enqueue_lock → _tts_queue.mutex`.

## Validation

- `py_compile` clean.
- **60 assertions pass** via `~/.claude/projects/-home-jp/scratch/queue-coalescing/test_queue_logic.py`. The service can't be imported (module-level `gi`/D-Bus/Azure side effects, hyphenated filename), so the harness **AST-extracts the real** `enqueue_speech` / `_coalesce_source` / `skip_current` / `_handle_speak` / `_handle_skip` / `_handle_queue` bodies from the source and execs them against stubs — it tests the shipped code text, not a copy. Covers: FIFO unchanged without a source, cross-source isolation, playing-item immunity, progress-burst convergence, capacity actually freed, id-scope match/mismatch/coercion/400, `source` on `/queue`, `interrupt`+`coalesce` together, and 4 threads × 25 concurrent coalescing bursts converging to one item.
- Not run from the worktree: the live service. Curl battery for merge-time live validation is in the handoff notes.

Docs: README HTTP API rows + a new Coalescing section, `CLAUDE.md`'s API line, and a decisions section appended to the design spec.

Closes #4
Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added source-based speech queue coalescing to remove older, unstarted items from the same source while preserving active playback.
  - Added progress-item handling for automatically dropping stale updates.
  - Added optional item-specific skipping with validation.
  - Queue details now include each item’s source, and speech responses report coalesced item IDs.

- **Documentation**
  - Updated HTTP API documentation with request fields, response metadata, validation rules, cancellation behavior, and queue outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->