### PR TITLE
docs: refresh README/site/CLAUDE.md for the Chronicle, prosody, and GNOME 50

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- claude-md-version: c2e0cdd | updated: 2026-03-22 -->
 # CLAUDE.md — gnome-speaks
 
-GNOME Shell extension (v46-48) for desktop voice interaction: STT, TTS, and AI conversation via Azure Speech Services.
+GNOME Shell extension (v46-50) for desktop voice interaction: STT, TTS, and AI conversation via Azure Speech Services.
 
 ## Architecture
 
@@ -9,18 +9,20 @@ Two-process design connected by session D-Bus (`org.gnome.Speaks`):
 
 | File | Runtime | Role | Lines |
 |------|---------|------|-------|
-| `extension.js` | GNOME Shell (GJS) | UI: badge, panel indicator, subtitle overlay, keybindings, drag | ~1,800 |
-| `gnome-speaks-service.py` | systemd user service (Python) | Audio, STT, TTS, speech queue, LLM, typing, clipboard, wake watcher | ~3,400 |
-| `spellbook.py` | imported by the service | Incantation matcher + executor ("cast …" → local actions); denylist | ~450 |
-| `spellbook.json` | data | Repo spells (self-control); user overlay at `~/.config/speech-to-cli/spellbook.json` merges + hot-reloads | — |
-| `prefs.js` | GNOME Extensions app (GJS/Gtk4) | 10-page preferences window (incl. Spellcraft) | ~1,750 |
-| `stylesheet.css` | GNOME Shell | Badge states, animations, subtitle overlay | ~350 |
+| `extension.js` | GNOME Shell (GJS) | UI: badge + pills + 📜 rune, panel indicator, subtitle overlay, chronicle scroll, keybindings, drag | ~2,620 |
+| `gnome-speaks-service.py` | systemd user service (Python) | Audio, STT, TTS, speech queue, chronicle, LLM, typing, clipboard, wake watcher | ~3,720 |
+| `spellbook.py` | imported by the service | Incantation matcher + executor ("cast …" → local actions); denylist | ~390 |
+| `spellbook.json` | data | 12 repo spells (self-control); user overlay at `~/.config/speech-to-cli/spellbook.json` merges + hot-reloads | — |
+| `spiel_provider.py` | imported by the service | Spiel/libspiel synthesis side (`org.gnome.Speaks.Speech.Provider`); off unless `spiel_provider` | ~120 |
+| `prefs.js` | GNOME Extensions app (GJS/Gtk4) | 6-page preferences window (task-first redesign, #5e49049) | ~1,540 |
+| `stylesheet.css` | GNOME Shell | Badge states, pills, animations, subtitle overlay, chronicle scroll | ~560 |
 
 The extension touches **no** network or audio -- all I/O is in the Python service.
 Spoken output serializes through a FIFO **speech queue** (HTTP callers never stomp
 each other; user speech preempts). Transcripts hit the **spellbook** before mode
-routing. A **wake watcher** thread streams mic audio to a LAN Wyoming
-openwakeword server while idle.
+routing. Everything said in either direction appends to the **chronicle**
+(`$XDG_STATE_HOME/gnome-speaks/chronicle.jsonl`) and is respeakable. A **wake
+watcher** thread streams mic audio to a LAN Wyoming openwakeword server while idle.
 
 ## External Dependencies
 
@@ -49,6 +51,10 @@ systemctl --user restart gnome-speaks.service
 
 No separate build step -- files are plain JS and Python (no transpilation, no bundling).
 
+`./pack.sh` builds the extensions.gnome.org submission zip via the official
+`gnome-extensions pack` into `dist/` (gitignored). Extension only -- the service
+is not a shell component and never ships in that zip.
+
 ## Service Management
 
 ```bash
@@ -62,14 +68,18 @@ flushes; `source` + `coalesce`/`kind:"progress"` drops that source's own
 unspoken backlog so agents never narrate stale status), `/skip` (optional
 `{"id":N}` scopes it to that item), `/stop` (drains queue), `/pause`,
 `/resume`, `/cast` (text seam into the spellbook — same gates as spoken casts),
-`GET /status`, `/queue` (pending + `source` + per-item outcomes:
-done/canceled/interrupted/error), `/voices`.
+`/respeak` (`{"id":N}`; omit id = last spoken line), `GET /status`, `/queue`
+(pending + `source` + per-item outcomes: done/canceled/interrupted/error),
+`/voices`, `/chronicle` (`?limit&q&kind=you|spoken`, oldest-first),
+`/api/version` (realm-sigil contract).
 
 ## D-Bus Interface
 
 Bus name: `org.gnome.Speaks` | Path: `/org/gnome/Speaks`
 
-Key methods: `StartListening`, `StopListening`, `Speak(text)`, `SpeakClipboard`, `SpeakSelection`, `Talk(text)`, `Stop`, `GetState`
+Key methods: `StartListening`, `StopListening`, `Speak(text)`, `SpeakClipboard`, `SpeakSelection`, `Talk(text)`, `Stop`, `GetState`, `GetChronicle(limit)` (`limit<=0` → 20), `Respeak(id)` (`0` → last spoken)
+
+Second bus name when `spiel_provider` is enabled: `org.gnome.Speaks.Speech.Provider` (`org.freedesktop.Speech.Provider`, see `spiel_provider.py`).
 
 Signals: `StateChanged`, `TranscriptionReady`, `PartialTranscription`, `SubtitleUpdate`, `AudioLevel`, `Error`
 
@@ -97,12 +107,13 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
 | Half/Full Duplex | Auto-detected speaker vs headphone routing |
 | Wake word | Idle-only mic stream to LAN openwakeword; detection = dictation hotkey. Toggle: "cast wake word" |
 | Spellbook | "cast …"/"invoke …" transcripts run local spells (never typed/LLM'd); `POST /cast` is the text seam |
+| Chronicle | Not a mode -- always-on ledger of both directions; 📜 badge rune (8 lines) + panel submenu (12), click to respeak. Spells: "cast echo" / "chronicle" / "seal the chronicle" |
 
 ## Coding Conventions
 
 - **extension.js**: GJS with GNOME Shell imports (St, Clutter, Meta, Shell). No ES modules from npm -- pure GObject Introspection. Prefix private methods with `_`.
 - **gnome-speaks-service.py**: GLib main loop + threading for blocking audio/network ops. `GLib.idle_add()` to marshal D-Bus signal emissions back to the main thread. Logs to stderr via `logging`.
-- **prefs.js**: Adw (libadwaita) preferences pages. Config changes written to `~/.config/speech-to-cli/config.json` with debounced saves.
+- **prefs.js**: Adw (libadwaita) preferences pages. Config changes written to `~/.config/speech-to-cli/config.json` with debounced, **merge-on-write** saves (#16): re-read the file and apply only the dirty/deleted keys, because the service writes the same file (spells, quality toggle) and dumping a stale full object would erase its changes. Track edits through `_setConfigValue`/`_deleteConfigKey` so they land in `_dirtyKeys`/`_deletedKeys` -- mutating `this._config` directly means the change is silently dropped at save time.
 - **stylesheet.css**: GNOME Shell CSS (subset of CSS3). No SCSS or preprocessors.
 
 ## Key Gotchas
@@ -114,11 +125,18 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
 - **Schema compilation**: After editing the `.gschema.xml`, must run `glib-compile-schemas` on the install directory.
 - **Disposed notification sources**: During shell init/restart, `MessageTray` `source-added` can fire with already-disposed `FdoNotificationDaemonSource` objects. Any signal connection on them crashes the shell. Always wrap `source.connect()` in try-catch and listen for `source-removed` to drop references before GC disposes them.
 - **Azure content filter**: Avoid `[SYSTEM:]` prefix in system prompts -- Azure GPT content filter blocks it.
-- **speech-to-cli `load_config()` whitelists keys**: unknown config.json keys are silently dropped. Adding a config key means adding it to the whitelist in `state.py` too, or the feature reads a default forever.
+- **speech-to-cli `load_config()` whitelists keys**: unknown config.json keys are silently dropped. Adding a config key means adding it to the whitelist in `state.py` too, or the feature reads a default forever. Scope: this only binds keys the **Python** side reads -- keys consumed only by extension.js (`subtitles_user`, `subtitles_tts`) bypass it entirely, since GJS parses config.json raw. Don't "fix" their absence from `state.py`, and don't assume a working extension key means the Python side can see it.
 - **`Shell.Eval` is dead** (returns `(false,'')`; Introspect/Screenshot are AccessDenied) -- `_get_focused_app()` is silently a no-op (#7). Desktop actuation needs D-Bus methods exported from extension.js.
 - **Public repo**: LAN hostnames/IPs, the HA domain, and the wake-word model name (it's the wake phrase) never enter git -- they live in `~/.config/speech-to-cli/config.json` and the user spellbook overlay. Scan patch history before pushing.
 - **systemctl scope trap**: this file prescribes `systemctl --user` for the voice service — but `systemctl --user is-active <system-unit>` answers `inactive` with **exit 0** for units that live in the system scope (e.g. litrpg-engine on this machine). A confidently wrong answer; check the scope before believing "inactive", and never build a health check or spell on the --user reading of a system unit.
 - **Speech-queue state ownership**: `_speak_token` fences playback cleanup -- a preempted worker must not reset state it no longer owns. Keep the token claims when adding new speech paths.
+- **`--nested` is gone on GNOME 50**: the nested-shell test harness is now `dbus-run-session -- gnome-shell --headless --virtual-monitor 1280x720`. Any doc, script, or muscle memory reaching for `--nested` fails on 50+.
+- **`addTopChrome` and `affectsInputRegion`**: GNOME 49+ tracks input regions from reactive actors automatically and **rejects** the param. It defaulted to `true` on 46-48, so omitting it is behavior-identical everywhere -- never re-add it.
+- **St renders only ONE box-shadow**: comma-separated shadow lists log `Ignoring excess values` per rule and the extra layers never draw. Keep one shadow per rule and get depth from gradients instead.
+- **`log()` is deprecated in GJS**: use `console.log/warn/error/debug`. Service-absent paths should log at `debug` so a solo-extension install (EGO users with no service) stays quiet.
+- **`PopupSubMenu.open()` refuses an EMPTY submenu** (`popupMenu.js` guards on `isEmpty()`): populating a submenu from its own `open-state-changed` deadlocks -- the event never fires, the row is dead. Seed a placeholder at build time and refresh from the PARENT menu's open instead (the Chronicle submenu bug, cff6745).
+- **Subtitles are conversation-mode only**: both user-voice subtitle paths early-return on `!this._conversationMode` (in dictation the text is already at the cursor). `subtitles_user` / `subtitles_tts` gate the two directions independently *on top of* the `live_subtitles` master; `live_subtitles` is dual-written to GSettings `live-subtitles` because the overlay gates on the GSettings layer.
+- **Orca's Spiel switch moved**: `orca.settings.speechSystemOverride` **no longer exists** in Orca 50 -- an `orca-customizations.py` setting it does nothing silently. Use the relocatable GSettings schema: `gsettings set "org.gnome.Orca.Speech:/org/gnome/orca/default/speech/" speech-server-factory spiel` (values: `speechdispatcherfactory` | `spiel`; the `:path` suffix is mandatory). libspiel is still unpackaged on Ubuntu 26.04 -- source build + `~/.config/environment.d/` typelib path.
 
 ## Testing
 
@@ -127,6 +145,9 @@ No test suite. Validate changes by:
 2. Checking logs (`journalctl --user -u gnome-speaks.service -f`)
 3. Testing via D-Bus (`dbus-send`) or keyboard shortcuts
 4. Python syntax check: `python3 -c "import py_compile; py_compile.compile('gnome-speaks-service.py', doraise=True)"`
+5. Shell-side changes: headless session (`--nested` is dead on 50, see gotchas) --
+   `dbus-run-session -- gnome-shell --headless --virtual-monitor 1280x720`, then
+   enable/disable/re-enable and require **zero** JS errors, shell CRITICALs, and St warnings.
 
 ## Git
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ GNOME Speaks preferences can configure all four projects from one unified settin
 
 ## Features
 
-- **Floating voice badge** — glassmorphism-styled status indicator with pulse animations
+- **Floating voice badge** — glassmorphism-styled status indicator with pulse animations, mode pills, and a 📜 Chronicle rune
+- **The Chronicle** — an append-only local ledger of everything said, both directions; click any line to hear it again, or say "cast echo"
 - **Wake word** — hands-free activation via a LAN openwakeword server; speaking your wake phrase opens the mic like the keyboard shortcut (idle-only, never over TTS)
 - **Voice spellbook** — "cast …" utterances run local spells instead of being typed: mode switching, status reports spoken back in themed voices, home-automation rituals, oracle consultations — with confirmation gates and a hardcoded denylist for anything destructive
 - **Speech queue** — the HTTP API queues utterances FIFO so concurrent callers (agents, scripts, browsers) never cut each other off; your own speech always preempts
@@ -49,6 +50,8 @@ GNOME Speaks preferences can configure all four projects from one unified settin
 - **Speech-to-text** — real-time streaming transcription via Azure WebSocket STT
 - **Live typing** — partial transcriptions appear in the text field as you speak, replaced by the final text when done
 - **Text-to-speech** — HD and Fast voice modes (DragonHD / Neural) with streaming playback
+- **Prosody controls** — speaking rate, pitch, and volume applied as SSML to every utterance; the rate composes with Fast mode's built-in boost instead of being ignored by it
+- **Per-voice subtitles** — the live-caption overlay has independent switches (and colors) for your voice and its voice
 - **Streaming LLM→TTS** — AI responses start speaking on the first complete sentence instead of waiting for the full reply
 - **Continuous STT session** — in loop mode, the recorder and WebSocket stay alive across cycles (no restart overhead)
 - **Voice quality toggle** — switch between HD (DragonHD, eastus) and Fast (Neural, westus) modes via `Super+Alt+V` or the panel menu
@@ -72,7 +75,8 @@ GNOME Shell process                    Background service
 │  - badge        │                    │  - Azure STT (WS) + TTS    │
 │  - panel menu   │                    │  - speech queue + HTTP API │
 │  - keybindings  │                    │  - spellbook.py dispatch   │
-│  - settings     │                    │  - wake-word watcher       │
+│  - subtitles    │                    │  - chronicle ledger        │
+│  - chronicle UI │                    │  - wake-word watcher       │
 │  - bus watcher  │                    │  - ydotool live typing     │
 └─────────────────┘                    │  - LLM integration         │
                                        └──────────┬─────────────────┘
@@ -133,7 +137,7 @@ Automatically reads GNOME desktop notifications aloud as they arrive.
 
 ## Requirements
 
-- GNOME Shell 46, 47, or 48
+- GNOME Shell 46–50 (developed on 46–48; verified on 50.1 / Ubuntu 26.04 LTS)
 - PipeWire (for audio capture and playback)
 - Python 3.10+
 - An [Azure Speech Services](https://azure.microsoft.com/en-us/products/ai-services/speech-services) API key
@@ -179,11 +183,23 @@ The installer will:
 1. Copy extension files to `~/.local/share/gnome-shell/extensions/gnome-speaks@jphein/`
 2. Compile GSettings schemas
 3. Install and start the systemd user service
-4. Register the D-Bus service for auto-activation
+4. Register the D-Bus service for auto-activation (plus the inert [Spiel provider](#spiel-provider) name)
 5. Install missing Python dependencies
 6. Enable the extension
 
+Dependencies are checked by **import**, not by `pip show` — distro packages and pip
+metadata lie in opposite directions, and only the import is ground truth. On PEP 668
+distros (Ubuntu 23.04+) the installer retries with `pip install --user
+--break-system-packages`, which stays scoped to your user site-packages.
+
 Restart GNOME Shell after installation (log out and back in on Wayland, or `Alt+F2` → `r` on X11).
+
+### Extension-only zip (extensions.gnome.org)
+
+`./pack.sh` wraps the official packer and writes
+`dist/gnome-speaks@jphein.shell-extension.zip`. Only the shell extension ships in
+that zip — the companion service (audio, STT/TTS, LLM, HTTP API) is not a shell
+component and still installs via `install.sh`.
 
 ### Meson build (alternative)
 
@@ -225,6 +241,42 @@ Create `~/.config/speech-to-cli/config.json`:
 | `language` | STT/TTS language code |
 
 You can get a free Azure Speech key at [Azure Portal](https://portal.azure.com) — the free tier includes 500K characters/month for TTS and 5 hours/month for STT.
+
+### Prosody
+
+Three keys shape every spoken utterance, applied as SSML `<prosody>`:
+
+| Key | Default | Values |
+|-----|---------|--------|
+| `speed` | `1.0` | Rate multiplier — `1.25` is 25% faster |
+| `pitch` | `"default"` | `x-low`, `low`, `medium`, `high`, `x-high` |
+| `volume` | `"default"` | `silent`, `x-soft`, `soft`, `medium`, `loud`, `x-loud` |
+
+Those are the steps preferences offers; `pitch`/`volume` are passed through to SSML after an
+injection-safety check, so relative forms Azure accepts (`+10%`, `-2st`) work if you edit the
+config by hand.
+
+`speed` **composes** with Fast quality's built-in +15% rather than being overwritten by it,
+so the setting works in both quality modes; `speed: 1.0` still means "whatever the voice
+does naturally". `pitch` and `volume` are left out of the SSML entirely while `"default"`,
+so an untouched config produces the same markup it always did.
+
+### Subtitles
+
+The caption overlay has a master switch plus one switch per direction, because the two
+directions are useful independently — captions of *its* voice with your own live transcript
+off is a common preference:
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `live_subtitles` | `true` | Master switch (mirrored into GSettings `live-subtitles`) |
+| `subtitles_user` | `true` | Live transcript while **you** speak |
+| `subtitles_tts` | `true` | Captions while **it** speaks |
+| `subtitle_color_user` / `subtitle_color_tts` | `light_green` / `amber` | Per-direction color |
+| `show_word_highlights` | `true` | Newly heard words flash as they arrive |
+
+Subtitles are a conversation-mode surface: in dictation mode the text is already landing at
+your cursor, so the overlay stays out of the way.
 
 ### Extension preferences
 
@@ -290,6 +342,9 @@ current utterance immediately and holds the queue until you finish.
 | `GET /queue` | Queue introspection: `{current, pending, depth, recent}`. Each entry carries its `source` (`null` when unset). `recent` holds the last 16 terminal outcomes — `done`, `canceled` (dropped before starting), `interrupted` (cut off mid-play), or `error` — so callers can learn the fate of a submitted `id`. |
 | `GET /status` | Service state, pause flag, `queue_depth`, playback progress. |
 | `GET /voices` | Available Azure voices (cached 5 min). |
+| `GET /chronicle` | Read the [Chronicle](#the-chronicle). Query params: `limit` (default 20, capped at 500), `q` (case-insensitive substring), `kind` (`you` / `spoken`). Returns `{entries, enabled}`, oldest-first — ready to display. |
+| `POST /respeak` | Play a Chronicle line again. Body `{"id": N}`; omit `id` to replay the last thing spoken. Returns `{ok, respeaking}`, or `404` on a bad id, an empty chronicle, or a full queue. |
+| `GET /api/version` | [realm-sigil](https://github.com/jphein/realm-sigil) version contract (git-derived, with a minimal fallback when realm-sigil isn't installed). |
 
 ```bash
 curl -X POST localhost:7710/speak -H 'Content-Type: application/json' \
@@ -327,6 +382,43 @@ that promotion is free — dropping older same-source items always leaves the
 newest, and the newest always gets spoken — so `kind: "progress"` is the same
 machinery under a name that reads better at the call site.
 
+## The Chronicle
+
+Speech is the one interface with no scrollback — you hear it once and it's gone. The
+Chronicle is an append-only ledger of everything said in both directions, so a line you
+half-caught is still there afterwards.
+
+Every final transcript is recorded as `kind: "you"`, and every utterance that actually
+played as `kind: "spoken"` (carrying its `voice` and `source`). One JSON object per line at
+`$XDG_STATE_HOME/gnome-speaks/chronicle.jsonl` (`~/.local/state/…` by default) — local
+only, never synced, never in git:
+
+```json
+{"kind": "you", "text": "how much battery is left", "ts": "2026-08-17T21:04:11-0700", "id": 1787025851000}
+{"kind": "spoken", "text": "The batteries hold 82 percent.", "ts": "2026-08-17T21:04:13-0700", "voice": "en-US-Ava:DragonHDLatestNeural", "source": "assistant", "id": 1787025853000}
+```
+
+Ids are millisecond timestamps, bumped on same-millisecond collisions, so they stay unique
+without a persistent counter. Writes are best-effort by design: a full disk logs a warning
+and must never take down the voice pipeline. A streamed AI reply is recorded as **one**
+entry rather than per-sentence — sentence-level shards would be useless to respeak.
+
+Five ways in:
+
+| Seam | Use |
+|---|---|
+| 📜 rune on the badge | Unfurls a scroll of the last 8 lines, newest first — green for you, violet for it. Click a line: it flares gold and respeaks. Click outside to dismiss. |
+| Panel menu → Chronicle | Submenu of the last 12 lines; click to hear one again. |
+| `GET /chronicle` · `POST /respeak` | Scripted access (see [HTTP API](#http-api)). |
+| `GetChronicle(limit)` · `Respeak(id)` | Same over D-Bus. `Respeak(0)` replays the last spoken line; `GetChronicle(0)` falls back to 20 entries. |
+| "cast echo" · "cast chronicle" · "cast seal the chronicle" | Replay the last line · recite the last three · stop/resume recording. |
+
+A respeak re-enters the normal speech queue rather than jumping it: a `spoken` line replays
+in its **original** voice, while a `you` line is read back in the current default voice.
+
+Recording is on by default and switchable in preferences ("Keep the Chronicle") or by
+voice; while sealed, nothing is written at all.
+
 ## Spiel provider
 
 gnome-speaks can register as a [Spiel](https://github.com/project-spiel) speech
@@ -344,12 +436,34 @@ The provider writes raw S16LE PCM to the client's pipe (the client owns
 playback, per Spiel's design), handles concurrent requests, and treats a
 closed pipe as cancellation. No SSML or word-event support is advertised.
 
-**Pointing Orca at it:** Orca ≥46 ships a Spiel backend, but note two traps:
-libspiel is not packaged on Ubuntu (build from source; make its typelib
-visible session-wide via `~/.config/environment.d/`), and Orca initializes
-speech *before* applying `speechServerFactory` from user settings — the
-reliable switch is `orca.settings.speechSystemOverride = "spiel"` in
-`~/.local/share/orca/orca-customizations.py`.
+**Pointing Orca at it:** Orca ≥46 ships a Spiel backend, but note two traps.
+
+First, libspiel is still not packaged on Ubuntu (26.04 included) — build from
+source and make its typelib visible session-wide via
+`~/.config/environment.d/`.
+
+Second, *how* you select the backend depends on your Orca version:
+
+- **Orca 50+** keeps settings in GSettings, and the old
+  `orca.settings.speechSystemOverride` hook **no longer exists** — an
+  `orca-customizations.py` that sets it is silently doing nothing. Use the
+  relocatable schema instead (an old `speechServerFactory` in your settings is
+  migrated to this key automatically):
+
+  ```bash
+  gsettings set "org.gnome.Orca.Speech:/org/gnome/orca/default/speech/" \
+      speech-server-factory spiel
+  ```
+
+  Valid values are `speechdispatcherfactory` (the default) and `spiel`. Note the
+  schema is relocatable, so the `:path` suffix is mandatory — plain
+  `gsettings set org.gnome.Orca.Speech …` errors out. Swap `default` for your
+  profile name if you use Orca profiles, and restart Orca.
+
+- **Orca 46–49** initializes speech *before* applying `speechServerFactory` from
+  user settings, so the reliable switch there is
+  `orca.settings.speechSystemOverride = "spiel"` in
+  `~/.local/share/orca/orca-customizations.py`.
 
 ## Voice Spellbook
 
@@ -364,14 +478,27 @@ Spells are data: the repo ships `spellbook.json` with the self-control spells;
 a user overlay at `~/.config/speech-to-cli/spellbook.json` merges over it by
 spell name and hot-reloads on save. POST spells can carry dictated
 text: `"remainder_field": "body"` injects the words spoken after the pattern
-into that body field, and `"reply"` speaks a fixed success line. The realm/oracle/home spells below are
-overlay examples — their endpoints are site-specific and never live in the repo.
+into that body field, and `"reply"` speaks a fixed success line.
+
+**Ships in the repo** (`spellbook.json`) — all self-control, no external endpoints:
 
 | Incantation | Effect |
 |---|---|
 | "cast silence" / "cast skip" | stop everything / skip current utterance |
 | "cast terminal mode" / "ai mode" / "type mode" | switch modes |
 | "cast read notifications" | toggle the notification herald |
+| "cast wake word" | arm or disarm the [waking watch](#wake-word) |
+| "cast deep thought" | toggle extended LLM thinking |
+| "cast subtitles" | toggle the caption overlay (writes both config and GSettings) |
+| "cast echo" | replay the last thing spoken |
+| "cast chronicle" | recite the last three [Chronicle](#the-chronicle) lines |
+| "cast seal the chronicle" | stop or resume recording the Chronicle |
+
+**Overlay examples** — these live in your own `~/.config/speech-to-cli/spellbook.json`
+because their endpoints are site-specific:
+
+| Incantation | Effect |
+|---|---|
 | "cast defense report" | combat-ward summary, spoken |
 | "cast my level" | character sheet from realm progression |
 | "cast recent events" | last 5 realm events, spoken |

--- a/docs/index.html
+++ b/docs/index.html
@@ -198,7 +198,7 @@ footer {
 
 <section class="wrap" id="features">
   <h2><span class="numeral">I.</span>What it does</h2>
-  <p class="sub">One floating badge, six ways to talk to your machine. The GNOME Shell extension handles only UI — audio, speech, and network live in a background service on the session bus.</p>
+  <p class="sub">One floating badge, seven ways to talk to your machine. The GNOME Shell extension handles only UI — audio, speech, and network live in a background service on the session bus.</p>
   <div class="grid">
     <div class="card">
       <div class="glyph">⌨️</div>
@@ -230,12 +230,17 @@ footer {
       <h3>A queue, not a shouting match</h3>
       <p>The local HTTP API serializes speech FIFO with per-utterance voices and outcome reporting — scripts and agents never cut each other off, and you always preempt.</p>
     </div>
+    <div class="card">
+      <div class="glyph">📜</div>
+      <h3>The Chronicle</h3>
+      <p>Speech is the one interface with no scrollback. Every line — yours and its — lands in a local ledger; unfurl the scroll from the badge and click any line to hear it again, or just say <code>cast echo</code>.</p>
+    </div>
   </div>
 </section>
 
 <section class="wrap" id="quickstart">
   <h2><span class="numeral">II.</span>Quickstart</h2>
-  <p class="sub">GNOME Shell 46–48. Azure Speech key required for cloud voices; the sibling <a href="https://github.com/techempower-org/speech-to-cli">speech-to-cli</a> engine provides audio and STT/TTS.</p>
+  <p class="sub">GNOME Shell 46–50, Ubuntu 26.04 LTS included. Azure Speech key required for cloud voices; the sibling <a href="https://github.com/techempower-org/speech-to-cli">speech-to-cli</a> engine provides audio and STT/TTS.</p>
   <pre class="block"><span class="c"># clone the extension and its engine side by side</span>
 git clone https://github.com/techempower-org/gnome-speaks
 git clone https://github.com/techempower-org/speech-to-cli
@@ -271,7 +276,7 @@ curl -X POST localhost:7710/speak -H 'Content-Type: application/json' \
   <div class="wrap footcols">
     <div>
       <h4>GNOME Speaks</h4>
-      <p>GPL-3.0-or-later.<br>Built for GNOME Shell 46–48.</p>
+      <p>GPL-3.0-or-later.<br>Built for GNOME Shell 46–50.</p>
     </div>
     <div>
       <h4>Ecosystem</h4>


### PR DESCRIPTION
Documentation drift audit + refresh against everything shipped since the prefs redesign. **Every claim was re-derived from source and from the live system** (GNOME Shell 50.1, Orca 50.2, Ubuntu 26.04) rather than from the older docs.

## The one that matters most

The README told users to set `orca.settings.speechSystemOverride = "spiel"` in `orca-customizations.py`. **That symbol no longer exists in Orca 50** — `grep -rn speechSystemOverride /usr/lib/python3/dist-packages/orca/` returns nothing, so anyone following that advice edits a file that does nothing and concludes the Spiel provider is broken. Replaced with the verified GSettings seam:

```bash
gsettings set "org.gnome.Orca.Speech:/org/gnome/orca/default/speech/" speech-server-factory spiel
```

Relocatable schema, so the `:path` suffix is mandatory — plain `gsettings set org.gnome.Orca.Speech …` errors out. Values are `speechdispatcherfactory` (default) | `spiel` per `speech_manager.py:66`; an old `speechServerFactory` migrates automatically. The 46–49 advice is kept, labelled as version-specific. The *other* half of that note — libspiel unpackaged on Ubuntu — I re-checked and it still holds on 26.04, so it stands.

## Undocumented shipped features, now documented

- **The Chronicle** — entirely absent from the docs. New README section: ledger path, entry shape, the ms-timestamp id scheme, best-effort writes, why a streamed reply is one entry and not per-sentence shards, and all five access seams (📜 badge rune, panel submenu, `GET /chronicle`, `POST /respeak`, `GetChronicle`/`Respeak`, the three spells).
- **Prosody** — `speed`/`pitch`/`volume`, including that the rate *composes* with Fast mode's +15% instead of being discarded by it (#17), and that pitch/volume are passthrough-sanitized so `+10%` works.
- **Per-voice subtitles** — `subtitles_user`/`subtitles_tts` with their colors, plus the scope nobody had written down: subtitles are a conversation-mode surface.
- **HTTP API** — table was missing `GET /chronicle`, `POST /respeak`, and `GET /api/version`.
- **Spellbook table** — listed 5 repo spells mixed with overlay examples; `spellbook.json` actually ships **12**. Split into "ships in the repo" vs "overlay examples".
- **GNOME 50** — requirements said 46–48 while `metadata.json` declares 46–50. Installer's import-based dependency check and PEP 668 fallback documented; `pack.sh`/EGO zip documented.

## CLAUDE.md

Architecture table line counts were 20–45% off and `prefs.js` was still described as a 10-page window three commits after the 10→6 redesign; `spiel_provider.py` was missing entirely. Added six gotchas that cost real debugging time and were only in commit messages: dead `--nested` on 50, `addTopChrome`'s rejected `affectsInputRegion`, St rendering only one box-shadow, deprecated `log()`, the `PopupSubMenu.open()` empty-submenu deadlock, and the merge-on-write save contract. Also **scoped** the `load_config()` whitelist gotcha — it binds only keys the Python side reads, so the absence of `subtitles_user` from `state.py` is correct and shouldn't be "fixed".

## Verification & safety

- Two claims in my own assignment brief turned out to be wrong; both are corrected in the findings file rather than propagated.
- Self-caught two errors in my own drafts: `Respeak` treats **0** (not -1) as "last spoken", and the JSON example's key order didn't match what the writer emits.
- All six internal README anchors resolve against actual headings.
- Leak scan `the LAN Wyoming host|<wake-word>|<lan-ip>|<site-domain>\.in` over `main...HEAD` → **0**. No LAN hostnames, IPs, domains, or the wake-word model name; generic placeholders throughout. `docs/index.html` keeps its established design language.
- `docs/superpowers/{plans,specs}/*.md` deliberately untouched — dated point-in-time records; rewriting them would falsify the history. Checked the highest-risk one for the dead Orca advice: not present.

Findings table (doc → claim → reality → fixed?): `~/.claude/projects/-home-jp/scratch/gnome-speaks-dreamteam/nebula-docs-drift.md`

**Docs only — no code changed. Not merging; orchestrator reviews.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for GNOME 50 support, installation, packaging, and runtime compatibility.
  * Documented Chronicle speech history, replay controls, subtitle settings, voice spells, and service endpoints.
  * Expanded architecture, configuration, version reporting, and headless testing instructions.
  * Updated the feature overview and quickstart to include the Chronicle feature and GNOME Shell versions through 50.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
