### PR TITLE
feat: keyboard + screen-reader access for the badge, pills and Chronicle

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -9,6 +9,7 @@
 
 import GLib from 'gi://GLib';
 import St from 'gi://St';
+import Atk from 'gi://Atk';
 import Clutter from 'gi://Clutter';
 import Gio from 'gi://Gio';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
@@ -182,24 +183,30 @@ const STATE_CONFIG = {
         label: '',
         styleClass: 'gnome-speaks-idle',
         showLabel: false,
+        // What a screen reader says instead of the icon. The badge's own
+        // label is empty while idle, so without this it announces nothing.
+        accessibleName: 'GNOME Speaks — idle, activate to start listening',
     },
     [States.LISTENING]: {
         iconName: 'audio-input-microphone-symbolic',
         label: 'Listening...',
         styleClass: 'gnome-speaks-listening',
         showLabel: true,
+        accessibleName: 'GNOME Speaks — listening, activate to stop',
     },
     [States.PROCESSING]: {
         iconName: 'process-working-symbolic',
         label: 'Processing...',
         styleClass: 'gnome-speaks-processing',
         showLabel: true,
+        accessibleName: 'GNOME Speaks — processing, activate to cancel',
     },
     [States.SPEAKING]: {
         iconName: 'audio-speakers-symbolic',
         label: 'Speaking...',
         styleClass: 'gnome-speaks-speaking',
         showLabel: true,
+        accessibleName: 'GNOME Speaks — speaking, activate to stop',
     },
 };
 
@@ -249,6 +256,13 @@ export default class GnomeSpeaksExtension extends Extension {
         this._wordHighlights = [];
         this._pendingPartialMarkup = null;
         this._lastVadTime = 0;
+        // Focus bookkeeping for the popups: the rows we can walk with the
+        // arrows, and the actor that gets focus back when they close.
+        this._chronicleLines = [];
+        this._chronicleFocusReturn = null;
+        this._contextMenuItems = [];
+        this._contextFocusReturn = null;
+        this._ctrlAltTabRegistered = false;
         this._settings = this.getSettings();
 
         // Restore persisted badge position
@@ -524,6 +538,8 @@ export default class GnomeSpeaksExtension extends Extension {
             x_align: Clutter.ActorAlign.CENTER,
             y_align: Clutter.ActorAlign.CENTER,
             ...boxOrientation(false),
+            accessible_role: Atk.Role.PUSH_BUTTON,
+            accessible_name: STATE_CONFIG[States.IDLE].accessibleName,
         });
 
         this._badge.add_child(this._icon);
