### PR TITLE
fix: GNOME 50 deprecation sweep

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -18,6 +18,30 @@ import Meta from 'gi://Meta';
 import Shell from 'gi://Shell';
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
+// St.BoxLayout:vertical was deprecated in GNOME 48 in favour of :orientation,
+// and upstream has it slated for removal. :orientation does not exist before
+// 48, and metadata.json still claims 46/47 — so detect once at load and let
+// every box construction speak whichever dialect this shell understands.
+// `pack-start` is already gone in GNOME 50; `vertical` is next.
+const HAS_ORIENTATION = 'orientation' in St.BoxLayout.prototype;
+
+/**
+ * Construct-time orientation props for an St.BoxLayout, portable across 46-50.
+ *
+ * @param {boolean} vertical - true for a column, false for a row
+ * @returns {object} props to spread into the St.BoxLayout constructor
+ */
+function boxOrientation(vertical) {
+    if (HAS_ORIENTATION) {
+        return {
+            orientation: vertical
+                ? Clutter.Orientation.VERTICAL
+                : Clutter.Orientation.HORIZONTAL,
+        };
+    }
+    return {vertical};
+}
+
 const DBUS_NAME = 'org.gnome.Speaks';
 const DBUS_PATH = '/org/gnome/Speaks';
 const DBUS_INTERFACE = 'org.gnome.Speaks';
@@ -499,7 +523,7 @@ export default class GnomeSpeaksExtension extends Extension {
             track_hover: true,
             x_align: Clutter.ActorAlign.CENTER,
             y_align: Clutter.ActorAlign.CENTER,
-            vertical: false,
+            ...boxOrientation(false),
         });
 
         this._badge.add_child(this._icon);
@@ -604,7 +628,7 @@ export default class GnomeSpeaksExtension extends Extension {
             style_class: 'gnome-speaks-waveform-wrapper',
             reactive: false,
             can_focus: false,
-            vertical: true,
+            ...boxOrientation(true),
             opacity: 0,
         });
 
