### PR TITLE
refactor: address badge labels by name, not by widget type

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -526,6 +526,10 @@ export default class GnomeSpeaksExtension extends Extension {
 
         this._label = new St.Label({
             text: '',
+            // Named, not inferred: the stylesheet used to reach this label
+            // through `.gnome-speaks-badge StLabel`, which also swept up
+            // every other label the badge will ever contain.
+            style_class: 'gnome-speaks-badge-label',
             y_align: Clutter.ActorAlign.CENTER,
             visible: false,
         });
@@ -825,6 +829,7 @@ export default class GnomeSpeaksExtension extends Extension {
     _createPill(text, styleClass, accessibleName, onActivate) {
         let label = new St.Label({
             text: text,
+            style_class: 'gnome-speaks-pill-label',
             y_align: Clutter.ActorAlign.CENTER,
             x_align: Clutter.ActorAlign.CENTER,
         });

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -47,24 +47,29 @@
     transition-duration: 250ms;
 }
 
-.gnome-speaks-badge StLabel {
+/* ── Labels inside the badge are addressed by NAME, never by type ──
+ *
+ * `.gnome-speaks-badge StLabel` used to live here, and a type selector
+ * cannot tell the difference between the one label it was written for and
+ * every label the badge would ever contain. It outranked the pill classes
+ * (0,1,1 beats 0,1,0), so their `margin-left: 6px` and their tinted
+ * `color` had never once applied — the row's real gap was this rule's 8px,
+ * and pill text took this rule's colour. Nothing looked wrong, so nothing
+ * said so. Wrapping each pill in an StButton then re-aimed the same rule
+ * at the inner label and widened every pill by 8px.
+ *
+ * Two named classes now: one for the badge's own status label, one for the
+ * text inside a pill. The gap lives on the pill classes where it is read,
+ * and a label added here tomorrow inherits nothing by accident.
+ * Rendered result is unchanged — verified by reading computed St.ThemeNode
+ * colours, margins and padding back out of a headless shell. */
+.gnome-speaks-badge-label {
     margin-left: 8px;
+}
+
+.gnome-speaks-badge-label,
+.gnome-speaks-pill-label {
     color: rgba(255, 255, 255, 0.92);
-}
-
-/* Every pill in the row used to BE an StLabel, so the rule above — not the
- * `margin-left: 6px` in the pill classes, which never won on specificity —
- * is what actually set the gaps between pills. A pill is now an StButton
- * wrapping an StLabel, so that same rule lands on the inner label, where an
- * 8px margin pushes the glyph off-centre and widens every pill by 8px.
- * Hand the gap back to the button and zero it on the label: same pixels,
- * different widget. Verified by AT-SPI extents against the old build. */
-.gnome-speaks-badge StButton {
-    margin-left: 8px;
-}
-
-.gnome-speaks-badge StButton StLabel {
-    margin-left: 0px;
 }
 
 .gnome-speaks-badge:hover {
@@ -160,7 +165,8 @@
     color: rgba(150, 245, 185, 1.0);
 }
 
-.gnome-speaks-listening StLabel {
+.gnome-speaks-listening .gnome-speaks-badge-label,
+.gnome-speaks-listening .gnome-speaks-pill-label {
     color: rgba(235, 255, 242, 0.98);
 }
 
@@ -184,7 +190,8 @@
     color: rgba(255, 214, 130, 1.0);
 }
 
-.gnome-speaks-processing StLabel {
+.gnome-speaks-processing .gnome-speaks-badge-label,
+.gnome-speaks-processing .gnome-speaks-pill-label {
     color: rgba(255, 246, 230, 0.98);
 }
 
@@ -208,7 +215,8 @@
     color: rgba(206, 168, 255, 1.0);
 }
 
-.gnome-speaks-speaking StLabel {
+.gnome-speaks-speaking .gnome-speaks-badge-label,
+.gnome-speaks-speaking .gnome-speaks-pill-label {
     color: rgba(246, 238, 255, 0.98);
 }
 
@@ -231,7 +239,8 @@
     color: rgba(255, 150, 150, 1.0);
 }
 
-.gnome-speaks-error StLabel {
+.gnome-speaks-error .gnome-speaks-badge-label,
+.gnome-speaks-error .gnome-speaks-pill-label {
     color: rgba(255, 236, 236, 0.98);
 }
 
@@ -262,7 +271,7 @@
     font-weight: 700;
     border-radius: 999px;
     padding: 3px 11px;
-    margin-left: 6px;
+    margin-left: 8px;   /* the row's real gap — see the badge-label note above */
     text-align: center;
     transition-duration: 200ms;
     border: 1px solid rgba(255, 255, 255, 0.10);


### PR DESCRIPTION
Follow-up to #23, from its review: remove the type-selector trap instead of just working around it.

## The trap

`.gnome-speaks-badge StLabel`, plus four `.gnome-speaks-<state> StLabel` rules, are **type** selectors. They cannot tell the one label they were written for from every label the badge would ever contain. Two consequences, both invisible:

1. At specificity (0,1,1) they outrank the pill classes at (0,1,0). So the pill classes' `margin-left: 6px` **had never once applied** — the row's real gap was the badge rule's 8px — and their tinted `color` never applied either, so pill text has always taken the *state* tint (pale green while listening, cream while processing, violet while speaking).
2. Once each pill became an `St.Button` wrapping an `St.Label` (#23), the same rules re-aimed at the inner label and widened every pill by 8px. #23 patched around that with `.gnome-speaks-badge StButton` + `.gnome-speaks-badge StButton StLabel` — two more type selectors.

## The change

All five type selectors are gone, replaced by two names:

| class | on | carries |
|---|---|---|
| `gnome-speaks-badge-label` | the badge's own status label | `margin-left: 8px`, base colour |
| `gnome-speaks-pill-label` | the text inside a pill | base colour |

The four state tints now select on those two names, so they still reach both actors. The pill row's real 8px gap is stated in the pill classes, where someone reading them will find it. A label added to the badge tomorrow inherits nothing by accident.

**Rendering is deliberately unchanged, including the pill text tints.** Whether those tints should instead come from each pill's own colour (gold HD / violet AI / cyan loop) is a design question for JP — not something a refactor should decide. Worth knowing it is now a one-line change if wanted.

## Verification — computed style, not eyeballs

The claim "rendering is identical" is a diff of numbers. For the badge, the status label and all five pill button/label pairs, computed `St.ThemeNode` values were read back out of a headless GNOME 50.1 shell — foreground colour, margin-left, padding-left/top, border width, allocated width/height — before and after, in **every** state:

| state | diff |
|---|---|
| listening | empty |
| idle | empty |
| processing | empty |
| speaking | empty |
| error | empty |

The error run is self-proving: its status label reads `255,236,236` (ember) against listening's `235,255,242` (green), so the error class really was live rather than silently absent.

Behaviour re-checked on top: extension **ACTIVE** across a disable/re-enable cycle, **0** criticals before shutdown, all keyboard paths still firing (`focused line index after move: 1`, `pill refocused: true`, `focused ctx item index after move: 1`, `badge refocused: true`), and AT-SPI still showing 10 buttons plus the named Chronicle panel.

Note on instruments: AT-SPI screen extents vary ±3px run-to-run for an actor whose `get_width()` is constant, so they are not the tool for a 1px question — the theme-node read is, and it is byte-identical.

## Not touched

`.gnome-speaks-badge StIcon` and the `.gnome-speaks-<state> StIcon` rules are type selectors too, but there is exactly one icon in the badge and no ambiguity to remove. Left alone to keep this diff about the actual trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)