### PR TITLE
feat(ui): quiet-glass overhaul — badge, pills, single-line subtitle ticker

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -817,11 +817,12 @@ export default class GnomeSpeaksExtension extends Extension {
             x_align: Clutter.ActorAlign.CENTER,
         });
 
-        // Enable word wrap on the underlying ClutterText
+        // Single-line ticker: no wrapping — Pango START ellipsizing keeps
+        // the TAIL of the transcript visible, so long dictation scrolls
+        // past a leading "…" instead of wrapping into an ever-taller block.
         let clutterText = this._subtitleLabel.get_clutter_text();
-        clutterText.set_line_wrap(true);
-        clutterText.set_line_wrap_mode(0); // PANGO_WRAP_WORD
-        clutterText.set_ellipsize(0); // PANGO_ELLIPSIZE_NONE
+        clutterText.set_line_wrap(false);
+        clutterText.set_ellipsize(1); // PANGO_ELLIPSIZE_START
 
         this._subtitleOverlay.add_child(this._subtitleLabel);
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -9,33 +9,59 @@
  */
 
 /* ============================================================
- * BASE BADGE
+ * DESIGN LANGUAGE — "quiet glass, state-lit"
+ *
+ * One constant dark-glass material everywhere; states never repaint
+ * the surface, they LIGHT it: an accent ring (border) + a soft outer
+ * glow + a tinted icon. Accents are shared across the whole system so
+ * the same color always means the same thing:
+ *
+ *   green  = you        (listening ring, VAD dot, waveform, mic)
+ *   amber  = thinking   (processing ring, panel tint)
+ *   violet = the voice  (speaking ring, AI pill, panel tint)
+ *   red    = trouble    (error ring)
+ *
+ * All state changes cross-fade (250ms); nothing snaps.
+ * ============================================================ */
+
+/* ============================================================
+ * BASE BADGE — the glass
  * ============================================================ */
 
 .gnome-speaks-badge {
-    border-radius: 28px;
-    padding: 8px 12px;
+    border-radius: 999px;
+    padding: 8px 14px;
     min-height: 32px;
-    background-color: rgba(30, 30, 30, 0.75);
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    background-color: rgba(16, 18, 26, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45),
+                0 1px 4px rgba(0, 0, 0, 0.35);
     color: rgba(255, 255, 255, 0.95);
     font-weight: bold;
     font-size: 13px;
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition-duration: 250ms;
 }
 
 .gnome-speaks-badge StIcon {
     icon-size: 20px;
-    color: rgba(255, 255, 255, 0.9);
+    color: rgba(255, 255, 255, 0.85);
+    transition-duration: 250ms;
 }
 
 .gnome-speaks-badge StLabel {
     margin-left: 8px;
-    color: rgba(255, 255, 255, 0.95);
+    color: rgba(255, 255, 255, 0.92);
+}
+
+.gnome-speaks-badge:hover {
+    background-color: rgba(28, 31, 42, 0.86);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.5),
+                0 1px 4px rgba(0, 0, 0, 0.35);
 }
 
 /* ============================================================
- * WAVEFORM BARS — audio-reactive visualization below badge
+ * WAVEFORM BARS — audio-reactive, always the "you" green
  * ============================================================ */
 
 .gnome-speaks-waveform-wrapper {
@@ -43,295 +69,277 @@
 }
 
 .gnome-speaks-waveform {
-    spacing: 1px;
+    spacing: 2px;
     height: 48px;
 }
 
 .gnome-speaks-waveform-bar {
-    min-width: 2px;
+    min-width: 3px;
     min-height: 2px;
-    border-radius: 2px;
-    background-color: rgba(100, 100, 120, 0.4);
+    border-radius: 3px;
+    background-color: rgba(120, 130, 150, 0.35);
     transition-duration: 0ms;
 }
 
