### PR TITLE
feat(prefs): task-first redesign — 10 pages → 6, research-backed

### DIFF
--- a/docs/superpowers/specs/2026-08-12-prefs-redesign.md
+++ b/docs/superpowers/specs/2026-08-12-prefs-redesign.md
@@ -1,0 +1,51 @@
+# Preferences redesign — task-first, search-honest, audit-fixed
+
+Research inputs (both live-verified, on the workstation):
+`~/.claude/projects/-home-jp/scratch/prefs-redesign/hig-research.md` (IA +
+rules; key finding: Adw 1.5 search never matches group descriptions — our 29
+paragraphs were unsearchable) and `control-audit.md` (101-row inventory; 5
+dead controls, entry help text never rendered, split-brain subtitle toggle,
+lying defaults, duplicated groups).
+
+## IA: 10 pages → 6, task-first
+
+`Dictation · AI Chat · Voice & Sound · Wake & Spells · Accounts · Advanced`
+
+- Azure page dissolves: creds → Accounts, voices → Voice & Sound, STT
+  tuning → Dictation. Cloud AI page → Accounts (creds) + AI Chat
+  (generation). Modes/Listening → Dictation. Feedback → Voice & Sound.
+  Extension → Dictation › Starting. Spellcraft → Wake & Spells.
+- Barge-in unified in AI Chat (was split across two pages).
+- All silence timeouts co-located in Dictation › Flow.
+
+## Rules applied (from HIG research)
+
+R1 explain on the row: group descriptions ≤3 total, subtitles everywhere.
+R2 money/destruction visible: Adw.Banner on Accounts (metering), cost
+subtitles on HD voice / max-tokens / Spiel-Azure. R3 one control per row.
+R5 no subsystem words in titles ("Speak While Listening", not "Half Duplex").
+R6 defaults stated in subtitles. (Deviation: no per-group Reset buttons —
+wiring cost outweighs value for a personal tool; revisit on demand.)
+
+## Audit fixes in this rebuild
+
+1. Dead controls dropped: Speed/Pitch/Volume/VAD-aggressiveness (params the
+   service never passes — follow-up issue to wire speed properly).
+2. `_addEntryRow`/`_addPasswordRow` help text: Adw.EntryRow has no subtitle —
+   help renders as tooltip + critical caveats (wake-model privacy) get
+   explicit info rows. Password rows no longer nest a PreferencesGroup
+   inside a group (invalid Adw).
+3. Live Subtitles: ONE switch writing both GSettings `live-subtitles` and
+   config `live_subtitles` (was split-brain with opposite owners).
+4. Deprecated `Adw.MessageDialog` → `Adw.AlertDialog`.
+5. Duplicates removed: one Shortcuts group, one Restart row.
+6. Truthful text: ydotool not wtype; echo-cancel default aligned to the
+   service's `false`.
+7. Gaps added: Spiel provider group (3 keys), `save_audio_dir`
+   (privacy-labeled), `conversation_silence_timeout`.
+
+Also: `llm_model` default unified to the dotted canonical (state.py had
+hyphens, prefs dots — llm_stream's MODEL_MAP speaks dots).
+
+Known-deferred (issue to file): prefs and service both rewrite config.json
+whole-file on save (last writer wins) — needs read-merge-write.

--- a/prefs.js
+++ b/prefs.js
@@ -6,6 +6,14 @@
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
+//
+// Preferences window — task-first IA (see docs/superpowers/specs/
+// 2026-08-12-prefs-redesign.md). Rules that shape every row here:
+//   - Explain on the row (subtitles), not in group prose — libadwaita's
+//     preferences search matches row subtitles but NEVER group
+//     descriptions, so prose paragraphs are invisible to search.
+//   - Money and destruction are visible: banners + warning subtitles.
+//   - Defaults are stated in subtitles; no subsystem jargon in titles.
 
 import Adw from 'gi://Adw';
 import Gio from 'gi://Gio';
@@ -63,6 +71,19 @@ const SUBTITLE_COLORS = [
     ['gray', 'Gray'],
 ];
 
+const HD_VOICES = [
+    'Ava', 'Andrew', 'Brian', 'Emma', 'Aria', 'Davis', 'Jenny', 'Guy',
+    'Steffan', 'Christopher', 'Eric', 'Roger', 'Alloy', 'Echo', 'Fable',
+    'Onyx', 'Nova', 'Shimmer',
+].map(n => [`en-US-${n}:DragonHDLatestNeural`, `${n} (DragonHD)`]);
+
+const FAST_VOICES = [
+    'Ava', 'Andrew', 'Aria', 'Davis', 'Jenny', 'Guy', 'Brian', 'Emma',
+    'Steffan', 'Christopher', 'Eric', 'Roger', 'Michelle', 'Monica',
+    'Cora', 'Jane', 'Nancy', 'Sara', 'Tony', 'Jason', 'Brandon', 'Jacob',
+    'Amber', 'Ashley', 'Elizabeth',
+].map(n => [`en-US-${n}Neural`, n]);
+
 // ─── Main Preferences Class ─────────────────────────────────────────────────
 export default class GnomeSpeaksPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
@@ -81,65 +102,128 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
             return false;
         });
 
-        this._addModesPage(window);
-        this._addAzurePage(window);
-        this._addCloudAIPage(window);
-        this._addVoicePage(window);
-        this._addListeningPage(window);
-        this._addAudioPage(window);
-        this._addSpellcraftPage(window);
-        this._addFeedbackPage(window);
-        this._addExtensionPage(window);
+        this._addDictationPage(window);
+        this._addAiChatPage(window);
+        this._addVoiceSoundPage(window);
+        this._addWakeSpellsPage(window);
+        this._addAccountsPage(window);
         this._addAdvancedPage(window);
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // Page 0 — Modes Guide
+    // Page 1 — Dictation: speaking text into the computer
     // ═══════════════════════════════════════════════════════════════════
