### PR TITLE
refactor: route press_enter's Enter through the Injector

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -2818,7 +2818,12 @@ class GnomeSpeaksService:
             # a bare voice-command word: the "cast" prefix + pattern match
             # means a misheard mid-sentence word can never execute a command.
             # Silent on success — the command's own output is the feedback.
-            _type_raw("\n")
+            # NB for the IBus backend: this is a KEYSTROKE, not a text
+            # commit. IBus commit_text("\n") inserts a newline character
+            # into the field; it does not press Return, so a shell never
+            # runs the command. This site must stay on a key-event backend
+            # (spec 5.4, "non-text targets") even after IBus lands.
+            get_injector().type_raw("\n")
             return None
         elif op == "loop_toggle":
             new = not CONFIG.get("continuous_dictation", False)


### PR DESCRIPTION
Follow-up to #28. **One line of routing plus a comment** — but it closes a real gap that is on `main` right now.

## What happened

#28 cut the Injector seam against `a3928fa`. In parallel, `3e45a31` ("cast run it" hands-free Enter) added a **new** injection call site — `_type_raw("\n")` in the `press_enter` spell op. Neither branch touched the other's lines, so the merge was textually clean and **semantically incomplete**: `main` now has the seam in place and exactly one injection call bypassing it.

Nothing is broken today — `_type_raw` still works exactly as before. It matters because the seam's whole value is the invariant *"no call site names a ydotool function"*, and Phase 2 will swap the backend underneath it. A site outside the seam is a site that silently keeps typing through ydotool after the switch.

## How it was caught

`verify_injector_seam.py`'s static scan, run against `main`:

```
[5] static scan — no injection call outside the seam
  FAIL no stray direct injection calls [(2821, '_type_raw("\\n")')]
```

59/60 checks green, and the one failure names the exact line. That check exists for precisely this shape of merge, and it earned its keep on its first day.

## The comment is the more important half

`press_enter` records at the site why it **cannot** follow the other call sites onto an IBus commit in Phase 2:

> pressing Return is a **key event**. `commit_text("\n")` inserts a newline *character* into the field — a shell never runs the command.

Spec §5.4 ("non-text targets") is the reason ydotool stays reachable permanently, and this is the first concrete site that proves the rule rather than just asserting it. Worth having in the code before someone does the obvious-looking `type_raw → commit` sweep.

## Verification

Nothing restarted; port 7710 never bound.

- `py_compile` clean.
- All five suites green, 5/5 runs each: `verify_queue_invariants`, `smoke_queue_ops`, `verify_chronicle_contract`, `verify_endpoints`, `verify_injector_seam` (now 60/60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)