@@ -534,10 +550,14 @@ export default class GnomeSpeaksExtension extends Extension {
         this._continuousMode = false;
         this._terminalMode = false;
 
-        this._qualityPill = this._createPill('✦', 'gnome-speaks-quality-hd', () => this._toggleVoiceQuality());
-        this._modePill = this._createPill('✏️', 'gnome-speaks-mode-dict', () => this._toggleMode());
-        this._continuousPill = this._createPill('🔄', 'gnome-speaks-pill-off', () => this._toggleContinuous());
-        this._terminalPill = this._createPill('>', 'gnome-speaks-pill-off', () => this._toggleTerminal());
+        this._qualityPill = this._createPill('✦', 'gnome-speaks-quality-hd',
+            'Voice quality', () => this._toggleVoiceQuality());
+        this._modePill = this._createPill('✏️', 'gnome-speaks-mode-dict',
+            'Speech mode', () => this._toggleMode());
+        this._continuousPill = this._createPill('🔄', 'gnome-speaks-pill-off',
+            'Continuous dictation', () => this._toggleContinuous());
+        this._terminalPill = this._createPill('>', 'gnome-speaks-pill-off',
+            'Terminal mode', () => this._toggleTerminal());
 
         this._badge.add_child(this._qualityPill);
         this._badge.add_child(this._modePill);
@@ -548,7 +568,8 @@ export default class GnomeSpeaksExtension extends Extension {
         // pills come and go with activity, but the ledger of what was said
         // is exactly what you reach for while idle, so it never hides.
         this._chroniclePill = this._createPill('📜', 'gnome-speaks-pill-chronicle',
-            () => this._toggleChronicleScroll());
+            'The Chronicle — recent speech',
+            fromKeyboard => this._toggleChronicleScroll(fromKeyboard));
         this._badge.add_child(this._chroniclePill);
 
         this._pills = [this._qualityPill, this._modePill, this._continuousPill, this._terminalPill];
@@ -560,7 +581,7 @@ export default class GnomeSpeaksExtension extends Extension {
         let pressId = this._badge.connect('button-press-event', (actor, event) => {
             let button = event.get_button();
             if (button === 3) {
-                this._showContextMenu(event);
+                this._showContextMenu();
                 return Clutter.EVENT_STOP;
             }
             if (button === 1) {
@@ -621,6 +642,40 @@ export default class GnomeSpeaksExtension extends Extension {
             return Clutter.EVENT_STOP;
         });
         this._signals.push({obj: this._badge, id: releaseId});
+
+        let keyId = this._badge.connect('key-press-event', (actor, event) => {
+            let symbol = event.get_key_symbol();
+
+            // Escape furls whatever is open, from anywhere in the badge —
+            // including while a pill holds focus, which is exactly where a
+            // keyboard user is standing when they open the Chronicle.
+            if (symbol === Clutter.KEY_Escape) {
+                if (this._chronicleScroll || this._contextMenu) {
+                    this._destroyChronicleScroll();
+                    this._destroyContextMenu();
+                    return Clutter.EVENT_STOP;
+                }
+                return Clutter.EVENT_PROPAGATE;
+            }
+
+            // Everything else belongs to the focused actor. A focused pill is
+            // an St.Button and answers Enter/Space itself; the badge must not
+            // reach past it and start listening on the same keystroke.
+            if (!actor.has_key_focus())
+                return Clutter.EVENT_PROPAGATE;
+
+            if (symbol === Clutter.KEY_Return || symbol === Clutter.KEY_KP_Enter ||
+                symbol === Clutter.KEY_space) {
+                this._onBadgeClicked();
+                return Clutter.EVENT_STOP;
+            }
+            if (symbol === Clutter.KEY_Menu) {
+                this._showContextMenu(true);
+                return Clutter.EVENT_STOP;
+            }
+            return Clutter.EVENT_PROPAGATE;
+        });
+        this._signals.push({obj: this._badge, id: keyId});
 
         // Waveform + timeout — vertical stack below badge
         this._waveformLevels = new Array(32).fill(0);
@@ -690,6 +745,19 @@ export default class GnomeSpeaksExtension extends Extension {
         Main.layoutManager.addTopChrome(this._badge, {
             trackFullscreen: false,
         });
+
+        // Chrome is invisible to the keyboard unless it joins the
+        // Ctrl+Alt+Tab ring — focusable pills are worth nothing if there is
+        // no door into the badge. Guarded: a shell that ever renames this
+        // manager should cost us a keyboard shortcut, not the extension.
+        try {
+            Main.ctrlAltTabManager.addGroup(this._badge, 'GNOME Speaks',
+                'audio-input-microphone-symbolic');
+            this._ctrlAltTabRegistered = true;
+        } catch (e) {
+            this._ctrlAltTabRegistered = false;
+            console.debug(`[GNOME Speaks] Ctrl+Alt+Tab registration skipped: ${e.message}`);
+        }
     }
 
     _endDrag() {
@@ -722,7 +790,9 @@ export default class GnomeSpeaksExtension extends Extension {
     _updateQualityPill() {
         if (!this._qualityPill) return;
         let isHD = this._voiceQuality === 'hd';
-        this._qualityPill.text = isHD ? '✦ HD' : '⚡ Fast';
+        this._setPillState(this._qualityPill, isHD ? '✦ HD' : '⚡ Fast',
+            isHD ? 'Voice quality: HD — activate for Fast'
+                : 'Voice quality: Fast — activate for HD');
         this._qualityPill.remove_style_class_name(
             isHD ? 'gnome-speaks-quality-fast' : 'gnome-speaks-quality-hd');
         this._qualityPill.add_style_class_name(
@@ -747,22 +817,42 @@ export default class GnomeSpeaksExtension extends Extension {
         });
     }
 
-    _createPill(text, styleClass, onClick) {
-        let pill = new St.Label({
+    // A pill is a real button, not a painted label: St.Button carries key
+    // focus, Enter/Space activation and an AT-SPI push-button role for free
+    // — the same things a screen reader needs to see it at all. The child
+    // label is explicit so text metrics and alignment stay exactly where the
+    // St.Label version put them; the visual identity must not move.
+    _createPill(text, styleClass, accessibleName, onActivate) {
+        let label = new St.Label({
             text: text,
-            style_class: styleClass,
-            reactive: true,
-            track_hover: true,
             y_align: Clutter.ActorAlign.CENTER,
             x_align: Clutter.ActorAlign.CENTER,
         });
-        pill.connect('button-release-event', (actor, event) => {
-            if (event.get_button() !== 1) return Clutter.EVENT_PROPAGATE;
-            onClick();
-            return Clutter.EVENT_STOP;
+        let pill = new St.Button({
+            style_class: styleClass,
+            child: label,
+            reactive: true,
+            can_focus: true,
+            track_hover: true,
+            y_align: Clutter.ActorAlign.CENTER,
+            x_align: Clutter.ActorAlign.CENTER,
+            accessible_name: accessibleName,
         });
-        pill.connect('button-press-event', () => Clutter.EVENT_STOP);
+        pill._pillLabel = label;
+        pill.connect('clicked', (actor, button) => {
+            // St.Button reports button 0 for keyboard activation — the only
+            // honest signal of "this came from the keyboard", which the
+            // Chronicle needs so it only steals focus when a keyboard asked.
+            onActivate(button === 0);
+        });
         return pill;
+    }
+
+    _setPillState(pill, text, accessibleName) {
+        if (!pill) return;
+        if (pill._pillLabel)
+            pill._pillLabel.text = text;
+        pill.accessible_name = accessibleName;
     }
 
     _toggleContinuous() {
@@ -783,7 +873,9 @@ export default class GnomeSpeaksExtension extends Extension {
     _updateContinuousPill() {
         if (!this._continuousPill) return;
         let on = this._continuousMode;
-        this._continuousPill.text = on ? '🔄 Loop' : '🔄';
+        this._setPillState(this._continuousPill, on ? '🔄 Loop' : '🔄',
+            on ? 'Continuous dictation: on — activate to stop looping'
+                : 'Continuous dictation: off — activate to loop');
         this._continuousPill.remove_style_class_name(on ? 'gnome-speaks-pill-off' : 'gnome-speaks-pill-on');
         this._continuousPill.add_style_class_name(on ? 'gnome-speaks-pill-on' : 'gnome-speaks-pill-off');
     }
@@ -804,7 +896,9 @@ export default class GnomeSpeaksExtension extends Extension {
     _updateTerminalPill() {
         if (!this._terminalPill) return;
         let on = this._terminalMode;
-        this._terminalPill.text = on ? '> Term' : '>';
+        this._setPillState(this._terminalPill, on ? '> Term' : '>',
+            on ? 'Terminal mode: on — activate to turn off'
+                : 'Terminal mode: off — activate to turn on');
         this._terminalPill.remove_style_class_name(on ? 'gnome-speaks-pill-off' : 'gnome-speaks-pill-on');
         this._terminalPill.add_style_class_name(on ? 'gnome-speaks-pill-on' : 'gnome-speaks-pill-off');
     }
@@ -1090,7 +1184,9 @@ export default class GnomeSpeaksExtension extends Extension {
     _updateModePill() {
         if (!this._modePill) return;
         let isChat = this._conversationMode;
-        this._modePill.text = isChat ? '🤖 AI' : '✏️ Type';
+        this._setPillState(this._modePill, isChat ? '🤖 AI' : '✏️ Type',
+            isChat ? 'Mode: AI chat — activate to switch to typing'
+                : 'Mode: typing — activate to switch to AI chat');
         this._modePill.remove_style_class_name(
             isChat ? 'gnome-speaks-mode-dict' : 'gnome-speaks-mode-chat');
         this._modePill.add_style_class_name(
@@ -1137,6 +1233,14 @@ export default class GnomeSpeaksExtension extends Extension {
         }
 
         if (this._badge) {
+            if (this._ctrlAltTabRegistered) {
+                try {
+                    Main.ctrlAltTabManager.removeGroup(this._badge);
+                } catch (e) {
+                    // Shell already dropped it (badge destroy does this too)
+                }
+                this._ctrlAltTabRegistered = false;
+            }
             this._badge.remove_all_transitions();
             Main.layoutManager.removeChrome(this._badge);
             this._badge.destroy();
@@ -1148,6 +1252,7 @@ export default class GnomeSpeaksExtension extends Extension {
         this._modePill = null;
         this._continuousPill = null;
         this._terminalPill = null;
+        this._chroniclePill = null;
         this._pills = null;
     }
 
@@ -1674,6 +1779,7 @@ export default class GnomeSpeaksExtension extends Extension {
         }
         this._badge.remove_style_class_name('gnome-speaks-error');
         this._badge.add_style_class_name(config.styleClass);
+        this._badge.accessible_name = config.accessibleName;
 
         // Update waveform bar color for state
         if (this._waveformBars) {
@@ -2293,15 +2399,34 @@ export default class GnomeSpeaksExtension extends Extension {
         this._trackTimeout(timeoutId, 'audio-pulse-resume');
     }
 
-    _showContextMenu(event) {
+    _showContextMenu(fromKeyboard = false) {
         if (!this._badge) return;
         this._destroyContextMenu();
+
+        this._contextFocusReturn = fromKeyboard ? this._badge : null;
+        this._contextMenuItems = [];
 
         this._contextMenu = new St.BoxLayout({
             ...boxOrientation(true),
             style_class: 'popup-menu-content',
             style: 'background-color: rgba(40,40,40,0.95); border-radius: 12px; padding: 8px 0; min-width: 200px;',
             reactive: true,
+            can_focus: true,
+            accessible_role: Atk.Role.MENU,
+            accessible_name: 'GNOME Speaks actions',
+        });
+
+        this._contextMenu.connect('key-press-event', (actor, keyEvent) => {
+            let symbol = keyEvent.get_key_symbol();
+            if (symbol === Clutter.KEY_Escape) {
+                this._destroyContextMenu();
+                return Clutter.EVENT_STOP;
+            }
+            if (symbol === Clutter.KEY_Down || symbol === Clutter.KEY_Tab)
+                return this._moveContextMenuFocus(1);
+            if (symbol === Clutter.KEY_Up || symbol === Clutter.KEY_ISO_Left_Tab)
+                return this._moveContextMenuFocus(-1);
+            return Clutter.EVENT_PROPAGATE;
         });
 
         let titleItem = new St.Label({
@@ -2355,6 +2480,9 @@ export default class GnomeSpeaksExtension extends Extension {
 
         Main.layoutManager.addTopChrome(this._contextMenu);
 
+        if (this._contextFocusReturn && this._contextMenuItems.length > 0)
+            this._contextMenuItems[0].grab_key_focus();
+
         // Position menu above the badge
         let [badgeX, badgeY] = this._badge.get_transformed_position();
         let badgeWidth = this._badge.get_width();
@@ -2404,29 +2532,50 @@ export default class GnomeSpeaksExtension extends Extension {
     }
 
     _createMenuItem(text, callback) {
-        let item = new St.Label({
-            text: text,
-            style: 'padding: 8px 16px; color: white; font-size: 14px;',
+        const BASE = 'padding: 8px 16px; color: white; font-size: 14px;';
+        const LIT = `${BASE} background-color: rgba(255,255,255,0.1);`;
+
+        let item = new St.Button({
+            child: new St.Label({
+                text: text,
+                x_align: Clutter.ActorAlign.START,
+                x_expand: true,
+            }),
+            style: BASE,
             reactive: true,
+            can_focus: true,
             track_hover: true,
+            x_expand: true,
+            accessible_name: text,
         });
 
-        item.connect('enter-event', () => {
-            item.set_style('padding: 8px 16px; color: white; font-size: 14px; background-color: rgba(255,255,255,0.1);');
-            return Clutter.EVENT_PROPAGATE;
-        });
+        // One highlight, two ways to earn it — the keyboard must light the
+        // row it is standing on exactly like the pointer does.
+        let relight = () => item.set_style(
+            item.hover || item.has_key_focus() ? LIT : BASE);
+        item.connect('notify::hover', relight);
+        item.connect('key-focus-in', relight);
+        item.connect('key-focus-out', relight);
+        item.connect('clicked', () => callback());
 
-        item.connect('leave-event', () => {
-            item.set_style('padding: 8px 16px; color: white; font-size: 14px;');
-            return Clutter.EVENT_PROPAGATE;
-        });
-
-        item.connect('button-release-event', () => {
-            callback();
-            return Clutter.EVENT_STOP;
-        });
+        // The open menu keeps its own focus ring order; this factory only
+        // ever builds rows for it, so registering here beats four call sites.
+        if (this._contextMenuItems)
+            this._contextMenuItems.push(item);
 
         return item;
+    }
+
+    _moveContextMenuFocus(delta) {
+        let items = this._contextMenuItems;
+        if (!items || items.length === 0)
+            return Clutter.EVENT_STOP;
+        let current = items.findIndex(i => i.has_key_focus());
+        let next = current < 0
+            ? (delta > 0 ? 0 : items.length - 1)
+            : (current + delta + items.length) % items.length;
+        items[next].grab_key_focus();
+        return Clutter.EVENT_STOP;
     }
 
     _destroyContextMenu() {
@@ -2435,33 +2584,71 @@ export default class GnomeSpeaksExtension extends Extension {
             this._menuGrabId = null;
         }
 
+        let returnTo = this._contextFocusReturn;
+        this._contextFocusReturn = null;
+        this._contextMenuItems = [];
+
         if (this._contextMenu) {
-            Main.layoutManager.removeChrome(this._contextMenu);
-            this._contextMenu.destroy();
+            let menu = this._contextMenu;
             this._contextMenu = null;
+
+            // Same rule as the Chronicle: hand focus back only if the menu
+            // still holds it.
+            let focused = global.stage.get_key_focus();
+            let hadFocus = focused && (focused === menu || menu.contains(focused));
+
+            Main.layoutManager.removeChrome(menu);
+            menu.destroy();
+
+            if (hadFocus && returnTo && !this._destroyed && this._badge)
+                returnTo.grab_key_focus();
         }
     }
 
     // -- The Chronicle scroll (OSD popup off the 📜 pill) -------------------
 
-    _toggleChronicleScroll() {
+    _toggleChronicleScroll(fromKeyboard = false) {
         if (this._chronicleScroll)
             this._destroyChronicleScroll();
         else
-            this._showChronicleScroll();
+            this._showChronicleScroll(fromKeyboard);
     }
 
-    _showChronicleScroll() {
+    _showChronicleScroll(fromKeyboard = false) {
         if (!this._badge || this._destroyed)
             return;
         this._destroyContextMenu();
+
+        // Only a keyboard-opened scroll takes key focus. A mouse click on
+        // chrome must never pull focus out of whatever the user was typing
+        // in — but a keyboard user who can't reach the lines has no scroll.
+        this._chronicleFocusReturn = fromKeyboard ? this._chroniclePill : null;
+        this._chronicleLines = [];
 
         let scroll = new St.BoxLayout({
             ...boxOrientation(true),
             style_class: 'gnome-speaks-chronicle-scroll',
             reactive: true,
+            can_focus: true,
+            accessible_role: Atk.Role.PANEL,
+            accessible_name: 'The Chronicle — recent speech',
         });
         this._chronicleScroll = scroll;
+
+        // Key handling lives on the container: key events bubble up from the
+        // focused line, so one handler covers every line plus the empty case.
+        scroll.connect('key-press-event', (actor, event) => {
+            let symbol = event.get_key_symbol();
+            if (symbol === Clutter.KEY_Escape) {
+                this._destroyChronicleScroll();
+                return Clutter.EVENT_STOP;
+            }
+            if (symbol === Clutter.KEY_Down || symbol === Clutter.KEY_Tab)
+                return this._moveChronicleFocus(1);
+            if (symbol === Clutter.KEY_Up || symbol === Clutter.KEY_ISO_Left_Tab)
+                return this._moveChronicleFocus(-1);
+            return Clutter.EVENT_PROPAGATE;
+        });
 
         let header = new St.Label({
             text: '📜  The Chronicle',
@@ -2509,16 +2696,26 @@ export default class GnomeSpeaksExtension extends Extension {
                 let text = entry.text.replace(/\s+/g, ' ');
                 if (text.length > 64)
                     text = `${text.substring(0, 64)}…`;
-                let line = new St.Label({
+                // Buttons, not labels: a line you can speak again is an
+                // action, and a screen reader should hear it as one.
+                let lineLabel = new St.Label({
                     text: `${isYou ? '🗣' : '✨'}  ${text}`,
-                    style_class: `gnome-speaks-chronicle-line gnome-speaks-chronicle-line-${isYou ? 'you' : 'it'}`,
-                    reactive: true,
-                    track_hover: true,
+                    x_align: Clutter.ActorAlign.START,
+                    x_expand: true,
                 });
-                line.connect('button-press-event', () => Clutter.EVENT_STOP);
-                line.connect('button-release-event', (actor, ev) => {
-                    if (ev.get_button() !== 1)
-                        return Clutter.EVENT_PROPAGATE;
+                let line = new St.Button({
+                    style_class: `gnome-speaks-chronicle-line gnome-speaks-chronicle-line-${isYou ? 'you' : 'it'}`,
+                    child: lineLabel,
+                    reactive: true,
+                    can_focus: true,
+                    track_hover: true,
+                    x_expand: true,
+                    // Dash, not a full stop: the ledger text already ends in
+                    // its own punctuation and "you.. Activate" reads badly
+                    // out loud — which is the only way this string is read.
+                    accessible_name: `${isYou ? 'You said' : 'Spoken'}: ${text} — activate to speak again`,
+                });
+                line.connect('clicked', actor => {
                     this._proxy.RespeakRemote(entry.id, () => {});
                     // Cast flash: the line lights gold, then the scroll furls.
                     actor.add_style_class_name('gnome-speaks-chronicle-line-cast');
@@ -2529,14 +2726,28 @@ export default class GnomeSpeaksExtension extends Extension {
                         return GLib.SOURCE_REMOVE;
                     });
                     this._trackTimeout(closeId, 'chronicle-cast-close');
-                    return Clutter.EVENT_STOP;
                 });
+                this._chronicleLines.push(line);
                 scroll.add_child(line);
             }
 
-            addQuietLine('a line, spoken again ✦ click to recast');
+            addQuietLine('a line, spoken again ✦ click or Enter to recast · Esc to furl');
             this._presentChronicleScroll();
         });
+    }
+
+    // Arrow keys and Tab walk the ledger. The scroll is not a modal grab, so
+    // nothing else moves focus between these lines for us.
+    _moveChronicleFocus(delta) {
+        let lines = this._chronicleLines;
+        if (!lines || lines.length === 0)
+            return Clutter.EVENT_STOP;
+        let current = lines.findIndex(l => l.has_key_focus());
+        let next = current < 0
+            ? (delta > 0 ? 0 : lines.length - 1)
+            : (current + delta + lines.length) % lines.length;
+        lines[next].grab_key_focus();
+        return Clutter.EVENT_STOP;
     }
 
     _presentChronicleScroll() {
@@ -2545,6 +2756,15 @@ export default class GnomeSpeaksExtension extends Extension {
             return;
 
         Main.layoutManager.addTopChrome(scroll);
+
+        // Keyboard-opened: land on the newest line (or the scroll itself when
+        // there is nothing to land on) so Escape and the arrows have a home.
+        if (this._chronicleFocusReturn) {
+            if (this._chronicleLines && this._chronicleLines.length > 0)
+                this._chronicleLines[0].grab_key_focus();
+            else
+                scroll.grab_key_focus();
+        }
 
         let [badgeX, badgeY] = this._badge.get_transformed_position();
         let badgeWidth = this._badge.get_width();
@@ -2601,12 +2821,26 @@ export default class GnomeSpeaksExtension extends Extension {
             global.stage.disconnect(this._chronicleGrabId);
             this._chronicleGrabId = null;
         }
+        let returnTo = this._chronicleFocusReturn;
+        this._chronicleFocusReturn = null;
+        this._chronicleLines = [];
         if (this._chronicleScroll) {
             let scroll = this._chronicleScroll;
             this._chronicleScroll = null;
+
+            // Give focus back only if it is still ours to give — the user may
+            // have clicked into a window since, and yanking it back there
+            // would be a worse bug than the one this fixes.
+            let focused = global.stage.get_key_focus();
+            let hadFocus = focused &&
+                (focused === scroll || scroll.contains(focused));
+
             scroll.remove_all_transitions();
             Main.layoutManager.removeChrome(scroll);
             scroll.destroy();
+
+            if (hadFocus && returnTo && !this._destroyed && this._badge)
+                returnTo.grab_key_focus();
         }
     }
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -52,6 +52,21 @@
     color: rgba(255, 255, 255, 0.92);
 }
 
+/* Every pill in the row used to BE an StLabel, so the rule above — not the
+ * `margin-left: 6px` in the pill classes, which never won on specificity —
+ * is what actually set the gaps between pills. A pill is now an StButton
+ * wrapping an StLabel, so that same rule lands on the inner label, where an
+ * 8px margin pushes the glyph off-centre and widens every pill by 8px.
+ * Hand the gap back to the button and zero it on the label: same pixels,
+ * different widget. Verified by AT-SPI extents against the old build. */
+.gnome-speaks-badge StButton {
+    margin-left: 8px;
+}
+
+.gnome-speaks-badge StButton StLabel {
+    margin-left: 0px;
+}
+
 .gnome-speaks-badge:hover {
     background-color: rgba(28, 31, 42, 0.86);
     border: 1px solid rgba(255, 255, 255, 0.16);
@@ -264,7 +279,8 @@
     border: 1px solid rgba(255, 205, 80, 0.48);
     box-shadow: 0 0 10px rgba(255, 190, 40, 0.22);
 }
-.gnome-speaks-quality-hd:hover {
+.gnome-speaks-quality-hd:hover,
+.gnome-speaks-quality-hd:focus {
     background-gradient-start: rgba(255, 214, 92, 0.44);
     background-gradient-end: rgba(230, 158, 26, 0.26);
     border: 1px solid rgba(255, 214, 100, 0.72);
@@ -280,7 +296,8 @@
     border: 1px solid rgba(94, 226, 140, 0.46);
     box-shadow: 0 0 10px rgba(94, 226, 140, 0.20);
 }
-.gnome-speaks-quality-fast:hover {
+.gnome-speaks-quality-fast:hover,
+.gnome-speaks-quality-fast:focus {
     background-gradient-start: rgba(130, 240, 170, 0.38);
     background-gradient-end: rgba(58, 190, 112, 0.22);
     border: 1px solid rgba(110, 236, 154, 0.68);
@@ -293,7 +310,8 @@
     color: rgba(255, 255, 255, 0.45);
     border: 1px solid rgba(255, 255, 255, 0.07);
 }
-.gnome-speaks-mode-dict:hover {
+.gnome-speaks-mode-dict:hover,
+.gnome-speaks-mode-dict:focus {
     background-color: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.75);
     box-shadow: 0 0 10px rgba(255, 255, 255, 0.10);
@@ -308,7 +326,8 @@
     border: 1px solid rgba(184, 132, 255, 0.52);
     box-shadow: 0 0 10px rgba(178, 122, 255, 0.24);
 }
-.gnome-speaks-mode-chat:hover {
+.gnome-speaks-mode-chat:hover,
+.gnome-speaks-mode-chat:focus {
     background-gradient-start: rgba(204, 160, 255, 0.46);
     background-gradient-end: rgba(148, 92, 234, 0.28);
     border: 1px solid rgba(196, 152, 255, 0.75);
@@ -321,7 +340,8 @@
     color: rgba(255, 255, 255, 0.35);
     border: 1px solid rgba(255, 255, 255, 0.07);
 }
-.gnome-speaks-pill-off:hover {
+.gnome-speaks-pill-off:hover,
+.gnome-speaks-pill-off:focus {
     background-color: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.65);
     box-shadow: 0 0 10px rgba(255, 255, 255, 0.10);
@@ -335,7 +355,8 @@
     border: 1px solid rgba(80, 205, 240, 0.5);
     box-shadow: 0 0 10px rgba(64, 196, 232, 0.22);
 }
-.gnome-speaks-pill-on:hover {
+.gnome-speaks-pill-on:hover,
+.gnome-speaks-pill-on:focus {
     background-gradient-start: rgba(110, 222, 248, 0.42);
     background-gradient-end: rgba(44, 166, 206, 0.24);
     border: 1px solid rgba(100, 214, 245, 0.72);
@@ -349,13 +370,31 @@
     color: rgba(255, 255, 255, 0.55);
     border: 1px solid rgba(255, 220, 150, 0.14);
 }
-.gnome-speaks-pill-chronicle:hover {
+.gnome-speaks-pill-chronicle:hover,
+.gnome-speaks-pill-chronicle:focus {
     background-gradient-direction: vertical;
     background-gradient-start: rgba(255, 216, 130, 0.24);
     background-gradient-end: rgba(210, 158, 60, 0.12);
     color: rgba(255, 236, 190, 1.0);
     border: 1px solid rgba(255, 216, 120, 0.55);
     box-shadow: 0 0 14px rgba(255, 200, 90, 0.35);
+}
+
+/* ── Keyboard focus: hover's light, plus a rim you can't mistake ──
+ *
+ * Hover is where the pointer happens to be; focus is where the keyboard
+ * IS, and a keyboard user must never have to guess which pill will fire.
+ * So focus takes the lit-hover treatment above and adds a pale rim on
+ * top — still 1px, so nothing in the row shifts as focus moves. Listed
+ * after the tinted rules so the rim wins on equal specificity. */
+.gnome-speaks-quality-hd:focus,
+.gnome-speaks-quality-fast:focus,
+.gnome-speaks-mode-dict:focus,
+.gnome-speaks-mode-chat:focus,
+.gnome-speaks-pill-off:focus,
+.gnome-speaks-pill-on:focus,
+.gnome-speaks-pill-chronicle:focus {
+    border: 1px solid rgba(255, 255, 255, 0.85);
 }
 
 /* ============================================================
@@ -398,9 +437,18 @@
     color: rgba(214, 190, 250, 0.95);
 }
 
+/* The 1px border is paid for out of the padding (6/12 → 5/11) so a lit
+ * line never nudges the ones below it. Focus does the same, brighter. */
 .gnome-speaks-chronicle-line:hover {
     background-color: rgba(255, 255, 255, 0.08);
     border: 1px solid rgba(255, 216, 130, 0.25);
+    padding: 5px 11px;
+}
+
+.gnome-speaks-chronicle-line:focus {
+    background-color: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 232, 170, 0.75);
+    box-shadow: 0 0 12px rgba(255, 200, 90, 0.25);
     padding: 5px 11px;
 }
 


### PR DESCRIPTION
## Why

This extension ships a **Spiel provider for Orca**. An a11y-hostile UI in the same extension is the wrong thing to publish on extensions.gnome.org — so the badge, the pills and the new Chronicle scroll now answer to a keyboard and to AT-SPI.

## What was wrong (verified in code first)

| Gap | Reality |
|---|---|
| 📜 pill + scroll lines | `St.Label` with `reactive: true` — painted buttons. No key focus, no Enter/Space, no role, no name. |
| Scroll popup | No Escape, no focus management. Opened by keyboard = a dead end. |
| Badge pills (quality/mode/loop/terminal) | Same pattern — generalized cleanly. |
| Right-click menu items | Same pattern again. |
| Focus styling | `:hover` only. Nothing showed where the keyboard was standing. |
| The chrome itself | Unreachable by keyboard at all — no way in. |

## What changed

- **Pills and ledger lines are `St.Button`** wrapping an explicit child `St.Label`, so text metrics stay put. `style_class` untouched — the "quiet glass, state-lit" language is unchanged.
- **Accessible names state value + consequence** — `Voice quality: HD — activate for Fast`, `You said: … — activate to speak again` — refreshed wherever pill text is.
- **Chronicle keyboard**: Escape furls, Up/Down/Tab walk the lines (wrapping), Enter recasts.
- **Focus is only taken when the open came from the keyboard.** `St.Button` reports `clicked` button `0` for key activation; a mouse click on chrome must never pull focus out of what you were typing in. Focus returns to the 📜 rune on close — and only if the scroll still holds it.
- **Right-click menu** gets the same treatment; the badge opens it on the **Menu** key.
- **Badge joins the Ctrl+Alt+Tab ring** (guarded in try/catch) — focusable pills are worth nothing without a door into the chrome.
- **`:focus` mirrors `:hover`** plus a pale rim. Same 1px border, so nothing shifts as focus moves.

### One CSS trap, found by measuring

`.gnome-speaks-badge StLabel { margin-left: 8px }` — a *type* selector — is what actually spaced the pill row. The `margin-left: 6px` in the pill classes never won on specificity. Once a pill is a button wrapping a label, that rule lands on the **inner** label and widens every pill by 8px. The gap moves out to the button and is zeroed on the label.

## Verification (GNOME 50.1, headless, isolated extensions dir)

The live session's install dir was never touched. A stub `org.gnome.Speaks` on a private session bus fed the scroll real ledger lines.

- `node --check` clean.
- Extension **ACTIVE** before and after a disable/re-enable cycle.
- **Zero** criticals/JS errors during operation on both this branch and `main` (both emit the usual GJS teardown noise after "Shutting down GNOME Shell").
- AT-SPI reports `(button)` roles with descriptive names for every pill and every ledger line, and `(panel)` for the scroll:

```
(button) 'GNOME Speaks — idle, activate to start listening'  focusable,showing
(button) 'Voice quality: Fast — activate for HD'             focusable
(button) 'The Chronicle — recent speech'                     focusable,showing
(panel)  'The Chronicle — recent speech'                     focusable,showing
(button) 'You said: open the chronicle — activate to speak again'  focusable,showing
(button) 'Spoken: The chronicle is open. — activate to speak again' focusable,showing
```

- Live focus behaviour: keyboard-open lands on the newest line, `focused line index after move: 1` after a Down, `pill refocused: true` after close, `focused ctx item index after move: 1` and `badge refocused: true` for the menu. Empty-ledger case exercised too — no throw.
- **Visual identity**: AT-SPI extents compared against the `main` build. Chronicle lines pixel-identical (`308x35` / `308x29`); pill heights identical (`23`); pill widths within 1px — and the *untouched* `Listening...` label varies 2px between runs, so that is measurement noise, not layout drift.

## Notes

- The badge is `Atk.Role.PUSH_BUTTON` on a container holding buttons. Slightly unusual, but activation is the badge's primary affordance and AT clients still descend into it.
- `prefs.js` copy was left alone on purpose: `lucid-gnome50-sweep` is editing that file, and a copy tweak isn't worth the merge conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)