-/* Three-color level metering */
+/* Three-level metering: comfortable → strong → clipping */
 .gnome-speaks-waveform-bar-good {
-    background-color: rgba(80, 220, 120, 0.85);
+    background-color: rgba(94, 226, 140, 0.9);
 }
 
 .gnome-speaks-waveform-bar-hot {
-    background-color: rgba(255, 200, 50, 0.9);
+    background-color: rgba(255, 202, 74, 0.92);
 }
 
 .gnome-speaks-waveform-bar-clip {
-    background-color: rgba(255, 70, 70, 0.95);
+    background-color: rgba(255, 92, 92, 0.95);
 }
 
-/* Silence fade — bars dim to gray when no speech for a while */
+/* Silence fade — bars rest to a faint slate */
 .gnome-speaks-waveform-bar-dim {
-    background-color: rgba(140, 140, 160, 0.35);
+    background-color: rgba(130, 138, 158, 0.28);
 }
 
-/* VAD dot — glowing green circle next to badge when speech detected */
+/* VAD dot — "I hear you", same green as the listening ring */
 .gnome-speaks-vad-dot {
     border-radius: 999px;
-    background-color: rgba(60, 255, 120, 1.0);
-    box-shadow: 0 0 16px rgba(60, 255, 120, 0.8), 0 0 32px rgba(60, 255, 120, 0.4);
-}
-
-
-/* ============================================================
- * HOVER
- * ============================================================ */
-
-.gnome-speaks-badge:hover {
-    background-color: rgba(50, 50, 55, 0.82);
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    background-color: rgba(94, 226, 140, 1.0);
+    box-shadow: 0 0 12px rgba(94, 226, 140, 0.75),
+                0 0 28px rgba(94, 226, 140, 0.35);
 }
 
 /* ============================================================
- * STATE: IDLE
- * Compact circle, quiet and unobtrusive
+ * STATE: IDLE — quiet, compact, nearly invisible until needed
  * ============================================================ */
 
 .gnome-speaks-idle {
-    background-color: rgba(40, 40, 46, 0.7);
-    padding: 6px 8px;
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
-    border: 1px solid rgba(255, 255, 255, 0.06);
+    padding: 6px 9px;
+    background-color: rgba(16, 18, 26, 0.66);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.3);
 }
 
 .gnome-speaks-idle StIcon {
     icon-size: 18px;
-    color: rgba(255, 255, 255, 0.6);
+    color: rgba(255, 255, 255, 0.55);
 }
 
 .gnome-speaks-idle:hover {
-    background-color: rgba(55, 55, 62, 0.78);
-    box-shadow: 0 3px 16px rgba(0, 0, 0, 0.35);
+    background-color: rgba(28, 31, 42, 0.78);
+    border: 1px solid rgba(255, 255, 255, 0.14);
 }
 
 .gnome-speaks-idle:hover StIcon {
-    color: rgba(255, 255, 255, 0.8);
+    color: rgba(255, 255, 255, 0.85);
 }
 
 /* ============================================================
- * STATE: LISTENING
- * Vibrant blue with radiating glow
+ * STATE: LISTENING — aurora-green ring: it's hearing YOU
+ * (matches the VAD dot, waveform, and user-speech subtitles)
  * ============================================================ */
 
 .gnome-speaks-listening {
-    background-color: rgba(30, 110, 230, 0.88);
     padding: 8px 18px;
-    box-shadow: 0 0 20px rgba(30, 130, 255, 0.5);
-    border: 1px solid rgba(120, 180, 255, 0.25);
+    background-color: rgba(14, 24, 20, 0.86);
+    border: 1px solid rgba(94, 226, 140, 0.55);
+    box-shadow: 0 0 18px rgba(94, 226, 140, 0.28),
+                0 8px 24px rgba(0, 0, 0, 0.45);
 }
 
 .gnome-speaks-listening StIcon {
-    color: white;
+    color: rgba(150, 245, 185, 1.0);
 }
 
 .gnome-speaks-listening StLabel {
-    color: white;
+    color: rgba(235, 255, 242, 0.98);
 }
 
 .gnome-speaks-listening:hover {
-    background-color: rgba(40, 120, 240, 0.92);
-    box-shadow: 0 0 20px rgba(30, 130, 255, 0.6);
+    border: 1px solid rgba(94, 226, 140, 0.75);
+    box-shadow: 0 0 24px rgba(94, 226, 140, 0.4),
+                0 8px 24px rgba(0, 0, 0, 0.45);
 }
 
 /* ============================================================
- * STATE: PROCESSING
- * Warm amber, indicates thinking
+ * STATE: PROCESSING — warm amber ring: thinking
  * ============================================================ */
 
 .gnome-speaks-processing {
-    background-color: rgba(210, 160, 30, 0.88);
     padding: 8px 18px;
-    box-shadow: 0 0 16px rgba(230, 180, 40, 0.4);
-    border: 1px solid rgba(255, 210, 80, 0.25);
+    background-color: rgba(26, 21, 12, 0.86);
+    border: 1px solid rgba(255, 190, 74, 0.5);
+    box-shadow: 0 0 16px rgba(255, 190, 74, 0.24),
+                0 8px 24px rgba(0, 0, 0, 0.45);
 }
 
 .gnome-speaks-processing StIcon {
-    color: rgba(255, 255, 255, 0.95);
+    color: rgba(255, 214, 130, 1.0);
 }
 
 .gnome-speaks-processing StLabel {
-    color: rgba(255, 255, 255, 0.95);
+    color: rgba(255, 246, 230, 0.98);
 }
 
 .gnome-speaks-processing:hover {
-    background-color: rgba(220, 170, 40, 0.92);
-    box-shadow: 0 0 22px rgba(230, 180, 40, 0.5);
+    border: 1px solid rgba(255, 190, 74, 0.7);
+    box-shadow: 0 0 22px rgba(255, 190, 74, 0.36),
+                0 8px 24px rgba(0, 0, 0, 0.45);
 }
 
 /* ============================================================
- * STATE: SPEAKING
- * Rich purple with vibrant glow
+ * STATE: SPEAKING — violet ring: the voice is talking
  * ============================================================ */
 
 .gnome-speaks-speaking {
-    background-color: rgba(140, 60, 220, 0.88);
     padding: 8px 18px;
-    box-shadow: 0 0 20px rgba(160, 80, 255, 0.5);
-    border: 1px solid rgba(190, 130, 255, 0.25);
+    background-color: rgba(20, 14, 30, 0.86);
+    border: 1px solid rgba(178, 122, 255, 0.55);
+    box-shadow: 0 0 18px rgba(178, 122, 255, 0.28),
+                0 8px 24px rgba(0, 0, 0, 0.45);
 }
 
 .gnome-speaks-speaking StIcon {
-    color: white;
+    color: rgba(206, 168, 255, 1.0);
 }
 
 .gnome-speaks-speaking StLabel {
-    color: white;
+    color: rgba(246, 238, 255, 0.98);
 }
 
 .gnome-speaks-speaking:hover {
-    background-color: rgba(150, 70, 230, 0.92);
-    box-shadow: 0 0 20px rgba(160, 80, 255, 0.6);
+    border: 1px solid rgba(178, 122, 255, 0.75);
+    box-shadow: 0 0 24px rgba(178, 122, 255, 0.4),
+                0 8px 24px rgba(0, 0, 0, 0.45);
 }
 
 /* ============================================================
- * STATE: ERROR
- * Red flash to signal problems
+ * STATE: ERROR — ember-red ring
  * ============================================================ */
 
 .gnome-speaks-error {
-    background-color: rgba(220, 50, 50, 0.88);
-    box-shadow: 0 0 16px rgba(255, 60, 60, 0.4);
-    border: 1px solid rgba(255, 120, 120, 0.25);
+    background-color: rgba(30, 13, 13, 0.88);
+    border: 1px solid rgba(255, 96, 96, 0.6);
+    box-shadow: 0 0 16px rgba(255, 96, 96, 0.3),
+                0 8px 24px rgba(0, 0, 0, 0.45);
 }
 
 .gnome-speaks-error StIcon {
-    color: white;
+    color: rgba(255, 150, 150, 1.0);
 }
 
 .gnome-speaks-error StLabel {
-    color: white;
+    color: rgba(255, 236, 236, 0.98);
 }
 
 .gnome-speaks-error:hover {
-    background-color: rgba(230, 60, 60, 0.92);
-    box-shadow: 0 0 22px rgba(255, 60, 60, 0.5);
+    border: 1px solid rgba(255, 96, 96, 0.8);
 }
 
 /* ============================================================
- * PILLS — shared base for quality + mode toggles
- * Frosted-glass look that blends with the badge
+ * PILLS — one shared shape, tinted by meaning
  * ============================================================ */
 