@@ -613,13 +637,13 @@ export default class GnomeSpeaksExtension extends Extension {
         this._waveformBarsTop = [];
         this._waveformRowTop = new St.BoxLayout({
             style_class: 'gnome-speaks-waveform',
-            vertical: false,
+            ...boxOrientation(false),
             y_align: Clutter.ActorAlign.END, // bars grow downward from bottom of top row
         });
         this._waveformRowTop.set_height(24);
         this._waveformRow = new St.BoxLayout({
             style_class: 'gnome-speaks-waveform',
-            vertical: false,
+            ...boxOrientation(false),
             y_align: Clutter.ActorAlign.START, // bars grow upward from top of bottom row
         });
         this._waveformRow.set_height(24);
@@ -822,7 +846,7 @@ export default class GnomeSpeaksExtension extends Extension {
     _createSubtitleOverlay() {
         this._subtitleOverlay = new St.BoxLayout({
             style_class: 'gnome-speaks-subtitle-overlay',
-            vertical: true,
+            ...boxOrientation(true),
             reactive: false,
             x_align: Clutter.ActorAlign.CENTER,
             y_align: Clutter.ActorAlign.END,
@@ -2274,7 +2298,7 @@ export default class GnomeSpeaksExtension extends Extension {
         this._destroyContextMenu();
 
         this._contextMenu = new St.BoxLayout({
-            vertical: true,
+            ...boxOrientation(true),
             style_class: 'popup-menu-content',
             style: 'background-color: rgba(40,40,40,0.95); border-radius: 12px; padding: 8px 0; min-width: 200px;',
             reactive: true,
@@ -2433,7 +2457,7 @@ export default class GnomeSpeaksExtension extends Extension {
         this._destroyContextMenu();
 
         let scroll = new St.BoxLayout({
-            vertical: true,
+            ...boxOrientation(true),
             style_class: 'gnome-speaks-chronicle-scroll',
             reactive: true,
         });

--- a/prefs.js
+++ b/prefs.js
@@ -981,14 +981,17 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
     }
 
     _addCorrectionsRow(group) {
-        const corrections = this._config['auto_corrections'] || {};
-        const text = Object.entries(corrections)
+        // Read from this._config on every open, not once at page-build time:
+        // _setConfigValue() mutates this._config in place, so a captured
+        // snapshot would re-show pre-save text the second time you edit.
+        const asText = () => Object.entries(this._config['auto_corrections'] || {})
             .map(([wrong, right]) => `${wrong}=${right}`)
             .join('\n');
+        const summary = n => `${n} defined — fix words it always mishears (wrong=right)`;
 
         const row = new Adw.ActionRow({
             title: 'Word Corrections',
-            subtitle: `${Object.keys(corrections).length} defined — fix words it always mishears (wrong=right)`,
+            subtitle: summary(Object.keys(this._config['auto_corrections'] || {}).length),
         });
 
         const editButton = new Gtk.Button({
@@ -997,11 +1000,13 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         });
 
         editButton.connect('clicked', () => {
-            const dialog = new Gtk.Dialog({
-                title: 'Auto-Corrections',
-                modal: true,
-                default_width: 400,
-                default_height: 300,
+            // Adw.AlertDialog, not Gtk.Dialog: Gtk.Dialog is deprecated since
+            // GTK 4.10, and the old call also presented without a parent, so
+            // the "modal" editor floated free of the prefs window. Mirrors the
+            // shortcut editor below.
+            const dialog = new Adw.AlertDialog({
+                heading: 'Auto-Corrections',
+                body: 'One correction per line: wrong=right',
             });
 
             const textView = new Gtk.TextView({
@@ -1013,45 +1018,39 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
                 left_margin: 8,
                 right_margin: 8,
             });
-            textView.buffer.set_text(text, -1);
+            textView.buffer.set_text(asText(), -1);
 
-            const scrolled = new Gtk.ScrolledWindow({
+            dialog.set_extra_child(new Gtk.ScrolledWindow({
                 child: textView,
                 vexpand: true,
                 hexpand: true,
-            });
+                width_request: 380,
+                height_request: 260,
+            }));
 
-            const box = dialog.get_content_area();
-            const label = new Gtk.Label({
-                label: 'One correction per line: wrong=right',
-                halign: Gtk.Align.START,
-                margin_start: 8,
-                margin_top: 8,
-            });
-            box.append(label);
-            box.append(scrolled);
-
-            dialog.add_button('Cancel', Gtk.ResponseType.CANCEL);
-            dialog.add_button('Save', Gtk.ResponseType.OK);
+            dialog.add_response('cancel', 'Cancel');
+            dialog.add_response('save', 'Save');
+            dialog.set_response_appearance('save', Adw.ResponseAppearance.SUGGESTED);
+            dialog.set_default_response('save');
+            dialog.set_close_response('cancel');
 
             dialog.connect('response', (dlg, response) => {
-                if (response === Gtk.ResponseType.OK) {
-                    let [start, end] = textView.buffer.get_bounds();
-                    let newText = textView.buffer.get_text(start, end, false);
-                    let newCorrections = {};
-                    for (let line of newText.split('\n')) {
-                        line = line.trim();
-                        if (!line || !line.includes('=')) continue;
-                        let [wrong, ...rightParts] = line.split('=');
-                        newCorrections[wrong.trim()] = rightParts.join('=').trim();
-                    }
-                    this._setConfigValue('auto_corrections', newCorrections);
-                    row.subtitle = `${Object.keys(newCorrections).length} defined — fix words it always mishears (wrong=right)`;
+                if (response !== 'save')
+                    return;
+                let [start, end] = textView.buffer.get_bounds();
+                let newText = textView.buffer.get_text(start, end, false);
+                let newCorrections = {};
+                for (let line of newText.split('\n')) {
+                    line = line.trim();
+                    if (!line || !line.includes('=')) continue;
+                    let [wrong, ...rightParts] = line.split('=');
+                    newCorrections[wrong.trim()] = rightParts.join('=').trim();
                 }
-                dlg.destroy();
+                this._setConfigValue('auto_corrections', newCorrections);
+                row.subtitle = summary(Object.keys(newCorrections).length);
             });
 
-            dialog.present();
+            dialog.present(group.get_root());
         });
 
         row.add_suffix(editButton);


### PR DESCRIPTION
Deprecation / API-drift sweep of `extension.js` + `prefs.js` against GNOME Shell **50.1** (Ubuntu 26.04), on top of the port in `a30a790`.

Two real deprecations, plus one latent bug found in the block being rewritten. Everything else on the GNOME 47/48/49/50 removal lists came back clean — the port was thorough.

## 1. `St.BoxLayout:vertical` → `:orientation` (7 sites)

Evidence it's real, from two independent directions:

- **Introspection against the live St-18 typelib**: `vertical` flags = `3221225699`, `orientation` flags = `1073742051`. The delta is exactly `2147483648` = `G_PARAM_DEPRECATED`.
- **gjs.guide (Shell 48 API changes)**: *"The `vertical` property of St widgets is deprecated and will be removed in a future GNOME Shell release (potentially version 50)."*
- Sibling property `pack-start` is **already gone** from St.BoxLayout in 50.
- GNOME 50's own shell JS (all 160 files extracted from `libshell-18.so`) uses `vertical:` **zero** times.

`metadata.json` still declares 46–50 and `orientation` doesn't exist before 48, so this **feature-detects once at module load** rather than rewriting blind, which would break 46/47.

## 2. `Gtk.Dialog` → `Adw.AlertDialog` (auto-corrections editor)

Deprecated since GTK 4.10; last deprecated GTK widget in `prefs.js`. The shortcut editor 20 lines below already used `Adw.AlertDialog`, so this was drift. No new dependency floor — `Adw.AlertDialog` is libadwaita 1.5 (GNOME 46) and was already used unguarded.

Two fixes ride along:
- The dialog was `modal: true` but `present()`ed **with no parent**, so it floated free of the prefs window.
- `_addCorrectionsRow` captured the corrections text **once at page-build time**, but `_setConfigValue` mutates `this._config` in place — so reopening the editor after a save showed pre-save text, and saving again silently reverted the edit.

## Verified clean (no change needed)

`Meta.Rectangle`, `Clutter.ClickAction`/`TapAction`, `Meta.Window.get_maximized`, `set_pointer_visible`, `Clutter.Image`, `releaseKeyboard`/`holdKeyboard`, `show-restart-message`, `Lang`/`Mainloop`/`imports.*`/`ExtensionUtils`/`byteArray`, global `log()`/`logError()`, `add_actor`/`remove_actor`, all `Clutter` enums, all `PopupMenu`/`PanelMenu` classes, all Adw widgets in use (none deprecated in Adw 1.9), multi-value `box-shadow`.

Notably **not** changed: `Adw.PreferencesWindow` + `window.add(page)` is correct — GNOME 50's own `ExtensionPreferences.fillPreferencesWindow` still passes an `Adw.PreferencesWindow` (verified by extracting the shell's own `prefs.js`).

## Verification

- `node --check` clean on both files.
- Headless probe on GNOME 50.1 — branch vs. shipped `main` vs. a control with the extension removed — each in its own `dbus-run-session` with an isolated `XDG_DATA_HOME`. (`--nested` is gone in 50.)
- **Positive load proof**: `org.gnome.Speaks` appears on the isolated bus in the `main` and branch runs and *not* in the control, so the extension genuinely loaded and enabled in both rather than being silently skipped.
- **0 JS errors** in every run.
- The installed copy in `~/.local/share` was used read-only and re-verified byte-identical to `main` afterwards.

### One caveat, stated plainly

A headless run **cannot** exercise the badge drag, context menu, chronicle scroll, or the prefs dialogs — there's no user input. The orientation change rests on `vertical` being a deprecated alias of `orientation`, which the flag arithmetic supports but which I did not confirm by eye. **Please open the prefs window and the badge menu before merging.**

Also worth knowing: gnome-speaks currently reports `state: 4` (OUT_OF_DATE) in the live session. That predates this branch — the shell caches `metadata.json` at login, and the GNOME-50 metadata landed after the current session started. A logout/login clears it; nothing in the repo is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)