-    _addModesPage(window) {
+    _addDictationPage(window) {
         const page = new Adw.PreferencesPage({
-            title: 'Modes',
-            icon_name: 'view-list-symbolic',
+            title: 'Dictation',
+            icon_name: 'input-keyboard-symbolic',
         });
 
-        // ── Type Mode ──
-        const typeGroup = new Adw.PreferencesGroup({
-            title: 'Type Mode',
-            description: 'Speech is transcribed and typed at the cursor via wtype (Wayland) or xdotool (X11). Click the floating badge or press Super+Alt+Space to start. Click again, say "over", or wait for silence to stop.',
-        });
+        // ── Typing ──
+        const typeGroup = new Adw.PreferencesGroup({title: 'Typing'});
         page.add(typeGroup);
 
         this._addSwitchRow(typeGroup, 'Type at Cursor',
-            'Type transcribed text where the cursor is. When off, text is copied to clipboard only.',
+            'Type transcribed words where the cursor is (via ydotool). Off = copy to clipboard only. Default: on',
             'dictation_mode', true);
 
-        this._addSwitchRow(typeGroup, 'Skip Final Paste',
-            'Keep live-typed text as-is instead of replacing it with the final corrected transcription',
+        this._addSwitchRow(typeGroup, 'Keep Live Text',
+            'Keep the live-typed words as-is instead of replacing them with the final corrected transcript. Default: on',
             'skip_final_paste', true);
 
-        this._addSwitchRow(typeGroup, 'Terminal Mode',
-            'All lowercase, no auto-capitalization or punctuation. Uses Azure Lexical output for code and terminal input.',
+        this._addSwitchRow(typeGroup, 'Terminal Style',
+            'All lowercase, no punctuation — for code and terminal input. Default: off',
             'terminal_mode', false);
 
-        this._addSwitchRow(typeGroup, 'Voice Commands',
-            'Convert spoken punctuation ("period", "comma", "new line") to characters',
+        this._addSwitchRow(typeGroup, 'Spoken Punctuation',
+            'Turn "period", "comma", "new line" into characters. Default: on',
             'voice_commands', true);
 
-        this._addEntryRow(typeGroup, 'End Word', 'end_word', 'over',
-            'Say this word to immediately stop recording');
+        this._addEntryRow(typeGroup, 'Stop Word', 'end_word', 'over',
+            'Say this word to stop recording immediately. Default: over');
 
-        // ── AI Mode ──
-        const aiGroup = new Adw.PreferencesGroup({
-            title: 'AI Mode',
-            description: 'Speech is sent to an LLM (Claude, GPT, etc.) and the response is spoken aloud. Toggle with the robot pill on the badge, or the panel menu.',
+        // ── Flow — every listening timeout lives here ──
+        const flowGroup = new Adw.PreferencesGroup({title: 'Flow'});
+        page.add(flowGroup);
+
+        this._addSwitchRow(flowGroup, 'Continuous Dictation',
+            'Listen again automatically after each pause — dictate without re-clicking. Default: off',
+            'continuous_dictation', false);
+
+        this._addSpinRow(flowGroup, 'Pause Before Stop', 'silence_timeout',
+            0.5, 10.0, 0.5, 1, 3.0,
+            'Seconds of silence after speech before recording stops. Default: 3');
+
+        this._addSpinRow(flowGroup, 'Give Up After', 'no_speech_timeout',
+            1.0, 30.0, 1.0, 0, 7.0,
+            'Seconds to wait for any speech before stopping. Default: 7');
+
+        this._addSpinRow(flowGroup, 'Continuous Pause', 'loop_silence_timeout',
+            0.3, 5.0, 0.1, 1, 1.2,
+            'Shorter pause detection while in continuous mode. Default: 1.2');
+
+        this._addSpinRow(flowGroup, 'Recording Limit', 'max_record_seconds',
+            5, 300, 5, 0, 120,
+            'Absolute maximum seconds for one recording. Default: 120');
+
+        // ── Hearing ──
+        const hearGroup = new Adw.PreferencesGroup({title: 'Hearing'});
+        page.add(hearGroup);
+
+        this._addSpinRow(hearGroup, 'Microphone Sensitivity', 'energy_multiplier',
+            0.5, 20.0, 0.5, 1, 2.5,
+            'Noise gate threshold — lower hears quieter speech, higher rejects more noise. Default: 2.5');
+
+        this._addEntryRow(hearGroup, 'Language', 'language', 'en-US',
+            'Speech recognition language code, e.g. en-US, de-DE, ja-JP. Default: en-US');
+
+        // ── Starting — badge, panel, shortcuts ──
+        const startGroup = new Adw.PreferencesGroup({title: 'Starting'});
+        page.add(startGroup);
+
+        this._addGSettingsSwitchRow(startGroup, 'Floating Badge',
+            'Show the voice badge on the desktop — click it to start listening',
+            'show-badge');
+
+        this._addGSettingsSwitchRow(startGroup, 'Panel Indicator',
+            'Show GNOME Speaks in the top panel',
+            'show-panel-indicator');
+
+        this._addGSettingsSpinRow(startGroup, 'Badge Position X', 'badge-position-x',
+            -1, 5000, 1, 0, '-1 centers automatically');
+
+        this._addGSettingsSpinRow(startGroup, 'Badge Position Y', 'badge-position-y',
+            -1, 5000, 1, 0, '-1 sits at the bottom automatically');
+
+        const shortcutGroup = new Adw.PreferencesGroup({title: 'Keyboard Shortcuts'});
+        page.add(shortcutGroup);
+
+        this._addShortcutRow(shortcutGroup, 'Toggle Listening', 'toggle-listening-shortcut');
+        this._addShortcutRow(shortcutGroup, 'Speak Clipboard', 'speak-clipboard-shortcut');
+        this._addShortcutRow(shortcutGroup, 'Read Selection', 'read-selection-shortcut');
+        this._addShortcutRow(shortcutGroup, 'Toggle Voice Quality', 'toggle-voice-quality-shortcut');
+
+        window.add(page);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Page 2 — AI Chat: talking WITH the computer
+    // ═══════════════════════════════════════════════════════════════════
+    _addAiChatPage(window) {
+        const page = new Adw.PreferencesPage({
+            title: 'AI Chat',
+            icon_name: 'user-available-symbolic',
         });
-        page.add(aiGroup);
 
-        this._addSwitchRow(aiGroup, 'AI Conversation',
-            'Send transcriptions to an LLM and speak the response aloud',
+        // ── Conversation ──
+        const convGroup = new Adw.PreferencesGroup({title: 'Conversation'});
+        page.add(convGroup);
+
+        this._addSwitchRow(convGroup, 'AI Conversation',
+            'Send what you say to an AI and speak its reply aloud. Default: off',
             'conversation_mode', false);
 
-        this._addComboRow(aiGroup, 'LLM Provider', 'llm_provider', [
+        this._addComboRow(convGroup, 'Provider', 'llm_provider', [
             ['local', 'Local (OpenAI-compatible)'],
             ['anthropic', 'Anthropic (Claude)'],
             ['openai', 'OpenAI (GPT)'],
@@ -151,7 +235,7 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
             ['cloud-chat-assistant', 'Cloud Chat Assistant'],
         ], 'anthropic');
 
-        this._addComboRow(aiGroup, 'LLM Model', 'llm_model', [
+        this._addComboRow(convGroup, 'Model', 'llm_model', [
             ['qwen36-coder', 'Qwen (local)'],
             ['claude-opus-4.6', 'Claude Opus 4.6'],
             ['claude-sonnet-4.6', 'Claude Sonnet 4.6'],
@@ -169,203 +253,316 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
             ['gemini-2.5-pro', 'Gemini 2.5 Pro'],
         ], 'claude-opus-4.6');
 
-        this._addPasswordRow(aiGroup, 'LLM API Key', 'llm_api_key',
-            'API key for the selected LLM provider');
+        this._addPasswordRow(convGroup, 'API Key (Chat AI)', 'llm_api_key',
+            'Key for the selected provider — cloud providers bill per token');
 
-        this._addSwitchRow(aiGroup, 'Deep Thought',
-            'Let local reasoning models think before answering — deeper replies, much slower first word ("cast deep thought" toggles by voice)',
+        this._addSwitchRow(convGroup, 'Deep Thought',
+            'Let local reasoning models think before answering — deeper replies, much slower first word. "cast deep thought" toggles by voice. Default: off',
             'llm_thinking', false);
 
-        this._addEntryRow(aiGroup, 'System Prompt', 'llm_system_prompt',
+        this._addEntryRow(convGroup, 'Personality', 'llm_system_prompt',
             'You are a helpful voice assistant. Keep responses concise and conversational.',
-            'Instructions for the LLM persona');
+            'Instructions that shape how the AI talks to you');
 
-        // Restart Service button
-        const restartRow = new Adw.ActionRow({
-            title: 'Restart Service',
-            subtitle: 'Apply provider/model changes immediately',
-        });
-        const restartBtn = new Gtk.Button({
-            label: 'Restart',
-            valign: Gtk.Align.CENTER,
-            css_classes: ['suggested-action'],
-        });
-        restartBtn.connect('clicked', () => {
-            try {
-                GLib.spawn_command_line_async('systemctl --user restart gnome-speaks.service');
-                restartBtn.label = 'Restarted';
-                restartBtn.sensitive = false;
-                GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2000, () => {
-                    restartBtn.label = 'Restart';
-                    restartBtn.sensitive = true;
-                    return GLib.SOURCE_REMOVE;
-                });
-            } catch (e) {
-                log(`Failed to restart service: ${e.message}`);
-            }
-        });
-        restartRow.add_suffix(restartBtn);
-        aiGroup.add(restartRow);
+        this._addSpinRow(convGroup, 'Reply Pause', 'conversation_silence_timeout',
+            0.5, 10.0, 0.5, 1, 4.0,
+            'Seconds of silence before your turn ends in a conversation. Default: 4');
 
-        // ── Continuous Dictation ──
-        const contGroup = new Adw.PreferencesGroup({
-            title: 'Continuous Dictation',
-            description: 'After each pause, listening automatically restarts so you can dictate without re-clicking the badge. Works in both Type and AI modes.',
-        });
-        page.add(contGroup);
-
-        this._addSwitchRow(contGroup, 'Continuous Dictation',
-            'Automatically restart listening after each utterance',
-            'continuous_dictation', false);
-
-        this._addSpinRow(contGroup, 'Silence Timeout', 'silence_timeout',
-            0.5, 10.0, 0.5, 1, 3.0,
-            'Seconds of silence after speech before auto-stop');
-
-        this._addSpinRow(contGroup, 'No Speech Timeout', 'no_speech_timeout',
-            1.0, 30.0, 1.0, 0, 7.0,
-            'Max seconds to wait for any speech before giving up');
-
-        this._addSpinRow(contGroup, 'Loop Silence Timeout', 'loop_silence_timeout',
-            0.3, 5.0, 0.1, 1, 1.2,
-            'Silence timeout in continuous loop mode (shorter = faster turnaround)');
-
-        // ── Barge-in ──
-        const bargeGroup = new Adw.PreferencesGroup({
-            title: 'Barge-in',
-            description: 'Interrupt TTS playback by speaking. The AI pauses, listens to you, then resumes or responds.',
-        });
+        // ── Interrupting (barge-in, unified here) ──
+        const bargeGroup = new Adw.PreferencesGroup({title: 'Interrupting'});
         page.add(bargeGroup);
 
-        this._addSwitchRow(bargeGroup, 'Enable Barge-in',
-            'Pause TTS when you start speaking',
+        this._addSwitchRow(bargeGroup, 'Interrupt by Speaking',
+            'Talking over the AI pauses its speech so it can hear you. Default: off',
             'enable_barge_in', false);
 
-        // ── Notification Reader ──
-        const notifGroup = new Adw.PreferencesGroup({
-            title: 'Notification Reader',
-            description: 'Automatically read GNOME desktop notifications aloud as they arrive.',
-        });
+        this._addSpinRow(bargeGroup, 'Interrupt Threshold', 'barge_in_frames',
+            1, 20, 1, 0, 3,
+            'How much speech before it counts as an interruption — higher ignores brief noise. Default: 3');
+
+        this._addSpinRow(bargeGroup, 'Resume After', 'barge_in_silence',
+            0.3, 10.0, 0.1, 1, 1.0,
+            'Seconds of silence before the AI resumes speaking. Default: 1');
+
+        this._addSwitchRow(bargeGroup, 'Interrupt Chime',
+            'Play a chime when an interruption is detected. Default: on',
+            'chime_barge_in', true);
+
+        // ── Generation (cloud-chat-assistant config) ──
+        const genGroup = new Adw.PreferencesGroup({title: 'Generation'});
+        page.add(genGroup);
+
+        this._addCcaSpinRow(genGroup, 'Temperature', 'temperature',
+            0.0, 2.0, 0.1, 1, 1.0,
+            '0 = predictable, 2 = wild. Default: 1');
+
+        this._addCcaSpinRow(genGroup, 'Reply Length Limit', 'max_completion_tokens',
+            64, 128000, 256, 0, 2048,
+            'Maximum tokens per reply — long limits cost more on cloud providers. Default: 2048');
+
+        this._addCcaComboRow(genGroup, 'Reasoning Effort', 'reasoning_effort', [
+            ['low', 'Low'],
+            ['medium', 'Medium'],
+            ['high', 'High'],
+        ], 'high');
+
+        this._addCcaSpinRow(genGroup, 'Memory Length', 'conversation_max_turns',
+            1, 500, 10, 0, 50,
+            'Conversation turns remembered before older ones are trimmed. Default: 50');
+
+        this._addCcaSpinRow(genGroup, 'Multi-Chat Timeout', 'multi_chat_timeout',
+            5, 120, 5, 0, 15,
+            'Per-model timeout when comparing multiple models. Default: 15');
+
+        // ── Notifications ──
+        const notifGroup = new Adw.PreferencesGroup({title: 'Notifications'});
         page.add(notifGroup);
 
-        this._addSwitchRow(notifGroup, 'Read Notifications',
-            'Speak notification titles and body text',
+        this._addSwitchRow(notifGroup, 'Read Notifications Aloud',
+            'Speak desktop notification titles and text as they arrive. "cast read notifications" toggles by voice. Default: off',
             'read_notifications', false);
 
-        // ── Mode Combinations ──
-        const comboGroup = new Adw.PreferencesGroup({
-            title: 'Mode Combinations',
-            description: 'Modes combine to create different workflows. Here is what happens with each combination of toggles.',
+        window.add(page);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Page 3 — Voice & Sound: how it sounds and looks when it talks
+    // ═══════════════════════════════════════════════════════════════════
+    _addVoiceSoundPage(window) {
+        const page = new Adw.PreferencesPage({
+            title: 'Voice & Sound',
+            icon_name: 'audio-speakers-symbolic',
         });
-        page.add(comboGroup);
 
-        this._addInfoRow(comboGroup, 'Type only',
-            'Click badge, speak, text typed at cursor, done. The simplest mode.');
-        this._addInfoRow(comboGroup, 'Type + Continuous',
-            'Click badge, speak, text typed, auto-listens again. Great for long dictation.');
-        this._addInfoRow(comboGroup, 'AI only',
-            'Click badge, speak, AI thinks and responds aloud, done.');
-        this._addInfoRow(comboGroup, 'AI + Continuous (Hands-Free)',
-            'Click badge, speak, AI responds, auto-listens, loop. Full voice assistant. Enable via panel menu Hands-Free toggle.');
-        this._addInfoRow(comboGroup, 'Talk Mode (D-Bus)',
-            'External apps call org.gnome.Speaks.Talk(text) for STT + LLM + TTS. Used by Claude Code, Copilot CLI, and MCP servers.');
+        // ── Voices ──
+        const voiceGroup = new Adw.PreferencesGroup({title: 'Voices'});
+        page.add(voiceGroup);
 
-        // ── Shortcuts ──
-        const shortcutsGroup = new Adw.PreferencesGroup({
-            title: 'Keyboard Shortcuts',
-            description: 'Global shortcuts available from any window. Customize on the Extension page.',
-        });
-        page.add(shortcutsGroup);
+        const hdRow = this._addComboRow(voiceGroup, 'HD Voice', 'voice',
+            HD_VOICES, 'en-US-Ava:DragonHDLatestNeural');
+        hdRow.subtitle = 'Natural prosody, metered — costs per character. Needs an HD region (e.g. East US)';
 
-        this._addShortcutRow(shortcutsGroup, 'Toggle Listening', 'toggle-listening-shortcut');
-        this._addShortcutRow(shortcutsGroup, 'Speak Clipboard', 'speak-clipboard-shortcut');
-        this._addShortcutRow(shortcutsGroup, 'Read Selection', 'read-selection-shortcut');
-        this._addShortcutRow(shortcutsGroup, 'Toggle Voice Quality', 'toggle-voice-quality-shortcut');
+        const fastRow = this._addComboRow(voiceGroup, 'Fast Voice', 'fast_voice',
+            FAST_VOICES, 'en-US-AvaNeural');
+        fastRow.subtitle = 'Low-latency neural voice (~120 ms), cheaper tier';
+
+        this._addEntryRow(voiceGroup, 'Offline Voice', 'wyoming_tts_voice', 'en_GB-cori-high',
+            'Piper voice used when the cloud is unreachable. Default: en_GB-cori-high');
+
+        // ── Subtitles — ONE switch, both layers ──
+        const subGroup = new Adw.PreferencesGroup({title: 'Subtitles'});
+        page.add(subGroup);
+
+        this._addSubtitlesMasterRow(subGroup);
+
+        this._addSwitchRow(subGroup, 'Word Highlights',
+            'Newly heard words flash as they appear. Default: on',
+            'show_word_highlights', true);
+
+        this._addComboRow(subGroup, 'Your Words', 'subtitle_color_user',
+            SUBTITLE_COLORS, 'light_green');
+
+        this._addComboRow(subGroup, 'Its Words', 'subtitle_color_tts',
+            SUBTITLE_COLORS, 'amber');
+
+        // ── Chimes ──
+        const chimeGroup = new Adw.PreferencesGroup({title: 'Chimes'});
+        page.add(chimeGroup);
+
+        this._addSwitchRow(chimeGroup, 'Ready',
+            'Ascending tone when the microphone opens. Default: on',
+            'chime_ready', true);
+
+        this._addSwitchRow(chimeGroup, 'Recognized',
+            'Blip when your speech is understood. Default: off',
+            'chime_processing', false);
+
+        this._addSwitchRow(chimeGroup, 'Speaking',
+            'Descending tone before it starts talking. Default: off',
+            'chime_speak', false);
+
+        this._addSwitchRow(chimeGroup, 'Done',
+            'Double-tap tone when it finishes talking. Default: off',
+            'chime_done', false);
+
+        this._addSwitchRow(chimeGroup, 'Thinking Hum',
+            'Soft hum while the AI is thinking. Default: off',
+            'chime_hum', false);
+
+        // ── Badge Effects ──
+        const fxGroup = new Adw.PreferencesGroup({title: 'Badge Effects'});
+        page.add(fxGroup);
+
+        this._addSwitchRow(fxGroup, 'Waveform',
+            'Live audio bars under the badge while you speak. Default: on',
+            'show_waveform', true);
+
+        this._addSwitchRow(fxGroup, 'Speech Dot',
+            'Green dot when your voice is detected. Default: on',
+            'show_vad_dot', true);
+
+        this._addSwitchRow(fxGroup, 'Silence Fade',
+            'Waveform dims during long silence. Default: on',
+            'show_silence_fade', true);
+
+        this._addSwitchRow(fxGroup, 'Pulse',
+            'Breathing animation while listening or speaking. Default: on',
+            'show_badge_pulse', true);
+
+        this._addSwitchRow(fxGroup, 'Volume Scale',
+            'Badge grows with your voice volume. Default: on',
+            'show_badge_scale', true);
+
+        this._addSwitchRow(fxGroup, 'VU Meter',
+            'Terminal volume meter during audio. Default: on',
+            'vu_meter', true);
+
+        this._addSwitchRow(fxGroup, 'Terminal Icons',
+            'Status icons in terminal output. Default: on',
+            'visual_indicator', true);
+
+        // ── Desktop Voices (Spiel provider) ──
+        const spielGroup = new Adw.PreferencesGroup({title: 'Desktop Voices (Spiel)'});
+        page.add(spielGroup);
+
+        this._addSwitchRow(spielGroup, 'Offer Voices to the Desktop',
+            'Let screen readers and other apps use these voices (Spiel provider). Default: off',
+            'spiel_provider', false);
+
+        this._addListEntryRow(spielGroup, 'Offered Voices', 'spiel_voices',
+            'en_GB-cori-high',
+            'Comma-separated Piper voice names offered to apps. Default: en_GB-cori-high');
+
+        this._addSwitchRow(spielGroup, 'Offer Cloud Voices Too',
+            'Also offer the metered Azure voices — a screen reader narrating your desktop through these costs real money per sentence. Default: off',
+            'spiel_expose_azure', false);
 
         window.add(page);
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // Page 1 — Azure Service Configuration
+    // Page 4 — Wake & Spells
     // ═══════════════════════════════════════════════════════════════════
-    _addAzurePage(window) {
+    _addWakeSpellsPage(window) {
         const page = new Adw.PreferencesPage({
-            title: 'Azure',
-            icon_name: 'network-server-symbolic',
+            title: 'Wake & Spells',
+            icon_name: 'weather-clear-night-symbolic',
         });
 
-        // ── Authentication ──
-        const authGroup = new Adw.PreferencesGroup({
-            title: 'Authentication',
-            description: 'Azure Speech Services credentials. Get a key at portal.azure.com.',
+        // ── Wake Word ──
+        const wakeGroup = new Adw.PreferencesGroup({title: 'Wake Word'});
+        page.add(wakeGroup);
+
+        this._addSwitchRow(wakeGroup, 'Wake Word',
+            'Say your wake phrase to open the microphone hands-free. Armed only while idle — never while dictating or speaking. "cast wake word" toggles by voice. Default: off',
+            'wake_word', false);
+
+        this._addEntryRow(wakeGroup, 'Wake Model', 'wake_word_model', '',
+            'openwakeword model name — this IS your wake phrase; keep it private, since anyone who knows it can open your mic by voice');
+
+        this._addSpinRow(wakeGroup, 'Wake Server Port', 'wyoming_wake_port',
+            1, 65535, 1, 0, 10400,
+            'openwakeword port on the offline server below. Default: 10400');
+
+        // ── Voice Spellbook ──
+        const spellGroup = new Adw.PreferencesGroup({
+            title: 'Voice Spellbook',
+            description: 'Say "cast …" or "invoke …" to run local spells instead of typing: mode switches, status reports, home rituals, oracle consultations. Test any spell without a mic: POST /cast on localhost:7710.',
         });
-        page.add(authGroup);
+        page.add(spellGroup);
 
-        this._addPasswordRow(authGroup, 'API Key', 'key',
-            'Azure Speech Services subscription key');
-
-        this._addRegionCombo(authGroup, 'Region', 'region',
-            'Primary region for STT and TTS', 'westus2');
-
-        // ── Separate TTS Region ──
-        const ttsGroup = new Adw.PreferencesGroup({
-            title: 'TTS Region (Optional)',
-            description: 'Use a different region for text-to-speech, e.g. eastus for DragonHD voices.',
+        const overlayRow = new Adw.ActionRow({
+            title: 'Your Spells',
+            subtitle: 'Edit ~/.config/speech-to-cli/spellbook.json — changes apply instantly',
         });
-        page.add(ttsGroup);
+        overlayRow.add_suffix(new Gtk.Image({icon_name: 'document-edit-symbolic'}));
+        overlayRow.activatable = true;
+        overlayRow.connect('activated', () => {
+            const path = GLib.get_home_dir() + '/.config/speech-to-cli/spellbook.json';
+            Gio.AppInfo.launch_default_for_uri(`file://${path}`, null);
+        });
+        spellGroup.add(overlayRow);
 
-        this._addRegionCombo(ttsGroup, 'TTS Region', 'tts_region',
-            'Leave empty to use the primary region', '');
+        // ── Offline Server ──
+        const offlineGroup = new Adw.PreferencesGroup({title: 'Offline Server'});
+        page.add(offlineGroup);
 
-        this._addPasswordRow(ttsGroup, 'TTS API Key', 'tts_key',
-            'Leave empty to use the primary key');
+        this._addEntryRow(offlineGroup, 'Server Address', 'wyoming_host', '',
+            'LAN hostname or IP of your Wyoming server — speech falls back here when the cloud is unreachable. Empty = off');
+
+        this._addSpinRow(offlineGroup, 'Voice Port', 'wyoming_tts_port',
+            1, 65535, 1, 0, 10200,
+            'Text-to-speech (e.g. wyoming-piper). Default: 10200');
+
+        this._addSpinRow(offlineGroup, 'Hearing Port', 'wyoming_stt_port',
+            1, 65535, 1, 0, 10300,
+            'Speech-to-text (e.g. wyoming-onnx-asr). Default: 10300');
 
         window.add(page);
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // Page — Cloud AI Providers (cloud-chat-assistant config)
+    // Page 5 — Accounts: every credential in one place, costs visible
     // ═══════════════════════════════════════════════════════════════════
-    _addCloudAIPage(window) {
+    _addAccountsPage(window) {
         const page = new Adw.PreferencesPage({
-            title: 'Cloud AI',
-            icon_name: 'weather-overcast-symbolic',
+            title: 'Accounts',
+            icon_name: 'dialog-password-symbolic',
         });
+
+        // Metering banner — the one place costs are impossible to miss.
+        const bannerGroup = new Adw.PreferencesGroup({});
+        page.add(bannerGroup);
+        const banner = new Adw.Banner({
+            title: 'Cloud speech and AI are metered — these accounts bill per use. Local and offline features cost nothing.',
+            revealed: true,
+        });
+        bannerGroup.add(banner);
+
+        // ── Azure Speech ──
+        const azureGroup = new Adw.PreferencesGroup({title: 'Azure Speech'});
+        page.add(azureGroup);
+
+        this._addPasswordRow(azureGroup, 'API Key (Azure Speech)', 'key',
+            'Subscription key from portal.azure.com — used for cloud dictation and voices');
+
+        this._addRegionCombo(azureGroup, 'Region', 'region',
+            'Primary region for speech recognition and voices. Default: West US 2', 'westus2');
+
+        this._addRegionCombo(azureGroup, 'HD Voice Region', 'tts_region',
+            'Optional separate region for DragonHD voices (e.g. East US)', '');
+
+        this._addPasswordRow(azureGroup, 'HD Voice Key', 'tts_key',
+            'Optional separate key for the HD voice region — empty uses the primary key');
 
         // ── Azure AI Foundry ──
-        const azureAiGroup = new Adw.PreferencesGroup({
-            title: 'Azure AI Foundry',
-            description: 'Azure AI endpoint for serverless and deployed models (GPT, Grok, DeepSeek, Llama, Phi, etc.).',
-        });
-        page.add(azureAiGroup);
+        const aiGroup = new Adw.PreferencesGroup({title: 'Azure AI Foundry'});
+        page.add(aiGroup);
 
-        this._addCcaEntryRow(azureAiGroup, 'Endpoint', 'endpoint', '',
+        this._addCcaEntryRow(aiGroup, 'Endpoint', 'endpoint', '',
             'Azure AI services endpoint URL');
 
-        this._addCcaPasswordRow(azureAiGroup, 'API Key', 'api_key',
-            'Azure AI API key');
+        this._addCcaPasswordRow(aiGroup, 'API Key (Azure AI)', 'api_key',
+            'For GPT, Grok, DeepSeek, Llama and other Azure AI models');
 
-        this._addCcaComboRow(azureAiGroup, 'Model Type', 'model_type', [
+        this._addCcaComboRow(aiGroup, 'Model Type', 'model_type', [
             ['bedrock', 'AWS Bedrock'],
             ['deployed', 'Azure Deployed'],
             ['serverless', 'Azure Serverless'],
             ['google', 'Google Vertex AI'],
         ], 'bedrock');
 
-        this._addCcaEntryRow(azureAiGroup, 'Deployment', 'deployment', '',
-            'Azure deployment name (for deployed models)');
+        this._addCcaEntryRow(aiGroup, 'Deployment', 'deployment', '',
+            'Azure deployment name, for deployed models only');
 
         // ── AWS Bedrock ──
-        const awsGroup = new Adw.PreferencesGroup({
-            title: 'AWS Bedrock',
-            description: 'AWS credentials for Claude, Nova, Llama 4, and other Bedrock models.',
-        });
+        const awsGroup = new Adw.PreferencesGroup({title: 'AWS Bedrock'});
         page.add(awsGroup);
 
-        this._addCcaPasswordRow(awsGroup, 'Access Key', 'aws_access_key',
-            'AWS Access Key ID');
+        this._addCcaPasswordRow(awsGroup, 'Access Key (AWS)', 'aws_access_key',
+            'AWS Access Key ID — Bedrock bills as AWS Marketplace, promotional credits do not apply');
 
-        this._addCcaPasswordRow(awsGroup, 'Secret Key', 'aws_secret_key',
+        this._addCcaPasswordRow(awsGroup, 'Secret Key (AWS)', 'aws_secret_key',
             'AWS Secret Access Key');
 
         this._addCcaComboRow(awsGroup, 'Region', 'aws_region', [
@@ -378,14 +575,11 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         ], 'us-east-1');
 
         // ── Google Vertex AI ──
-        const googleGroup = new Adw.PreferencesGroup({
-            title: 'Google Vertex AI',
-            description: 'Google Cloud credentials for Gemini models.',
-        });
+        const googleGroup = new Adw.PreferencesGroup({title: 'Google Vertex AI'});
         page.add(googleGroup);
 
-        this._addCcaPasswordRow(googleGroup, 'API Key', 'google_api_key',
-            'Google Cloud API key');
+        this._addCcaPasswordRow(googleGroup, 'API Key (Google)', 'google_api_key',
+            'Google Cloud API key for Gemini models');
 
         this._addCcaEntryRow(googleGroup, 'Project ID', 'google_project', '',
             'GCP project ID or number');
@@ -400,217 +594,24 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
             ['asia-southeast1', 'Asia Southeast 1'],
         ], 'global');
 
-        // ── Generation Parameters ──
-        const genGroup = new Adw.PreferencesGroup({
-            title: 'Generation',
-            description: 'LLM response generation parameters.',
-        });
-        page.add(genGroup);
-
-        this._addCcaSpinRow(genGroup, 'Temperature', 'temperature',
-            0.0, 2.0, 0.1, 1, 1.0,
-            '0 = deterministic, 2 = maximum randomness');
-
-        this._addCcaSpinRow(genGroup, 'Max Tokens', 'max_completion_tokens',
-            64, 128000, 256, 0, 2048,
-            'Maximum tokens in LLM response');
-
-        this._addCcaComboRow(genGroup, 'Reasoning Effort', 'reasoning_effort', [
-            ['low', 'Low'],
-            ['medium', 'Medium'],
-            ['high', 'High'],
-        ], 'high');
-
-        this._addCcaSpinRow(genGroup, 'Max Conversation Turns', 'conversation_max_turns',
-            1, 500, 10, 0, 50,
-            'History turns before auto-trimming');
-
-        // ── Multi-Chat ──
-        const multiGroup = new Adw.PreferencesGroup({
-            title: 'Multi-Chat',
-            description: 'Compare responses from multiple models simultaneously.',
-        });
-        page.add(multiGroup);
-
-        this._addCcaSpinRow(multiGroup, 'Timeout (seconds)', 'multi_chat_timeout',
-            5, 120, 5, 0, 15,
-            'Per-model timeout for multi-chat queries');
-
         window.add(page);
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // Page 2 — Voice & TTS
+    // Page 6 — Advanced
     // ═══════════════════════════════════════════════════════════════════
-    _addVoicePage(window) {
+    _addAdvancedPage(window) {
         const page = new Adw.PreferencesPage({
-            title: 'Voice',
-            icon_name: 'audio-speakers-symbolic',
+            title: 'Advanced',
+            icon_name: 'preferences-other-symbolic',
         });
 
-        // ── HD Voice ──
-        const hdGroup = new Adw.PreferencesGroup({
-            title: 'HD Voice',
-            description: 'High-quality DragonHD voice with natural prosody. Requires a supported region (e.g. eastus).',
-        });
-        page.add(hdGroup);
-
-        this._addComboRow(hdGroup, 'HD Voice Name', 'voice', [
-            ['en-US-Ava:DragonHDLatestNeural', 'Ava (DragonHD)'],
-            ['en-US-Andrew:DragonHDLatestNeural', 'Andrew (DragonHD)'],
-            ['en-US-Brian:DragonHDLatestNeural', 'Brian (DragonHD)'],
-            ['en-US-Emma:DragonHDLatestNeural', 'Emma (DragonHD)'],
-            ['en-US-Aria:DragonHDLatestNeural', 'Aria (DragonHD)'],
-            ['en-US-Davis:DragonHDLatestNeural', 'Davis (DragonHD)'],
-            ['en-US-Jenny:DragonHDLatestNeural', 'Jenny (DragonHD)'],
-            ['en-US-Guy:DragonHDLatestNeural', 'Guy (DragonHD)'],
-            ['en-US-Steffan:DragonHDLatestNeural', 'Steffan (DragonHD)'],
-            ['en-US-Christopher:DragonHDLatestNeural', 'Christopher (DragonHD)'],
-            ['en-US-Eric:DragonHDLatestNeural', 'Eric (DragonHD)'],
-            ['en-US-Roger:DragonHDLatestNeural', 'Roger (DragonHD)'],
-            ['en-US-Alloy:DragonHDLatestNeural', 'Alloy (DragonHD)'],
-            ['en-US-Echo:DragonHDLatestNeural', 'Echo (DragonHD)'],
-            ['en-US-Fable:DragonHDLatestNeural', 'Fable (DragonHD)'],
-            ['en-US-Onyx:DragonHDLatestNeural', 'Onyx (DragonHD)'],
-            ['en-US-Nova:DragonHDLatestNeural', 'Nova (DragonHD)'],
-            ['en-US-Shimmer:DragonHDLatestNeural', 'Shimmer (DragonHD)'],
-        ], 'en-US-Ava:DragonHDLatestNeural');
-
-        // ── Fast Voice ──
-        const fastGroup = new Adw.PreferencesGroup({
-            title: 'Fast Voice',
-            description: 'Low-latency neural voice for quick responses (~120ms).',
-        });
-        page.add(fastGroup);
-
-        this._addComboRow(fastGroup, 'Fast Voice Name', 'fast_voice', [
-            ['en-US-AvaNeural', 'Ava'],
-            ['en-US-AndrewNeural', 'Andrew'],
-            ['en-US-AriaNeural', 'Aria'],
-            ['en-US-DavisNeural', 'Davis'],
-            ['en-US-JennyNeural', 'Jenny'],
-            ['en-US-GuyNeural', 'Guy'],
-            ['en-US-BrianNeural', 'Brian'],
-            ['en-US-EmmaNeural', 'Emma'],
-            ['en-US-SteffanNeural', 'Steffan'],
-            ['en-US-ChristopherNeural', 'Christopher'],
-            ['en-US-EricNeural', 'Eric'],
-            ['en-US-RogerNeural', 'Roger'],
-            ['en-US-MichelleNeural', 'Michelle'],
-            ['en-US-MonicaNeural', 'Monica'],
-            ['en-US-CoraNeural', 'Cora'],
-            ['en-US-JaneNeural', 'Jane'],
-            ['en-US-NancyNeural', 'Nancy'],
-            ['en-US-SaraNeural', 'Sara'],
-            ['en-US-TonyNeural', 'Tony'],
-            ['en-US-JasonNeural', 'Jason'],
-            ['en-US-BrandonNeural', 'Brandon'],
-            ['en-US-JacobNeural', 'Jacob'],
-            ['en-US-AmberNeural', 'Amber'],
-            ['en-US-AshleyNeural', 'Ashley'],
-            ['en-US-ElizabethNeural', 'Elizabeth'],
-        ], 'en-US-AvaNeural');
-
-        // ── Speech Parameters ──
-        const paramGroup = new Adw.PreferencesGroup({
-            title: 'Speech Parameters',
-        });
-        page.add(paramGroup);
-
-        this._addSpinRow(paramGroup, 'Speed', 'speed',
-            0.5, 3.0, 0.1, 1, 1.0);
-
-        this._addComboRow(paramGroup, 'Pitch', 'pitch', [
-            ['default', 'Default'],
-            ['x-low', 'Extra Low'],
-            ['low', 'Low'],
-            ['medium', 'Medium'],
-            ['high', 'High'],
-            ['x-high', 'Extra High'],
-        ], 'default');
-
-        this._addComboRow(paramGroup, 'Volume', 'volume', [
-            ['default', 'Default'],
-            ['silent', 'Silent'],
-            ['x-soft', 'Extra Soft'],
-            ['soft', 'Soft'],
-            ['medium', 'Medium'],
-            ['loud', 'Loud'],
-            ['x-loud', 'Extra Loud'],
-        ], 'default');
-
-        window.add(page);
-    }
-
-    // ═══════════════════════════════════════════════════════════════════
-    // Page 3 — Listening / STT
-    // ═══════════════════════════════════════════════════════════════════
-    _addListeningPage(window) {
-        const page = new Adw.PreferencesPage({
-            title: 'Listening',
-            icon_name: 'audio-input-microphone-symbolic',
-        });
-
-        // ── Timing ──
-        const timingGroup = new Adw.PreferencesGroup({
-            title: 'Timing',
-            description: 'Control when recording starts and stops.',
-        });
-        page.add(timingGroup);
-
-        this._addSpinRow(timingGroup, 'Talk Silence Timeout', 'talk_silence_timeout',
-            0.5, 10.0, 0.5, 1, 4.0,
-            'Silence timeout for talk/converse mode (D-Bus Talk calls)');
-
-        this._addSpinRow(timingGroup, 'Max Record Seconds', 'max_record_seconds',
-            5, 300, 5, 0, 120,
-            'Absolute maximum recording duration');
-
-        // ── Detection ──
-        const detectGroup = new Adw.PreferencesGroup({
-            title: 'Detection',
-            description: 'Fine-tune speech detection sensitivity.',
-        });
-        page.add(detectGroup);
-
-        this._addSpinRow(detectGroup, 'VAD Aggressiveness', 'vad_aggressiveness',
-            0, 3, 1, 0, 3,
-            '0 = least aggressive, 3 = most aggressive noise rejection');
-
-        this._addSpinRow(detectGroup, 'Energy Multiplier', 'energy_multiplier',
-            0.5, 20.0, 0.5, 1, 2.5,
-            'Noise gate threshold multiplier. Lower = more sensitive to quiet speech');
-
-        // ── Language ──
-        const langGroup = new Adw.PreferencesGroup({
-            title: 'Language',
-        });
-        page.add(langGroup);
-
-        this._addEntryRow(langGroup, 'STT Language', 'language', 'en-US',
-            'BCP-47 language code for speech recognition (e.g. en-US, de-DE, ja-JP)');
-
-        window.add(page);
-    }
-
-    // ═══════════════════════════════════════════════════════════════════
-    // Page 4 — Audio Devices
-    // ═══════════════════════════════════════════════════════════════════
-    _addAudioPage(window) {
-        const page = new Adw.PreferencesPage({
-            title: 'Audio',
-            icon_name: 'audio-card-symbolic',
-        });
-
-        // Enumerate PipeWire sinks and sources for device menus
+        // ── Audio Devices ──
         const sinks = this._enumeratePipeWireDevices('sinks');
         const sources = this._enumeratePipeWireDevices('sources');
 
-        // ── Playback ──
-        const playGroup = new Adw.PreferencesGroup({
-            title: 'Playback',
-        });
-        page.add(playGroup);
+        const devGroup = new Adw.PreferencesGroup({title: 'Audio Devices'});
+        page.add(devGroup);
 
         const playerOptions = [['auto', 'Auto-detect']];
         for (const [cmd, label] of [
@@ -619,428 +620,70 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
             ['pw-cat', 'pw-cat (PipeWire)'],
             ['ffplay', 'ffplay (FFmpeg)'],
         ]) {
-            if (this._commandExists(cmd))
-                playerOptions.push([cmd, label]);
-            else
-                playerOptions.push([cmd, `${label} — not found`]);
+            playerOptions.push([cmd,
+                this._commandExists(cmd) ? label : `${label} — not found`]);
         }
-        this._addComboRow(playGroup, 'Player', 'player', playerOptions, 'auto');
+        this._addComboRow(devGroup, 'Player', 'player', playerOptions, 'auto');
 
-        this._addComboRow(playGroup, 'Speaker', 'speaker_sink',
+        this._addComboRow(devGroup, 'Speaker', 'speaker_sink',
             [['', 'System Default'], ...sinks], '');
-
-        // ── Recording ──
-        const recGroup = new Adw.PreferencesGroup({
-            title: 'Recording',
-        });
-        page.add(recGroup);
 
         const recorderOptions = [['auto', 'Auto-detect']];
         for (const [cmd, label] of [
             ['pw-record', 'pw-record (PipeWire)'],
             ['arecord', 'arecord (ALSA)'],
         ]) {
-            if (this._commandExists(cmd))
-                recorderOptions.push([cmd, label]);
-            else
-                recorderOptions.push([cmd, `${label} — not found`]);
+            recorderOptions.push([cmd,
+                this._commandExists(cmd) ? label : `${label} — not found`]);
         }
-        this._addComboRow(recGroup, 'Recorder', 'recorder', recorderOptions, 'auto');
+        this._addComboRow(devGroup, 'Recorder', 'recorder', recorderOptions, 'auto');
 
-        this._addComboRow(recGroup, 'Microphone', 'mic_source',
+        this._addComboRow(devGroup, 'Microphone', 'mic_source',
             [['', 'System Default'], ...sources], '');
 
-        // ── Duplex ──
-        const duplexGroup = new Adw.PreferencesGroup({
-            title: 'Duplex Mode',
-            description: 'Controls whether TTS and STT can run simultaneously.',
-        });
-        page.add(duplexGroup);
-
-        this._addComboRow(duplexGroup, 'Half Duplex', 'half_duplex', [
-            ['auto', 'Auto (speakers→half, headphones→full)'],
-            ['true', 'Force Half Duplex (speak then listen)'],
-            ['false', 'Force Full Duplex (simultaneous)'],
+        const duplexRow = this._addComboRow(devGroup, 'Speak While Listening', 'half_duplex', [
+            ['auto', 'Auto — speakers take turns, headphones overlap'],
+            ['true', 'Take Turns (speak, then listen)'],
+            ['false', 'Overlap (speak and listen together)'],
         ], 'auto');
+        duplexRow.subtitle = 'Whether talking and listening can happen at the same time. Default: Auto';
 
-        window.add(page);
-    }
+        this._addSwitchRow(devGroup, 'Echo Cancellation',
+            'Use PipeWire echo-cancel nodes when available, so it does not hear itself. Default: off',
+            'enable_echo_cancel', false);
 
-    /**
-     * Enumerate PipeWire sinks or sources by parsing `wpctl status`.
-     * Returns [[nodeId, label], ...] suitable for _addComboRow.
-     */
-    _enumeratePipeWireDevices(type) {
-        const devices = [];
-        try {
-            const [ok, stdout, stderr, exitCode] = GLib.spawn_command_line_sync('wpctl status');
-            if (!ok || exitCode !== 0) return devices;
+        this._addSwitchRow(devGroup, 'Allow Pause',
+            'Allow pausing and resuming playback. Default: on',
+            'enable_pause', true);
 
-            const output = new TextDecoder('utf-8').decode(stdout);
-            const lines = output.split('\n');
+        this._addSpinRow(devGroup, 'Talk Mode Pause', 'talk_silence_timeout',
+            0.5, 10.0, 0.5, 1, 4.0,
+            'Silence timeout for external apps using the Talk D-Bus call. Default: 4');
 
-            // Find the section header: "Sinks:" or "Sources:" within the Audio block
-            const header = type === 'sinks' ? 'Sinks:' : 'Sources:';
-            let inAudio = false;
-            let inSection = false;
-
-            for (const line of lines) {
-                const trimmed = line.trim();
-
-                // Track whether we are inside the "Audio" top-level block so
-                // we don't accidentally match Video sinks/sources.
-                if (trimmed === 'Audio') {
-                    inAudio = true;
-                    continue;
-                }
-                if (inAudio && /^(Video|Settings)$/.test(trimmed)) {
-                    break;           // left the Audio block
-                }
-                if (!inAudio) continue;
-
-                if (trimmed.endsWith(header)) {
-                    inSection = true;
-                    continue;
-                }
-
-                // Stop at next sub-section (empty pipe line, blank line, or a
-                // new header such as "Sink endpoints:" / "Streams:")
-                if (inSection && (trimmed === '│' || trimmed === '' ||
-                    (trimmed.endsWith(':') && !trimmed.match(/^\d/)))) {
-                    break;
-                }
-
-                if (!inSection) continue;
-
-                // Strip leading box-drawing characters (│ ├ └ ─ etc.) so the
-                // regex only sees the device text, e.g.:
-                //   "│      35. USB Audio Device Analog Stereo      [vol: 0.19]"
-                //   "│  *   55. Built-in Audio Analog Stereo        [vol: 0.65]"
-                const stripped = trimmed.replace(/^[│├└─┬┤┼╌╎\s]+/, '');
-
-                // Match: optional "*", node ID, name, and optional "[...]" tail
-                const match = stripped.match(/^(\*?)\s*(\d+)\.\s+(.+?)(?:\s+\[.*\])?\s*$/);
-                if (match) {
-                    const isDefault = match[1] === '*';
-                    const nodeId = match[2];
-                    const name = match[3].trim();
-                    const label = isDefault ? `${name} (default)` : name;
-                    devices.push([nodeId, label]);
-                }
-            }
-        } catch (e) {
-            // wpctl not available — return empty list
-        }
-        return devices;
-    }
-
-    /**
-     * Check if a command exists on the system (uses `which`).
-     */
-    _commandExists(cmd) {
-        try {
-            const [ok, stdout, stderr, exitCode] = GLib.spawn_command_line_sync(`which ${cmd}`);
-            return ok && exitCode === 0;
-        } catch (e) {
-            return false;
-        }
-    }
-
-    // ═══════════════════════════════════════════════════════════════════
-    // Page — Spellcraft (wake word, spellbook, offline fallback)
-    // ═══════════════════════════════════════════════════════════════════
-    _addSpellcraftPage(window) {
-        const page = new Adw.PreferencesPage({
-            title: 'Spellcraft',
-            icon_name: 'weather-clear-night-symbolic',
-        });
-
-        // ── Wake Word ──
-        const wakeGroup = new Adw.PreferencesGroup({
-            title: 'Wake Word',
-            description: 'Hands-free activation via a Wyoming openwakeword server on your LAN. ' +
-                'Speaking your wake phrase while idle opens the mic exactly like the keyboard shortcut. ' +
-                'Never armed during dictation or TTS playback.',
-        });
-        page.add(wakeGroup);
-
-        this._addSwitchRow(wakeGroup, 'Enable Wake Word',
-            'Stream mic audio to the wake server while idle ("cast wake word" toggles this by voice)',
-            'wake_word', false);
-
-        this._addEntryRow(wakeGroup, 'Wake Model', 'wake_word_model', '',
-            'openwakeword model name — effectively your wake phrase; treat it as private');
-
-        this._addSpinRow(wakeGroup, 'Wake Server Port', 'wyoming_wake_port',
-            1, 65535, 1, 0, 10400,
-            'Wyoming openwakeword port on the fallback host below');
-
-        // ── Voice Spellbook ──
-        const spellGroup = new Adw.PreferencesGroup({
-            title: 'Voice Spellbook',
-            description: 'Utterances starting with "cast" or "invoke" run local spells instead of ' +
-                'being typed or sent to the LLM: mode switching, realm scrying, home rituals, oracle ' +
-                'consultations. Spells are JSON — the extension ships the self-control set; add your ' +
-                'own in the overlay below (hot-reloads on save). Test without a mic: ' +
-                'POST /cast on localhost:7710.',
-        });
-        page.add(spellGroup);
-
-        const overlayRow = new Adw.ActionRow({
-            title: 'User Spell Overlay',
-            subtitle: '~/.config/speech-to-cli/spellbook.json',
-        });
-        overlayRow.add_suffix(new Gtk.Image({ icon_name: 'document-edit-symbolic' }));
-        overlayRow.activatable = true;
-        overlayRow.connect('activated', () => {
-            const path = GLib.get_home_dir() + '/.config/speech-to-cli/spellbook.json';
-            Gio.AppInfo.launch_default_for_uri(`file://${path}`, null);
-        });
-        spellGroup.add(overlayRow);
-
-        // ── Offline Fallback ──
-        const offlineGroup = new Adw.PreferencesGroup({
-            title: 'Offline Fallback',
-            description: 'When Azure is unreachable, speech falls back to a Wyoming server on your ' +
-                'LAN (Piper TTS + local STT). A 60-second circuit breaker skips Azure while it is ' +
-                'down. Leave the host empty to disable.',
-        });
-        page.add(offlineGroup);
-
-        this._addEntryRow(offlineGroup, 'Wyoming Host', 'wyoming_host', '',
-            'LAN hostname or IP of the Wyoming server (empty = feature off)');
-
-        this._addSpinRow(offlineGroup, 'TTS Port', 'wyoming_tts_port',
-            1, 65535, 1, 0, 10200,
-            'Wyoming TTS service (e.g. wyoming-piper)');
-
-        this._addSpinRow(offlineGroup, 'STT Port', 'wyoming_stt_port',
-            1, 65535, 1, 0, 10300,
-            'Wyoming STT service (e.g. wyoming-onnx-asr)');
-
-        this._addEntryRow(offlineGroup, 'Offline Voice', 'wyoming_tts_voice', 'en_GB-cori-high',
-            'Piper voice name (empty = server default)');
-
-        window.add(page);
-    }
-
-    // ═══════════════════════════════════════════════════════════════════
-    // Page 5 — Feedback (Chimes & Visual)
-    // ═══════════════════════════════════════════════════════════════════
-    _addFeedbackPage(window) {
-        const page = new Adw.PreferencesPage({
-            title: 'Feedback',
-            icon_name: 'preferences-desktop-notifications-symbolic',
-        });
-
-        // ── Sound Chimes ──
-        const chimeGroup = new Adw.PreferencesGroup({
-            title: 'Sound Chimes',
-            description: 'Audio feedback cues during speech operations.',
-        });
-        page.add(chimeGroup);
-
-        this._addSwitchRow(chimeGroup, 'Ready Chime',
-            'Play ascending tone when microphone opens',
-            'chime_ready', true);
-
-        this._addSwitchRow(chimeGroup, 'Processing Chime',
-            'Play blip when speech is recognized',
-            'chime_processing', false);
-
-        this._addSwitchRow(chimeGroup, 'Speak Chime',
-            'Play descending tone before TTS starts',
-            'chime_speak', false);
-
-        this._addSwitchRow(chimeGroup, 'Done Chime',
-            'Play double-tap tone when TTS finishes',
-            'chime_done', false);
-
-        this._addSwitchRow(chimeGroup, 'Thinking Hum',
-            'Play looping 150Hz hum while processing',
-            'chime_hum', false);
-
-        // ── Visual Feedback ──
-        const visualGroup = new Adw.PreferencesGroup({
-            title: 'Visual Feedback',
-        });
-        page.add(visualGroup);
-
-        this._addGSettingsSwitchRow(visualGroup, 'Live Subtitles',
-            'Show real-time transcription text',
-            'live-subtitles');
-
-        this._addSwitchRow(visualGroup, 'Waveform Bars',
-            'Show audio level waveform below badge',
-            'show_waveform', true);
-
-        this._addSwitchRow(visualGroup, 'VAD Indicator',
-            'Show green dot when speech is detected',
-            'show_vad_dot', true);
-
-        this._addSwitchRow(visualGroup, 'Silence Fade',
-            'Waveform dims during extended silence',
-            'show_silence_fade', true);
-
-        this._addSwitchRow(visualGroup, 'Badge Pulse',
-            'Breathing animation when listening or speaking',
-            'show_badge_pulse', true);
-
-        this._addSwitchRow(visualGroup, 'Badge Audio Scale',
-            'Badge grows with voice volume',
-            'show_badge_scale', true);
-
-        this._addSwitchRow(visualGroup, 'Word Highlights',
-            'New words flash blue in subtitles',
-            'show_word_highlights', true);
-
-        this._addSwitchRow(visualGroup, 'VU Meter',
-            'Show volume meter animation during audio',
-            'vu_meter', true);
-
-        this._addSwitchRow(visualGroup, 'Visual Indicator',
-            'Show status icons in terminal',
-            'visual_indicator', true);
-
-        // ── Subtitle Colors ──
-        const colorGroup = new Adw.PreferencesGroup({
-            title: 'Subtitle Colors',
-        });
-        page.add(colorGroup);
-
-        this._addComboRow(colorGroup, 'User Speech Color', 'subtitle_color_user',
-            SUBTITLE_COLORS, 'light_green');
-
-        this._addComboRow(colorGroup, 'TTS Speech Color', 'subtitle_color_tts',
-            SUBTITLE_COLORS, 'amber');
-
-        window.add(page);
-    }
-
-    // ═══════════════════════════════════════════════════════════════════
-    // Page 6 — Extension Settings (GSettings)
-    // ═══════════════════════════════════════════════════════════════════
-    _addExtensionPage(window) {
-        const page = new Adw.PreferencesPage({
-            title: 'Extension',
-            icon_name: 'preferences-system-symbolic',
-        });
-
-        // ── Badge ──
-        const badgeGroup = new Adw.PreferencesGroup({
-            title: 'Floating Badge',
-            description: 'The floating voice-status badge on your desktop.',
-        });
-        page.add(badgeGroup);
-
-        this._addGSettingsSwitchRow(badgeGroup, 'Show Badge',
-            'Display the floating badge on the desktop',
-            'show-badge');
-
-        this._addGSettingsSpinRow(badgeGroup, 'Position X', 'badge-position-x',
-            -1, 5000, 1, 0,
-            '-1 for auto-center');
-
-        this._addGSettingsSpinRow(badgeGroup, 'Position Y', 'badge-position-y',
-            -1, 5000, 1, 0,
-            '-1 for auto-position at bottom');
-
-        // ── Panel ──
-        const panelGroup = new Adw.PreferencesGroup({
-            title: 'Panel Indicator',
-        });
-        page.add(panelGroup);
-
-        this._addGSettingsSwitchRow(panelGroup, 'Show Panel Indicator',
-            'Display GNOME Speaks in the top panel',
-            'show-panel-indicator');
-
-        // ── Keyboard Shortcuts ──
-        const shortcutGroup = new Adw.PreferencesGroup({
-            title: 'Keyboard Shortcuts',
-            description: 'Global shortcuts. Change via GNOME Settings > Keyboard > Custom Shortcuts, or edit dconf directly.',
-        });
-        page.add(shortcutGroup);
-
-        this._addShortcutRow(shortcutGroup, 'Toggle Listening', 'toggle-listening-shortcut');
-        this._addShortcutRow(shortcutGroup, 'Speak Clipboard', 'speak-clipboard-shortcut');
-        this._addShortcutRow(shortcutGroup, 'Read Selection', 'read-selection-shortcut');
-        this._addShortcutRow(shortcutGroup, 'Toggle Voice Quality', 'toggle-voice-quality-shortcut');
-
-        window.add(page);
-    }
-
-    // ═══════════════════════════════════════════════════════════════════
-    // Page 7 — Advanced
-    // ═══════════════════════════════════════════════════════════════════
-    _addAdvancedPage(window) {
-        const page = new Adw.PreferencesPage({
-            title: 'Advanced',
-            icon_name: 'preferences-other-symbolic',
-        });
-
-        // ── Debug ──
-        const debugGroup = new Adw.PreferencesGroup({
-            title: 'Debug',
-        });
-        page.add(debugGroup);
-
-        this._addSwitchRow(debugGroup, 'Debug Mode',
-            'Write detailed logs to /tmp/speech-debug.log',
-            'debug', false);
-
-        // ── Barge-in Details ──
-        const bargeGroup = new Adw.PreferencesGroup({
-            title: 'Barge-in Details',
-            description: 'Fine-tune barge-in behavior (enable on the Modes page).',
-        });
-        page.add(bargeGroup);
-
-        this._addSpinRow(bargeGroup, 'Barge-in Frames', 'barge_in_frames',
-            1, 20, 1, 0, 3,
-            'Speech frames needed to trigger barge-in');
-
-        this._addSpinRow(bargeGroup, 'Barge-in Silence', 'barge_in_silence',
-            0.3, 10.0, 0.1, 1, 1.0,
-            'Seconds of silence before resuming TTS');
-
-        this._addSwitchRow(bargeGroup, 'Barge-in Chime',
-            'Play chime when barge-in is detected',
-            'chime_barge_in', true);
-
-        // ── Auto-Corrections ──
-        const correctGroup = new Adw.PreferencesGroup({
-            title: 'Auto-Corrections',
-            description: 'Custom word replacements applied to transcriptions. Format: wrong=right, one per line.',
-        });
+        // ── Corrections ──
+        const correctGroup = new Adw.PreferencesGroup({title: 'Auto-Corrections'});
         page.add(correctGroup);
 
         this._addCorrectionsRow(correctGroup);
 
-        // ── Other ──
-        const otherGroup = new Adw.PreferencesGroup({
-            title: 'Other',
-        });
-        page.add(otherGroup);
+        // ── Privacy & Debug ──
+        const privGroup = new Adw.PreferencesGroup({title: 'Privacy & Debug'});
+        page.add(privGroup);
 
-        this._addSwitchRow(otherGroup, 'Echo Cancellation',
-            'Use PipeWire echo cancellation nodes if available',
-            'enable_echo_cancel', true);
+        this._addEntryRow(privGroup, 'Save Spoken Audio To', 'save_audio_dir', '',
+            'Folder where every TTS utterance is saved as audio — fills up and records everything said. Empty = off');
 
-        this._addSwitchRow(otherGroup, 'Enable Pause',
-            'Allow pausing and resuming playback',
-            'enable_pause', true);
+        this._addSwitchRow(privGroup, 'Debug Log',
+            'Write detailed logs to /tmp/speech-debug.log — includes everything you dictate. Default: off',
+            'debug', false);
 
-        // ── Service Management ──
-        const serviceGroup = new Adw.PreferencesGroup({
-            title: 'Service',
-            description: 'Restart to apply config.json changes to the running speech service.',
-        });
+        // ── Service ──
+        const serviceGroup = new Adw.PreferencesGroup({title: 'Service'});
         page.add(serviceGroup);
 
         const restartRow = new Adw.ActionRow({
             title: 'Restart Speech Service',
-            subtitle: 'systemctl --user restart gnome-speaks.service',
+            subtitle: 'Most settings apply live — restart after changing devices, accounts, or the AI provider',
         });
         const restartButton = new Gtk.Button({
             label: 'Restart',
@@ -1056,21 +699,70 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // Widget Helpers — config.json backed
+    // Special rows
     // ═══════════════════════════════════════════════════════════════════
 
-    _addInfoRow(group, title, subtitle) {
-        const row = new Adw.ActionRow({
+    /**
+     * The Live Subtitles master switch. One concept lives in two stores:
+     * GSettings `live-subtitles` gates the extension's overlay rendering,
+     * config `live_subtitles` gates the service's subtitle stream (and the
+     * "cast subtitles" spell flips the config side). This row writes BOTH,
+     * and follows external changes to either.
+     */
+    _addSubtitlesMasterRow(group) {
+        const row = new Adw.SwitchRow({
+            title: 'Live Subtitles',
+            subtitle: 'Show the words as they are heard and spoken. "cast subtitles" toggles by voice. Default: on',
+            active: this._settings.get_boolean('live-subtitles'),
+        });
+
+        row.connect('notify::active', () => {
+            if (this._settings.get_boolean('live-subtitles') !== row.active)
+                this._settings.set_boolean('live-subtitles', row.active);
+            this._setConfigValue('live_subtitles', row.active);
+        });
+
+        // Follow the GSettings side if something else (or the spell path,
+        // which syncs GSettings too) changes it while the window is open.
+        const changedId = this._settings.connect('changed::live-subtitles', () => {
+            const val = this._settings.get_boolean('live-subtitles');
+            if (row.active !== val)
+                row.active = val;
+        });
+        row.connect('destroy', () => this._settings.disconnect(changedId));
+
+        group.add(row);
+        return row;
+    }
+
+    /** Entry row whose config value is a LIST, edited as comma-separated. */
+    _addListEntryRow(group, title, configKey, defaultValue, help) {
+        const current = this._config[configKey];
+        const text = Array.isArray(current) ? current.join(', ')
+            : (current || defaultValue);
+        const row = new Adw.EntryRow({
             title: title,
-            subtitle: subtitle,
-            subtitle_lines: 3,
+            text: text,
+            show_apply_button: true,
+            tooltip_text: help || '',
+        });
+        row.connect('apply', () => {
+            const items = row.get_text().split(',')
+                .map(s => s.trim()).filter(s => s.length);
+            if (items.length === 0)
+                this._deleteConfigKey(configKey);
+            else
+                this._setConfigValue(configKey, items);
         });
         group.add(row);
         return row;
     }
 
+    // ═══════════════════════════════════════════════════════════════════
+    // Widget Helpers — config.json backed
+    // ═══════════════════════════════════════════════════════════════════
+
     _addComboRow(group, title, configKey, options, defaultValue) {
-        // options: [[value, label], ...]
         const values = options.map(o => o[0]);
         const labels = options.map(o => o[1]);
 
@@ -1104,11 +796,9 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         const regions = [...REGIONS];
         const currentValue = this._config[configKey] || defaultValue;
 
-        // Add current value if custom (not in preset list)
         if (currentValue && !regions.find(r => r[0] === currentValue))
             regions.push([currentValue, `${currentValue} (custom)`]);
 
-        // For optional fields, add "none" option
         if (defaultValue === '')
             regions.unshift(['', 'Same as primary region']);
 
@@ -1186,18 +876,20 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         return row;
     }
 
-    _addEntryRow(group, title, configKey, defaultValue, description) {
+    /**
+     * Adw.EntryRow has no subtitle property, which is how nine help texts
+     * silently vanished in the previous layout — the help now renders as a
+     * tooltip (hover/focus), and cost/privacy caveats are worded into row
+     * TITLES or neighboring rows where they must be seen, not hovered.
+     */
+    _addEntryRow(group, title, configKey, defaultValue, help) {
         const currentValue = this._config[configKey] ?? defaultValue;
         const row = new Adw.EntryRow({
             title: title,
             text: currentValue != null ? String(currentValue) : '',
             show_apply_button: true,
+            tooltip_text: help || '',
         });
-
-        if (description) {
-            // Wrap in an ExpanderRow for description, or use group description
-            // For simplicity, show as subtitle via ActionRow approach
-        }
 
         row.connect('apply', () => {
             const text = row.get_text().trim();
@@ -1211,7 +903,7 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         return row;
     }
 
-    _addPasswordRow(group, title, configKey, subtitle) {
+    _addPasswordRow(group, title, configKey, help) {
         const currentValue = this._config[configKey] || '';
 
         let row;
@@ -1220,13 +912,14 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
                 title: title,
                 text: currentValue,
                 show_apply_button: true,
+                tooltip_text: help || '',
             });
         } catch (e) {
-            // Fallback for older Adw without PasswordEntryRow
             row = new Adw.EntryRow({
                 title: title,
                 text: currentValue,
                 show_apply_button: true,
+                tooltip_text: help || '',
             });
         }
 
@@ -1237,13 +930,6 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
             else
                 this._setConfigValue(configKey, text);
         });
-
-        if (subtitle) {
-            const wrapper = new Adw.PreferencesGroup({description: subtitle});
-            wrapper.add(row);
-            group.add(wrapper);
-            return row;
-        }
 
         group.add(row);
         return row;
@@ -1256,8 +942,8 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
             .join('\n');
 
         const row = new Adw.ActionRow({
-            title: 'Edit Corrections',
-            subtitle: `${Object.keys(corrections).length} corrections defined`,
+            title: 'Word Corrections',
+            subtitle: `${Object.keys(corrections).length} defined — fix words it always mishears (wrong=right)`,
         });
 
         const editButton = new Gtk.Button({
@@ -1315,7 +1001,7 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
                         newCorrections[wrong.trim()] = rightParts.join('=').trim();
                     }
                     this._setConfigValue('auto_corrections', newCorrections);
-                    row.subtitle = `${Object.keys(newCorrections).length} corrections defined`;
+                    row.subtitle = `${Object.keys(newCorrections).length} defined — fix words it always mishears (wrong=right)`;
                 }
                 dlg.destroy();
             });
@@ -1343,10 +1029,9 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         });
 
         editButton.connect('clicked', () => {
-            const dialog = new Adw.MessageDialog({
+            const dialog = new Adw.AlertDialog({
                 heading: `Set shortcut for "${title}"`,
                 body: 'Enter a keyboard shortcut (e.g. <Super><Alt>space):',
-                modal: true,
             });
 
             const entry = new Gtk.Entry({
@@ -1358,9 +1043,11 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
             dialog.set_extra_child(entry);
 
             dialog.add_response('cancel', 'Cancel');
-            dialog.add_response('save', 'Save');
             dialog.add_response('disable', 'Disable');
+            dialog.add_response('save', 'Save');
             dialog.set_response_appearance('save', Adw.ResponseAppearance.SUGGESTED);
+            dialog.set_default_response('save');
+            dialog.set_close_response('cancel');
 
             dialog.connect('response', (dlg, response) => {
                 if (response === 'save') {
@@ -1375,7 +1062,7 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
                 }
             });
 
-            dialog.present();
+            dialog.present(group.get_root());
         });
 
         row.add_suffix(editButton);
@@ -1424,6 +1111,76 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
 
         group.add(row);
         return row;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // System probes
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * Enumerate PipeWire sinks or sources by parsing `wpctl status`.
+     * Returns [[nodeId, label], ...] suitable for _addComboRow.
+     */
+    _enumeratePipeWireDevices(type) {
+        const devices = [];
+        try {
+            const [ok, stdout, stderr, exitCode] = GLib.spawn_command_line_sync('wpctl status');
+            if (!ok || exitCode !== 0) return devices;
+
+            const output = new TextDecoder('utf-8').decode(stdout);
+            const lines = output.split('\n');
+
+            const header = type === 'sinks' ? 'Sinks:' : 'Sources:';
+            let inAudio = false;
+            let inSection = false;
+
+            for (const line of lines) {
+                const trimmed = line.trim();
+
+                if (trimmed === 'Audio') {
+                    inAudio = true;
+                    continue;
+                }
+                if (inAudio && /^(Video|Settings)$/.test(trimmed)) {
+                    break;
+                }
+                if (!inAudio) continue;
+
+                if (trimmed.endsWith(header)) {
+                    inSection = true;
+                    continue;
+                }
+
+                if (inSection && (trimmed === '│' || trimmed === '' ||
+                    (trimmed.endsWith(':') && !trimmed.match(/^\d/)))) {
+                    break;
+                }
+
+                if (!inSection) continue;
+
+                const stripped = trimmed.replace(/^[│├└─┬┤┼╌╎\s]+/, '');
+                const match = stripped.match(/^(\*?)\s*(\d+)\.\s+(.+?)(?:\s+\[.*\])?\s*$/);
+                if (match) {
+                    const isDefault = match[1] === '*';
+                    const nodeId = match[2];
+                    const name = match[3].trim();
+                    const label = isDefault ? `${name} (default)` : name;
+                    devices.push([nodeId, label]);
+                }
+            }
+        } catch (e) {
+            // wpctl not available — return empty list
+        }
+        return devices;
+    }
+
+    _commandExists(cmd) {
+        try {
+            const [ok, stdout, stderr, exitCode] = GLib.spawn_command_line_sync(`which ${cmd}`);
+            return ok && exitCode === 0;
+        } catch (e) {
+            return false;
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -1584,12 +1341,13 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         return row;
     }
 
-    _addCcaEntryRow(group, title, configKey, defaultValue, description) {
+    _addCcaEntryRow(group, title, configKey, defaultValue, help) {
         const currentValue = this._ccaConfig[configKey] ?? defaultValue;
         const row = new Adw.EntryRow({
             title: title,
             text: currentValue != null ? String(currentValue) : '',
             show_apply_button: true,
+            tooltip_text: help || '',
         });
 
         row.connect('apply', () => {
@@ -1604,7 +1362,7 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         return row;
     }
 
-    _addCcaPasswordRow(group, title, configKey, subtitle) {
+    _addCcaPasswordRow(group, title, configKey, help) {
         const currentValue = this._ccaConfig[configKey] || '';
 
         let row;
@@ -1613,12 +1371,14 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
                 title: title,
                 text: currentValue,
                 show_apply_button: true,
+                tooltip_text: help || '',
             });
         } catch (e) {
             row = new Adw.EntryRow({
                 title: title,
                 text: currentValue,
                 show_apply_button: true,
+                tooltip_text: help || '',
             });
         }
 
@@ -1669,10 +1429,10 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
 
     _restartService(button) {
         button.set_sensitive(false);
-        button.set_label('Restarting...');
+        button.set_label('Restarting…');
 
         try {
-            const [ok] = GLib.spawn_command_line_async(
+            GLib.spawn_command_line_async(
                 'systemctl --user restart gnome-speaks.service'
             );
             GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2000, () => {


### PR DESCRIPTION
## Summary
Rebuild of the preferences window from two live-verified research passes (GNOME HIG + exemplar analysis; full 101-row control audit):
- **Task-first IA**: `Dictation · AI Chat · Voice & Sound · Wake & Spells · Accounts · Advanced`. Technology-first pages dissolved into task homes; barge-in and every silence timeout finally live together; duplicate Shortcuts/Restart groups collapsed to one each.
- **Search-honest**: explanations moved into row subtitles — libadwaita's prefs search matches subtitles but never group descriptions, so the old 29 prose paragraphs were invisible to search.
- **Costs visible**: metering `Adw.Banner` on Accounts; warnings on HD voice, reply-length limit, Spiel cloud voices, Bedrock's Marketplace billing.
- **Audit fixes**: 4 dead controls dropped (service never passes speed/pitch/volume/VAD params); entry help finally renders (EntryRow has no subtitle — tooltips + caveats worded into visible text); invalid nested PreferencesGroup in password rows removed; Live Subtitles is ONE switch writing both GSettings and config with external-change follow; deprecated `MessageDialog` → `AlertDialog`; "wtype" claim corrected to ydotool; echo-cancel default aligned to the service's false.
- **Gaps filled**: Spiel provider group, `save_audio_dir` (privacy-labeled), `conversation_silence_timeout`, comma-separated `spiel_voices` editor.

## Test Plan
- [x] `node --check`
- [x] Window opens live with all six pages, exit clean
- [x] Every config key from the old layout preserved or deliberately dropped-with-record (spec: docs/superpowers/specs/2026-08-12-prefs-redesign.md)
- [ ] JP click-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)