-/* Base pill style — expanded (listening/speaking/processing) */
+/* Shared geometry: every pill is the same object, only the tint
+ * changes. Radius/typography/padding identical across all pills so
+ * the row reads as one instrument, not four stickers. */
 .gnome-speaks-quality-hd,
 .gnome-speaks-quality-fast,
 .gnome-speaks-mode-dict,
-.gnome-speaks-mode-chat {
-    font-size: 11px;
-    font-weight: 700;
-    border-radius: 12px;
-    padding: 3px 10px;
-    margin-left: 6px;
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    background-color: rgba(255, 255, 255, 0.10);
-    color: rgba(255, 255, 255, 0.85);
-    text-align: center;
-}
-
-/* Pills are hidden in idle state — no compact styles needed */
-
-/* ── Quality: HD (warm gold — premium feel) ── */
-.gnome-speaks-quality-hd {
-    background-color: rgba(255, 190, 40, 0.25);
-    color: rgba(255, 220, 120, 1.0);
-    border: 1px solid rgba(255, 200, 60, 0.35);
-    box-shadow: 0 0 8px rgba(255, 190, 40, 0.15);
-}
-.gnome-speaks-quality-hd:hover {
-    background-color: rgba(255, 190, 40, 0.38);
-}
-
-/* ── Quality: Fast (cool green — snappy feel) ── */
-.gnome-speaks-quality-fast {
-    background-color: rgba(60, 200, 100, 0.25);
-    color: rgba(100, 240, 150, 1.0);
-    border: 1px solid rgba(60, 200, 100, 0.35);
-    box-shadow: 0 0 8px rgba(60, 200, 100, 0.15);
-}
-.gnome-speaks-quality-fast:hover {
-    background-color: rgba(60, 200, 100, 0.38);
-}
-
-/* ── Mode: Type (muted — default, unobtrusive) ── */
-.gnome-speaks-mode-dict {
-    background-color: rgba(255, 255, 255, 0.06);
-    color: rgba(255, 255, 255, 0.45);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-}
-.gnome-speaks-mode-dict:hover {
-    background-color: rgba(255, 255, 255, 0.12);
-    color: rgba(255, 255, 255, 0.7);
-}
-
-/* ── Mode: AI Chat (vivid purple — clearly active) ── */
-.gnome-speaks-mode-chat {
-    background-color: rgba(160, 100, 255, 0.30);
-    color: rgba(200, 160, 255, 1.0);
-    border: 1px solid rgba(160, 100, 255, 0.40);
-    box-shadow: 0 0 8px rgba(160, 100, 255, 0.20);
-}
-.gnome-speaks-mode-chat:hover {
-    background-color: rgba(160, 100, 255, 0.42);
-}
-
-/* ── Pill: Off (dim, inactive toggle) ── */
-.gnome-speaks-pill-off {
-    font-size: 11px;
-    font-weight: 700;
-    border-radius: 12px;
-    padding: 3px 10px;
-    margin-left: 6px;
-    background-color: rgba(255, 255, 255, 0.06);
-    color: rgba(255, 255, 255, 0.35);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    text-align: center;
-}
-.gnome-speaks-pill-off:hover {
-    background-color: rgba(255, 255, 255, 0.12);
-    color: rgba(255, 255, 255, 0.6);
-}
-
-/* ── Pill: On (bright cyan — clearly enabled) ── */
+.gnome-speaks-mode-chat,
+.gnome-speaks-pill-off,
 .gnome-speaks-pill-on {
     font-size: 11px;
     font-weight: 700;
-    border-radius: 12px;
-    padding: 3px 10px;
+    border-radius: 999px;
+    padding: 3px 11px;
     margin-left: 6px;
-    background-color: rgba(40, 180, 220, 0.30);
-    color: rgba(100, 220, 255, 1.0);
-    border: 1px solid rgba(40, 180, 220, 0.40);
-    box-shadow: 0 0 8px rgba(40, 180, 220, 0.20);
     text-align: center;
+    transition-duration: 200ms;
+    border: 1px solid rgba(255, 255, 255, 0.10);
+    background-color: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.8);
+}
+
+/* ── Quality: HD — warm gold, "premium & metered" ── */
+.gnome-speaks-quality-hd {
+    background-color: rgba(255, 190, 40, 0.20);
+    color: rgba(255, 222, 130, 1.0);
+    border: 1px solid rgba(255, 200, 60, 0.4);
+}
+.gnome-speaks-quality-hd:hover {
+    background-color: rgba(255, 190, 40, 0.34);
+    border: 1px solid rgba(255, 200, 60, 0.6);
+}
+
+/* ── Quality: Fast — cool green, "snappy & free-ish" ── */
+.gnome-speaks-quality-fast {
+    background-color: rgba(94, 226, 140, 0.18);
+    color: rgba(150, 245, 185, 1.0);
+    border: 1px solid rgba(94, 226, 140, 0.4);
+}
+.gnome-speaks-quality-fast:hover {
+    background-color: rgba(94, 226, 140, 0.3);
+    border: 1px solid rgba(94, 226, 140, 0.6);
+}
+
+/* ── Mode: Type — muted, the default state of the world ── */
+.gnome-speaks-mode-dict {
+    background-color: rgba(255, 255, 255, 0.05);
+    color: rgba(255, 255, 255, 0.45);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+}
+.gnome-speaks-mode-dict:hover {
+    background-color: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.75);
+}
+
+/* ── Mode: AI Chat — violet, same accent as the speaking ring ── */
+.gnome-speaks-mode-chat {
+    background-color: rgba(178, 122, 255, 0.22);
+    color: rgba(206, 168, 255, 1.0);
+    border: 1px solid rgba(178, 122, 255, 0.45);
+}
+.gnome-speaks-mode-chat:hover {
+    background-color: rgba(178, 122, 255, 0.36);
+    border: 1px solid rgba(178, 122, 255, 0.65);
+}
+
+/* ── Toggle pills: off = ghost, on = cyan-lit ── */
+.gnome-speaks-pill-off {
+    background-color: rgba(255, 255, 255, 0.05);
+    color: rgba(255, 255, 255, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+}
+.gnome-speaks-pill-off:hover {
+    background-color: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.gnome-speaks-pill-on {
+    background-color: rgba(64, 196, 232, 0.2);
+    color: rgba(140, 226, 255, 1.0);
+    border: 1px solid rgba(64, 196, 232, 0.45);
 }
 .gnome-speaks-pill-on:hover {
-    background-color: rgba(40, 180, 220, 0.42);
+    background-color: rgba(64, 196, 232, 0.34);
+    border: 1px solid rgba(64, 196, 232, 0.65);
 }
 
 /* ============================================================
- * CHAT-MODE BADGE BORDER TINT
+ * CHAT-MODE BADGE TINT — a faint violet promise while idle
  * ============================================================ */
 
 .gnome-speaks-chat-active {
-    border: 1px solid rgba(160, 100, 255, 0.30);
+    border: 1px solid rgba(178, 122, 255, 0.32);
 }
 
 .gnome-speaks-idle.gnome-speaks-chat-active {
-    border: 1px solid rgba(160, 100, 255, 0.20);
-    box-shadow: 0 0 10px rgba(140, 80, 230, 0.20);
+    border: 1px solid rgba(178, 122, 255, 0.24);
+    box-shadow: 0 0 10px rgba(178, 122, 255, 0.18),
+                0 4px 14px rgba(0, 0, 0, 0.3);
 }
 
 /* ============================================================
- * PANEL INDICATOR
+ * PANEL INDICATOR — same accent vocabulary, tiny
  * ============================================================ */
 
 .gnome-speaks-panel-idle {
@@ -339,39 +347,63 @@
 }
 
 .gnome-speaks-panel-listening {
-    color: rgba(100, 180, 255, 1.0);
+    color: rgba(94, 226, 140, 1.0);
 }
 
 .gnome-speaks-panel-processing {
-    color: rgba(255, 180, 50, 1.0);
+    color: rgba(255, 190, 74, 1.0);
 }
 
 .gnome-speaks-panel-speaking {
-    color: rgba(180, 120, 255, 1.0);
+    color: rgba(178, 122, 255, 1.0);
 }
 
 /* ============================================================
- * SUBTITLE OVERLAY — cinematic bottom-center display
+ * SUBTITLE OVERLAY — a single-line ticker in the same glass
+ *
+ * The label never wraps: Pango START-ellipsizing keeps the newest
+ * words visible while older text slides away behind a leading "…".
  * ============================================================ */
 
 .gnome-speaks-subtitle-overlay {
-    background-color: rgba(20, 12, 36, 0.85);
-    border-radius: 12px;
-    padding: 12px 24px;
-    min-width: 300px;
-    max-width: 800px;
-    border: 1px solid rgba(160, 120, 255, 0.12);
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+    background-color: rgba(16, 18, 26, 0.84);
+    border-radius: 999px;
+    padding: 10px 26px;
+    min-width: 120px;
+    max-width: 900px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5),
+                0 1px 4px rgba(0, 0, 0, 0.35);
+    transition-duration: 200ms;
 }
 
 .gnome-speaks-subtitle-text {
-    font-size: 18px;
+    font-size: 17px;
     font-weight: 400;
-    color: rgba(232, 220, 200, 0.95);
+    color: rgba(236, 232, 224, 0.96);
     text-align: center;
 }
 
-/* -- Color variants for subtitle color setting -- */
+/* Live (partial) = italic whisper on a green-kissed ring;
+ * final = settled weight on a neutral ring. */
+.gnome-speaks-subtitle-partial {
+    border: 1px solid rgba(94, 226, 140, 0.28);
+}
+
+.gnome-speaks-subtitle-partial .gnome-speaks-subtitle-text {
+    font-style: italic;
+    color: rgba(236, 232, 224, 0.88);
+}
+
+.gnome-speaks-subtitle-final {
+    border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.gnome-speaks-subtitle-final .gnome-speaks-subtitle-text {
+    font-weight: 500;
+}
+
+/* -- Color variants for the subtitle color setting -- */
 
 .gnome-speaks-subtitle-green .gnome-speaks-subtitle-text {
     color: #6eb86e;
@@ -435,14 +467,4 @@
 
 .gnome-speaks-subtitle-gray .gnome-speaks-subtitle-text {
     color: #a0a0a0;
-}
-
-/* -- Partial (live) vs final transcription styling -- */
-
-.gnome-speaks-subtitle-partial .gnome-speaks-subtitle-text {
-    font-style: italic;
-}
-
-.gnome-speaks-subtitle-final .gnome-speaks-subtitle-text {
-    font-weight: 500;
 }


### PR DESCRIPTION
## Summary
- **Subtitle wrap bug fixed at the render layer**: the overlay is a single-line ticker now — Pango `ELLIPSIZE_START` keeps the transcript tail visible behind a leading "…" instead of wrapping forever (word-highlight markup preserved).
- **"Quiet glass, state-lit" design language**: one constant glass surface; states express through accent ring + glow + icon tint. Unified accent vocabulary — green=you, amber=thinking, violet=voice, red=trouble — including moving *listening* from blue to green so it matches the VAD dot, waveform, and user-speech subtitles it sits next to.
- Pills unified into one geometry with meaning-tinted variants; 200–250 ms cross-fades everywhere; panel indicator uses the same accents.

## Test Plan
- [x] `node --check`; nested Wayland shell: extension ACTIVE, zero extension errors in the shell log
- [x] Class-name contract unchanged (pure CSS value redesign + 3-line ClutterText change)
- [ ] Visual pass by JP after next login (extension reload pending anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)