### PR TITLE
feat: IBus injection backend (injection_method=ibus|auto)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ Two-process design connected by session D-Bus (`org.gnome.Speaks`):
 |------|---------|------|-------|
 | `extension.js` | GNOME Shell (GJS) | UI: badge + pills + 📜 rune, panel indicator, subtitle overlay, chronicle scroll, keybindings, drag | ~2,620 |
 | `gnome-speaks-service.py` | systemd user service (Python) | Audio, STT, TTS, speech queue, chronicle, LLM, typing, clipboard, wake watcher | ~3,720 |
+| `injector.py` | imported by the service | The `Injector` seam: the contract both injection backends implement | ~120 |
+| `ibus_injector.py` | imported by the service | `IbusInjector` — text injection as an IBus engine (D-Bus commits, preedit, crash recovery) | ~660 |
 | `spellbook.py` | imported by the service | Incantation matcher + executor ("cast …" → local actions); denylist | ~390 |
 | `spellbook.json` | data | 14 repo spells (self-control); user overlay at `~/.config/speech-to-cli/spellbook.json` merges + hot-reloads | — |
 | `spiel_provider.py` | imported by the service | Spiel/libspiel synthesis side (`org.gnome.Speaks.Speech.Provider`); off unless `spiel_provider` | ~120 |
@@ -106,6 +108,7 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
 | Talk | D-Bus API for external apps (blocking call) |
 | Half/Full Duplex | Auto-detected speaker vs headphone routing |
 | Wake word | Idle-only mic stream to LAN openwakeword; detection = dictation hotkey. Toggle: "cast wake word" |
+| Injection | How text reaches the cursor. `injection_method`: `ydotool` (default, synthesizes keys) · `ibus` (D-Bus commits, no stuck keys) · `auto` (ibus when reachable). Falls back to ydotool for every failure, never to nothing |
 | Spellbook | "cast …"/"invoke …" transcripts run local spells (never typed/LLM'd); `POST /cast` is the text seam |
 | Chronicle | Not a mode -- always-on ledger of both directions; 📜 badge rune (8 lines) + panel submenu (12), click to respeak. Spells: "cast echo" / "chronicle" / "seal the chronicle" |
 
@@ -117,6 +120,18 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
 - **stylesheet.css**: GNOME Shell CSS (subset of CSS3). No SCSS or preprocessors.
 
 ## Key Gotchas
+
+- **IBus crash state is "no input method", not "the wrong one"**: measured on GNOME 50.1 — if the
+  service dies between `SetGlobalEngine(ours)` and the restore, the global engine is left **empty**
+  and the daemon does **not** auto-revert. On a desktop where the keymap comes from an IBus engine
+  that can mean no working keyboard. Hence the four mitigations in `ibus_injector.py`
+  (`$XDG_RUNTIME_DIR/gnome-speaks/prior-engine` written *before* the swap, restore-on-start,
+  `ExecStopPost=… --restore-ime`, and a session watchdog). Do not treat any of them as optional,
+  and keep `restore_prior_engine()` dependency-free — it must run with no config and no instance.
+- **`commit_text("\n")` is not the Enter key**: it inserts a newline *character*, so a shell never
+  runs the command. `press_enter()` is a distinct seam method for this reason and delegates to a
+  key-event backend even when IBus is active (spec §5.4, "non-text targets"). Never collapse it
+  into `commit`/`type_raw`.
 
 - **ydotool stuck keys**: If a ydotool command is interrupted between key-down and key-up, the virtual device retains that key as pressed. The service auto-restarts `ydotoold` to recover. Scripts: `fix-ydotool.sh`, `install-ydotool.sh`.
 - **pw-record ignores SIGTERM**: Must use SIGKILL (`proc.kill()`) to stop PipeWire recorder processes.

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -35,6 +35,17 @@ from dataclasses import dataclass
 import queue
 
 import spellbook
+from injector import Injector
+
+# The IBus backend is optional at runtime: a machine without the IBus typelib,
+# or a partial install, must still start on ydotool rather than not at all.
+try:
+    from ibus_injector import IbusInjector, restore_prior_engine
+except Exception as _ibus_exc:  # pragma: no cover - platform dependent
+    IbusInjector = None
+
+    def restore_prior_engine(reason="startup"):
+        return False
 from concurrent.futures import ThreadPoolExecutor
 import threading
 import time
@@ -895,64 +906,18 @@ def replace_typed_text(old_text, new_text):
 # Injection seam
 # ---------------------------------------------------------------------------
 # Every path that puts text in front of the user's cursor goes through an
-# Injector.  Today there is exactly one backend (ydotool/xdotool, the functions
-# above); the seam exists so an IBus backend can be added beside it without
-# touching the STT cycle.  See the IBus spec, phase 1 — this extraction is a
-# pure refactor and deliberately changes no behavior.
+# Injector.  The contract lives in injector.py; the two backends are
+# YdotoolInjector below (synthesized key events) and IbusInjector in
+# ibus_injector.py (D-Bus text commits).
 #
-# YdotoolInjector delegates to the module-level functions rather than absorbing
-# them: it keeps their bodies byte-identical (so every timing quirk survives by
-# construction) and keeps them patchable by name, which the test harnesses rely
-# on to stay off the real uinput device.
-
-
-class Injector:
-    """Backend-agnostic text injection.
-
-    Subclasses implement the five injection primitives the STT cycle uses.
-    ``prepare``/``recover``/``available``/``supports_preedit`` have safe
-    defaults so a partial backend degrades instead of crashing.
-    """
-
-    name = "base"
-
-    def prepare(self):
-        """One-time backend startup. Called off the main thread at boot."""
-
-    def available(self):
-        """True if this backend can type live at the cursor."""
-        return False
-
-    def supports_preedit(self):
-        """True if partials can go to a volatile pre-edit region."""
-        return False
-
-    def commit(self, text):
-        """Put final ``text`` at the cursor. Returns True on success."""
-        raise NotImplementedError
-
-    def type_raw(self, text):
-        """Type ``text`` with no focus-settle delay and no fallback."""
-        raise NotImplementedError
-
-    def send_backspaces(self, count):
-        """Retract ``count`` characters already put at the cursor."""
-        raise NotImplementedError
-
-    def replace_text(self, old_text, new_text):
-        """Update live-typed text from ``old_text`` to ``new_text``."""
-        raise NotImplementedError
-
-    def paste(self, text):
-        """Deliver ``text`` via the clipboard. Returns True on success."""
-        raise NotImplementedError
-
-    def recover(self):
-        """Clear any wedged backend state (called on shutdown)."""
+# YdotoolInjector delegates to the module-level functions above rather than
+# absorbing them: it keeps their bodies byte-identical (so every timing quirk
+# survives by construction) and keeps them patchable by name, which the test
+# harnesses rely on to stay off the real uinput device.
 
 
 class YdotoolInjector(Injector):
-    """The shipping backend: ydotool (or xdotool), synthesizing key events.
+    """The original backend: ydotool (or xdotool), synthesizing key events.
 
     Thin adapter over the module-level typing functions above — same code,
     same timings, same quirks.
@@ -976,6 +941,9 @@ class YdotoolInjector(Injector):
     def type_raw(self, text):
         return _type_raw(text)
 
+    def press_enter(self):
+        return _type_raw("\n")
+
     def send_backspaces(self, count):
         return _send_backspaces(count)
 
@@ -992,36 +960,74 @@ class YdotoolInjector(Injector):
 _INJECTION_METHODS = ("ydotool", "ibus", "auto")
 
 _injector = None
+_injector_method = None
 _injector_lock = threading.Lock()
 
 
 def _make_injector():
     """Pick a backend from CONFIG['injection_method'].
 
-    Only ydotool is implemented; every other value falls back to it.  The
-    config key must also be whitelisted in speech-to-cli's state.py
-    load_config(), or it reads "ydotool" forever.
+    Falls back to ydotool for every failure: an unknown value, IBus bindings
+    missing, the daemon unreachable, registration refused.  Never falls back
+    to nothing — losing dictation to a misconfigured key is a worse outcome
+    than ignoring the key.  (The key must also be whitelisted in
+    speech-to-cli's state.py load_config(), or it reads "ydotool" forever.)
     """
     method = str(CONFIG.get("injection_method") or "ydotool").strip().lower()
     if method not in _INJECTION_METHODS:
         log.warning("Unknown injection_method %r (expected one of %s), using ydotool",
                     method, ", ".join(_INJECTION_METHODS))
-    elif method == "ibus":
-        log.warning("injection_method=ibus is not implemented yet, using ydotool")
-    elif method == "auto":
-        log.info("injection_method=auto resolves to ydotool (no IBus backend yet)")
-    return YdotoolInjector()
+        method = "ydotool"
+
+    ydotool = YdotoolInjector()
+    if method == "ydotool":
+        return ydotool
+
+    if IbusInjector is None:
+        # "auto" resolving to ydotool because this machine has no IBus is the
+        # designed outcome, not a fault — warning about it would cry wolf on
+        # every non-GNOME session. An explicit "ibus" request is different:
+        # the user asked for something they are not getting.
+        if method == "ibus":
+            log.warning("injection_method=ibus requested but the IBus backend "
+                        "could not be imported; using ydotool")
+        else:
+            log.info("injection_method=auto: no IBus backend available, "
+                     "using ydotool")
+        return ydotool
+
+    ibus = IbusInjector(fallback=ydotool)
+    if ibus.available():
+        return ibus
+    if method == "ibus":
+        log.warning("injection_method=ibus requested but IBus is unavailable; "
+                    "using ydotool")
+    else:
+        log.info("injection_method=auto: IBus unavailable, using ydotool")
+    return ydotool
 
 
 def get_injector():
-    """The process-wide injection backend (lazy, built once)."""
-    global _injector
-    if _injector is None:
-        with _injector_lock:
-            if _injector is None:
-                _injector = _make_injector()
-                log.info("Injection backend: %s", _injector.name)
-    return _injector
+    """The process-wide injection backend (lazy, rebuilt when config changes)."""
+    global _injector, _injector_method
+    method = str(CONFIG.get("injection_method") or "ydotool").strip().lower()
+    if _injector is not None and method == _injector_method:
+        return _injector
+    with _injector_lock:
+        if _injector is not None and method == _injector_method:
+            return _injector
+        previous = _injector
+        if previous is not None:
+            # Hand the desktop back before swapping backends underneath it.
+            try:
+                previous.cancel()
+            except Exception:
+                log.debug("Previous injector cancel failed", exc_info=True)
+        _injector = _make_injector()
+        _injector_method = method
+        log.info("Injection backend: %s (injection_method=%s)",
+                 _injector.name, method)
+        return _injector
 
 
 # ── Terminal-mode smart lowercasing ──────────────────────────────────────
@@ -1444,6 +1450,10 @@ class GnomeSpeaksService:
         "conversation_mode", "continuous_dictation", "dictation_mode",
         "terminal_mode", "skip_final_paste", "read_notifications",
         "wake_word", "wake_word_model", "llm_thinking",
+        # Backend escape hatch: editing this key alone must be enough to get
+        # off IBus, because the reason for getting off IBus may be that the
+        # user cannot type.
+        "injection_method",
         "speed", "pitch", "volume", "chronicle",
         # LLM provider config
         "llm_provider", "llm_model", "llm_api_key", "llm_system_prompt",
@@ -1560,6 +1570,17 @@ class GnomeSpeaksService:
             self._state = new_state
             GLib.idle_add(self._emit_state_changed, new_state)
         log.info("State %s -> %s", old, new_state)
+        if new_state == "idle":
+            # Idle means no utterance is in flight, so it is the one place
+            # every path — streaming, single-shot, conversation, error — is
+            # guaranteed to pass through. end() is idempotent and flushes any
+            # coalesced commit, so the IBus backend hands the user's input
+            # method back here rather than depending on each call site to
+            # remember. The watchdog covers the case where even this is missed.
+            try:
+                get_injector().end()
+            except Exception:
+                log.debug("Injector end() failed", exc_info=True)
         self._reset_inactivity_timer()
 
     def _emit_state_changed(self, state_str):
@@ -2823,7 +2844,7 @@ class GnomeSpeaksService:
             # into the field; it does not press Return, so a shell never
             # runs the command. This site must stay on a key-event backend
             # (spec 5.4, "non-text targets") even after IBus lands.
-            get_injector().type_raw("\n")
+            get_injector().press_enter()
             return None
         elif op == "loop_toggle":
             new = not CONFIG.get("continuous_dictation", False)
@@ -4355,7 +4376,25 @@ def main():
         default=int(os.environ.get("GNOME_SPEAKS_HTTP_PORT", "7710")),
         help="HTTP REST API port (default: 7710, env: GNOME_SPEAKS_HTTP_PORT)",
     )
+    parser.add_argument(
+        "--restore-ime", action="store_true",
+        help="Restore a stranded IBus global engine and exit (ExecStopPost hook)",
+    )
     args = parser.parse_args()
+
+    # Crash recovery for the IBus backend, BEFORE anything else happens.
+    # Deliberately unconditional -- not gated on injection_method: the run that
+    # stranded the engine is not the run that has to clean up after it, and by
+    # now the user may well have flipped the config back to ydotool precisely
+    # BECAUSE their input method is broken. Measured on GNOME 50.1: a crash
+    # mid-session leaves NO global engine and the daemon does not auto-revert,
+    # so on a desktop where the keymap comes from an IBus engine this is the
+    # difference between self-healing and no working keyboard.
+    if args.restore_ime:
+        # ExecStopPost= path: restore and exit, never start a service.
+        restore_prior_engine("service stop")
+        return
+    restore_prior_engine("service start")
 
     # Validate config
     if not CONFIG.get("key"):

--- a/gnome-speaks.service
+++ b/gnome-speaks.service
@@ -9,6 +9,9 @@ Wants=graphical-session.target
 Type=dbus
 BusName=org.gnome.Speaks
 ExecStart=/home/jp/Projects/gnome-speaks/gnome-speaks-service.py
+# Restore a stranded IBus global engine on every stop (restart, OOM-kill).
+# '-' so a failed restore never blocks the stop.
+ExecStopPost=-/home/jp/Projects/gnome-speaks/gnome-speaks-service.py --restore-ime
 # Always restart so the HTTP API on :7710 stays reachable; the inactivity
 # timeout is disabled below for the same reason.
 Restart=always

--- a/gnome-speaks.service.in
+++ b/gnome-speaks.service.in
@@ -8,6 +8,11 @@ Wants=graphical-session.target
 Type=dbus
 BusName=org.gnome.Speaks
 ExecStart=@SERVICE_EXEC@
+# Release blocker, not polish: a crash between SetGlobalEngine(ours) and
+# SetGlobalEngine(prior) leaves NO global engine and the daemon does not
+# auto-revert (measured, GNOME 50.1). This runs on every stop, including
+# restart and OOM-kill. '-' so a failed restore never blocks the stop.
+ExecStopPost=-@SERVICE_EXEC@ --restore-ime
 Restart=always
 RestartSec=2
 TimeoutStopSec=10

--- a/ibus_injector.py
+++ b/ibus_injector.py
@@ -1,0 +1,662 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# GNOME Speaks — IBus text injection backend
+# Copyright (C) 2025 JP Hein
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+"""Inject text by being an IBus engine, instead of by faking keystrokes.
+
+Why this exists: a `CommitText` D-Bus call has no key-down/key-up pair, so it
+cannot leave a modifier stuck. That failure mode -- a wedged key with no hands
+free to clear it -- is what this backend eliminates by construction.
+
+It introduces a different one, and the mitigations for it are not optional.
+Measured on GNOME 50.1 (spec 5.5): if this process dies between
+`SetGlobalEngine(ours)` and `SetGlobalEngine(prior)`, the global engine is left
+**empty** and the daemon does not auto-revert. Not "the wrong input method" --
+*no* input method, on a desktop where the keyboard layout is itself delivered
+by an IBus engine. So:
+
+  * the prior engine is written to $XDG_RUNTIME_DIR before we ever swap it,
+  * `restore_prior_engine()` runs at service start and undoes a previous
+    run's crash before anything else happens,
+  * the systemd unit runs the same restore from `ExecStopPost=`,
+  * and a watchdog force-restores a session that outlives its bound.
+
+Any one of those alone is a coin flip. Together they mean the worst case
+self-heals on the next service start, which systemd does automatically.
+
+We build on `gi.repository.IBus` rather than hand-rolling the wire protocol.
+libibus then owns the two GVariant shapes that are easy to get silently wrong
+(the 4-argument preedit update, and variant-wrapped attribute lists).
+"""
+
+import logging
+import os
+import threading
+import time
+
+from injector import Injector
+
+log = logging.getLogger("gnome-speaks")
+
+try:
+    import gi
+    gi.require_version("IBus", "1.0")
+    from gi.repository import IBus, GLib, GObject  # noqa: F401
+    HAS_IBUS = True
+except (ImportError, ValueError) as _exc:  # pragma: no cover - platform dependent
+    IBus = None
+    HAS_IBUS = False
+    log.debug("IBus bindings unavailable: %s", _exc)
+
+
+# ── identity ─────────────────────────────────────────────────────────────
+COMPONENT_NAME = "org.freedesktop.IBus.GnomeSpeaks"
+ENGINE_NAME = "gnome-speaks-stt"
+ENGINE_PATH = "/org/freedesktop/IBus/Engine/GnomeSpeaks"
+
+# layout "default" means "do not touch the keymap". Hardcoding "us" here --
+# as the Rust implementation this design was researched from does -- silently
+# switches a Dvorak or AZERTY user's physical keyboard for the whole session.
+ENGINE_LAYOUT = "default"
+
+# ── timings ──────────────────────────────────────────────────────────────
+FOCUS_WAIT = 0.4          # how long acquire() waits for the daemon's FocusIn
+CONTENT_TYPE_GRACE = 0.05  # ...then for SetContentType to settle behind it
+COALESCE_DELAY = 0.12     # back-to-back finals merge into one commit
+SESSION_MAX_SECONDS = 120  # watchdog: no session may outlive this
+
+# IBus.InputPurpose values we refuse to type into.
+_SECURE_PURPOSES = (8, 9)  # PASSWORD, PIN
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Crash recovery — deliberately module-level and dependency-free
+# ─────────────────────────────────────────────────────────────────────────
+# These must work with no IbusInjector instance, no service state, and no
+# config: they run at service start (before the backend is even chosen) and
+# from ExecStopPost= after the process is gone. Keep them that way.
+
+def _state_dir():
+    base = os.environ.get("XDG_RUNTIME_DIR") or "/tmp"
+    return os.path.join(base, "gnome-speaks")
+
+
+def prior_engine_path():
+    return os.path.join(_state_dir(), "prior-engine")
+
+
+def write_prior_engine(name):
+    """Record the engine to go back to. Called BEFORE the swap, never after."""
+    if not name:
+        return False
+    try:
+        os.makedirs(_state_dir(), exist_ok=True)
+        tmp = prior_engine_path() + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.write(name)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, prior_engine_path())
+        return True
+    except OSError:
+        log.warning("Could not persist prior IBus engine", exc_info=True)
+        return False
+
+
+def clear_prior_engine():
+    """Drop the breadcrumb. Only ever after a restore actually succeeded."""
+    try:
+        os.unlink(prior_engine_path())
+    except FileNotFoundError:
+        pass
+    except OSError:
+        log.debug("Could not clear prior-engine file", exc_info=True)
+
+
+def read_prior_engine():
+    try:
+        with open(prior_engine_path(), encoding="utf-8") as fh:
+            return fh.read().strip() or None
+    except (OSError, ValueError):
+        return None
+
+
+def restore_prior_engine(reason="startup"):
+    """Undo a swap this process is no longer around to undo itself.
+
+    Safe to call always: no file means the last run ended cleanly, and that is
+    the overwhelmingly common case. Returns True only when a restore actually
+    happened, so callers can log the interesting case and stay quiet otherwise.
+    """
+    name = read_prior_engine()
+    if not name:
+        return False
+    if not HAS_IBUS:
+        log.warning("Stranded IBus engine recorded (%s) but IBus bindings are "
+                    "missing; cannot restore", name)
+        return False
+    try:
+        IBus.init()
+        bus = IBus.Bus()
+        if not bus.is_connected():
+            log.warning("Stranded IBus engine recorded (%s) but the daemon is "
+                        "not reachable; leaving the breadcrumb for next time", name)
+            return False
+        current = bus.get_global_engine()
+        current_name = current.get_name() if current else None
+        if current_name == name:
+            # Someone already put it back; the breadcrumb is just stale.
+            clear_prior_engine()
+            return False
+        bus.set_global_engine(name)
+        clear_prior_engine()
+        log.warning("Restored IBus global engine to %r after %s "
+                    "(was %r) -- previous run did not shut down cleanly",
+                    name, reason, current_name)
+        return True
+    except Exception:
+        log.warning("IBus restore failed", exc_info=True)
+        return False
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Commit coalescing
+# ─────────────────────────────────────────────────────────────────────────
+
+class _Coalescer:
+    """Merge back-to-back finals into a single commit.
+
+    Rapid successive commits race in the daemon and only the last one lands in
+    the target -- the "only the last second or two appears" bug. Loop mode
+    fires finals back-to-back, which is exactly that shape.
+
+    The whitespace rule inserts a separator only when neither side already
+    carries one, so a backend emitting stripped segments gets spaces restored
+    and one emitting natural leading spaces never gets doubles.
+    """
+
+    def __init__(self):
+        self.pending = ""
+        self.committed_any = False
+
+    def push(self, text):
+        if not text:
+            return
+        if self.pending and not self.pending[-1].isspace() and not text[:1].isspace():
+            self.pending += " "
+        self.pending += text
+
+    def take(self, allowed=True):
+        """Return the text to commit and clear the buffer.
+
+        `allowed=False` DISCARDS: better to lose a segment than to commit it
+        into a target we are no longer sure of.
+        """
+        if not self.pending:
+            return ""
+        text, self.pending = self.pending, ""
+        if not allowed:
+            return ""
+        if self.committed_any and not text[:1].isspace():
+            text = " " + text
+        return text
+
+    def reset(self):
+        self.pending = ""
+        self.committed_any = False
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# The engine object the daemon drives
+# ─────────────────────────────────────────────────────────────────────────
+
+if HAS_IBUS:
+
+    class SpeaksEngine(IBus.Engine):
+        """Receives focus and content-type; sends preedit and commits.
+
+        Deliberately passive about keys: `do_process_key_event` returns False
+        so every keystroke passes straight through to the application. That
+        single line is why swapping the global engine mid-utterance does not
+        take the user's keyboard away.
+        """
+
+        __gtype_name__ = "GnomeSpeaksEngine"
+
+        def __init__(self, bus, object_path):
+            # has_focus_id decides whether the daemon delivers focus as
+            # FocusInId/FocusOutId. Recent ibus uses the _id form; without
+            # this property set, focus never arrives at all.
+            if hasattr(IBus.Engine.props, "has_focus_id"):
+                super().__init__(connection=bus.get_connection(),
+                                 object_path=object_path, has_focus_id=True)
+            else:
+                super().__init__(connection=bus.get_connection(),
+                                 object_path=object_path)
+            self.purpose = 0
+            self.hints = 0
+            self.focused = False
+            self.saw_content_type = False
+            self._preediting = False
+
+        # -- key events ---------------------------------------------------
+
+        def do_process_key_event(self, keyval, keycode, state):
+            return False  # we synthesize no input; keys are the user's
+
+        # -- focus (both spellings; newer ibus only sends the _id form) ----
+
+        def do_focus_in(self):
+            self.do_focus_in_id("", "")
+
+        def do_focus_in_id(self, object_path, client):
+            self.focused = True
+            log.debug("IBus focus in (client=%s)", client)
+
+        def do_focus_out(self):
+            self.do_focus_out_id("")
+
+        def do_focus_out_id(self, object_path):
+            self.focused = False
+            # Anything provisional dies with the focus it belonged to.
+            self.clear_preedit()
+            log.debug("IBus focus out")
+
+        def do_reset(self):
+            self.clear_preedit()
+
+        def do_set_content_type(self, purpose, hints):
+            self.purpose = purpose
+            self.hints = hints
+            self.saw_content_type = True
+            log.debug("IBus content type purpose=%s hints=%s", purpose, hints)
+
+        # -- text ---------------------------------------------------------
+
+        def is_secure(self):
+            return self.purpose in _SECURE_PURPOSES
+
+        def supports_preedit_region(self):
+            return bool(self.client_capabilities & IBus.Capabilite.PREEDIT_TEXT)
+
+        def set_preedit(self, text):
+            """Replace the volatile region. Successive calls replace, never add."""
+            if not text:
+                self.clear_preedit()
+                return
+            if not self.supports_preedit_region():
+                # A client with no preedit region silently drops everything we
+                # send it -- saying so once beats typing into a black hole.
+                log.debug("IBus client has no preedit capability; skipping partial")
+                return
+            self.update_preedit_text_with_mode(
+                IBus.Text.new_from_string(text),
+                len(text),                     # cursor at end; CHARS, not bytes
+                True,
+                IBus.PreeditFocusMode.CLEAR,   # focus-out DISCARDS, never commits
+            )
+            self._preediting = True
+
+        def clear_preedit(self):
+            if not self._preediting:
+                return
+            try:
+                self.update_preedit_text_with_mode(
+                    IBus.Text.new_from_string(""), 0, False,
+                    IBus.PreeditFocusMode.CLEAR)
+                self.hide_preedit_text()
+            except Exception:
+                log.debug("IBus preedit clear failed", exc_info=True)
+            self._preediting = False
+
+        def commit(self, text):
+            if not text:
+                return False
+            # A commit supersedes the volatile tail: clear first, in this order.
+            self.clear_preedit()
+            self.commit_text(IBus.Text.new_from_string(text))
+            return True
+
+    class SpeaksFactory(IBus.Factory):
+        """Hands the daemon an engine, and keeps a handle on the one it made."""
+
+        __gtype_name__ = "GnomeSpeaksFactory"
+
+        def __init__(self, bus, on_engine):
+            self._bus = bus
+            self._on_engine = on_engine
+            super().__init__(object_path=IBus.PATH_FACTORY,
+                             connection=bus.get_connection())
+
+        def do_create_engine(self, engine_name):
+            if engine_name != ENGINE_NAME:
+                return super().do_create_engine(engine_name)
+            engine = SpeaksEngine(self._bus, ENGINE_PATH)
+            self._on_engine(engine)
+            return engine
+
+else:  # pragma: no cover - platform dependent
+    SpeaksEngine = None
+    SpeaksFactory = None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# The backend
+# ─────────────────────────────────────────────────────────────────────────
+
+class IbusInjector(Injector):
+    """Commit text as an IBus engine, swapping the global engine per utterance.
+
+    `fallback` is required, not optional: IBus commits into *text input
+    contexts*, and some of what this seam is asked to do is not a text commit
+    at all (pressing Return). Those delegate rather than being approximated.
+    """
+
+    name = "ibus"
+
+    def __init__(self, fallback=None):
+        self._fallback = fallback
+        self._bus = None
+        self._factory = None
+        self._engine = None
+        self._registered = False
+        self._connect_failed = False
+        self._lock = threading.RLock()
+        self._prior = None
+        self._active = False
+        self._coalescer = _Coalescer()
+        self._flush_timer = None
+        self._watchdog = None
+
+    # ── setup ────────────────────────────────────────────────────────────
+
+    def prepare(self):
+        self._ensure_registered()
+        if self._fallback is not None:
+            # The fallback still owns keystrokes; let it detect its tooling.
+            self._fallback.prepare()
+
+    def _ensure_registered(self):
+        """Connect and register the component. Idempotent; safe to call often."""
+        if self._registered or self._connect_failed or not HAS_IBUS:
+            return self._registered
+        with self._lock:
+            if self._registered or self._connect_failed:
+                return self._registered
+            try:
+                IBus.init()
+                bus = IBus.Bus()
+                if not bus.is_connected():
+                    log.warning("IBus daemon not reachable; injection stays on "
+                                "the fallback backend")
+                    self._connect_failed = True
+                    return False
+                component = IBus.Component.new(
+                    COMPONENT_NAME, "GNOME Speaks dictation", "1.0",
+                    "GPL-3.0-or-later", "JP Hein", "", "", "gnome-speaks")
+                component.add_engine(IBus.EngineDesc.new(
+                    ENGINE_NAME, "GNOME Speaks", "Voice dictation", "en",
+                    "GPL-3.0-or-later", "JP Hein", "", ENGINE_LAYOUT))
+                if not bus.register_component(component):
+                    log.warning("IBus refused our component registration")
+                    self._connect_failed = True
+                    return False
+                self._factory = SpeaksFactory(bus, self._on_engine_created)
+                self._bus = bus
+                self._registered = True
+                log.info("IBus component registered (engine %s, layout %s)",
+                         ENGINE_NAME, ENGINE_LAYOUT)
+                return True
+            except Exception:
+                log.warning("IBus registration failed", exc_info=True)
+                self._connect_failed = True
+                return False
+
+    def _on_engine_created(self, engine):
+        self._engine = engine
+        log.debug("IBus engine object created")
+
+    # ── capability ───────────────────────────────────────────────────────
+
+    def available(self):
+        if not HAS_IBUS:
+            return False
+        if not self._ensure_registered():
+            return False
+        try:
+            return bool(self._bus and self._bus.is_connected())
+        except Exception:
+            return False
+
+    def supports_preedit(self):
+        return True
+
+    # ── session lifecycle ────────────────────────────────────────────────
+
+    def acquire(self):
+        """Become the global engine for one utterance.
+
+        Returns False only when we must NOT type: the swap was refused, or the
+        target is a password field. A slow or absent FocusIn is the ordinary
+        field case, not a refusal -- treating it as one would break dictation
+        into perfectly normal windows.
+        """
+        if not self.available():
+            return False
+        with self._lock:
+            if self._active:
+                return not self._is_secure()
+            try:
+                prior = self._bus.get_global_engine()
+                prior_name = prior.get_name() if prior else None
+            except Exception:
+                prior_name = None
+            if prior_name == ENGINE_NAME:
+                prior_name = None  # never record ourselves as the way back
+            # Persist BEFORE the swap: a crash in between is the whole reason
+            # this file exists, and a breadcrumb written afterwards is a
+            # breadcrumb that is missing exactly when it is needed.
+            if prior_name:
+                write_prior_engine(prior_name)
+            self._prior = prior_name
+            try:
+                if not self._bus.set_global_engine(ENGINE_NAME):
+                    log.warning("IBus refused SetGlobalEngine; not typing")
+                    clear_prior_engine()
+                    self._prior = None
+                    return False
+            except Exception:
+                log.warning("IBus SetGlobalEngine failed", exc_info=True)
+                clear_prior_engine()
+                self._prior = None
+                return False
+            self._active = True
+            self._start_watchdog()
+
+        # Wait for the daemon to push focus at us, then let SetContentType
+        # settle behind it -- a bare read loses that race.
+        deadline = time.monotonic() + FOCUS_WAIT
+        while time.monotonic() < deadline:
+            eng = self._engine
+            if eng is not None and eng.focused:
+                break
+            time.sleep(0.01)
+        time.sleep(CONTENT_TYPE_GRACE)
+
+        if self._is_secure():
+            log.info("IBus target is a password field; refusing to type")
+            self.cancel()
+            return False
+        return True
+
+    def _is_secure(self):
+        eng = self._engine
+        return bool(eng is not None and eng.is_secure())
+
+    def _ensure_session(self):
+        if self._active:
+            # Re-read the purpose every time: SetContentType can arrive late,
+            # and focus can move into a password field mid-session.
+            if self._is_secure():
+                log.info("IBus focus moved into a password field; discarding")
+                self.cancel()
+                return False
+            return True
+        return self.acquire()
+
+    def end(self):
+        """Finish cleanly: flush what is buffered, then hand the IME back."""
+        with self._lock:
+            self._cancel_timers()
+            if self._active:
+                self._flush(allowed=True)
+                eng = self._engine
+                if eng is not None:
+                    eng.clear_preedit()
+            self._coalescer.reset()
+            self._restore()
+
+    def cancel(self):
+        """Abandon: discard anything provisional and hand the IME back."""
+        with self._lock:
+            self._cancel_timers()
+            self._coalescer.reset()
+            eng = self._engine
+            if eng is not None:
+                eng.clear_preedit()
+            self._restore()
+
+    def _restore(self):
+        """Put the user's engine back. Restore-once; safe to call repeatedly."""
+        if not self._active:
+            return
+        self._active = False
+        prior, self._prior = self._prior, None
+        try:
+            if prior:
+                self._bus.set_global_engine(prior)
+                log.debug("IBus global engine restored to %r", prior)
+            else:
+                # Nothing to go back to. Leaving OURS installed would hand the
+                # user a dead input method, so stand down either way.
+                log.debug("IBus had no prior engine to restore")
+        except Exception:
+            log.warning("IBus restore failed; the breadcrumb file will be "
+                        "used at next service start", exc_info=True)
+            return
+        clear_prior_engine()
+
+    def recover(self):
+        self.cancel()
+        restore_prior_engine("recover")
+        if self._fallback is not None:
+            self._fallback.recover()
+
+    # ── watchdog ─────────────────────────────────────────────────────────
+
+    def _start_watchdog(self):
+        self._stop_watchdog()
+        self._watchdog = threading.Timer(SESSION_MAX_SECONDS, self._on_watchdog)
+        self._watchdog.daemon = True
+        self._watchdog.start()
+
+    def _stop_watchdog(self):
+        if self._watchdog is not None:
+            self._watchdog.cancel()
+            self._watchdog = None
+
+    def _on_watchdog(self):
+        log.warning("IBus session exceeded %ss; force-restoring the input "
+                    "method", SESSION_MAX_SECONDS)
+        self.cancel()
+
+    # ── commit path ──────────────────────────────────────────────────────
+
+    def _cancel_timers(self):
+        self._stop_watchdog()
+        if self._flush_timer is not None:
+            self._flush_timer.cancel()
+            self._flush_timer = None
+
+    def _arm_flush(self):
+        if self._flush_timer is not None:
+            self._flush_timer.cancel()
+        self._flush_timer = threading.Timer(COALESCE_DELAY, self._timed_flush)
+        self._flush_timer.daemon = True
+        self._flush_timer.start()
+
+    def _timed_flush(self):
+        with self._lock:
+            self._flush_timer = None
+            self._flush(allowed=True)
+
+    def _flush(self, allowed=True):
+        text = self._coalescer.take(allowed=allowed and not self._is_secure())
+        if not text:
+            return False
+        eng = self._engine
+        if eng is None:
+            log.warning("IBus flush with no engine object; text dropped")
+            return False
+        try:
+            eng.commit(text)
+            self._coalescer.committed_any = True
+            return True
+        except Exception:
+            log.warning("IBus commit failed", exc_info=True)
+            return False
+
+    # ── Injector interface ───────────────────────────────────────────────
+
+    def commit(self, text):
+        if not text:
+            return False
+        if not self._ensure_session():
+            return False
+        with self._lock:
+            self._coalescer.push(text)
+            self._arm_flush()
+        return True
+
+    def type_raw(self, text):
+        # Text, not keys -- it goes through the same coalesced commit so the
+        # whitespace-join rule can stop it doubling a separator.
+        return self.commit(text)
+
+    def press_enter(self):
+        # A KEY EVENT. commit_text("\n") puts a newline character in the field
+        # and no shell ever runs the command, so this must not be a commit.
+        if self._fallback is None:
+            log.warning("No fallback backend for press_enter; Enter not sent")
+            return None
+        return self._fallback.press_enter()
+
+    def set_preedit(self, text):
+        if text and not self._ensure_session():
+            return
+        eng = self._engine
+        if eng is None:
+            return
+        try:
+            eng.set_preedit(text)
+        except Exception:
+            log.debug("IBus preedit update failed", exc_info=True)
+
+    def replace_text(self, old_text, new_text):
+        # Replacement is what a preedit region is for: no diffing, no prefix
+        # arithmetic, no backspaces.
+        self.set_preedit(new_text)
+
+    def send_backspaces(self, count):
+        # Retracting provisional text is one idempotent call here; there is
+        # nothing committed to take back.
+        self.set_preedit("")
+
+    def paste(self, text):
+        # The clipboard round-trip existed to work around ydotool dropping
+        # characters in long bursts. A D-Bus commit has no such failure mode.
+        return self.commit(text)

--- a/injector.py
+++ b/injector.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# GNOME Speaks — text injection backend contract
+# Copyright (C) 2025 JP Hein
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+"""The `Injector` seam: every path that puts text in front of the cursor.
+
+Two backends implement this:
+
+  * `YdotoolInjector` (in gnome-speaks-service.py) synthesizes key events on a
+    uinput device. Always reachable — see below.
+  * `IbusInjector` (in ibus_injector.py) commits text over D-Bus as an IBus
+    engine. No key events, so nothing can be left stuck.
+
+The contract is deliberately shaped so the STT cycle never asks which backend
+it has. `replace_text`, `send_backspaces` and `paste` mean *intent* ("revise
+the live text", "retract it", "deliver this block"), not mechanism, and each
+backend spends that intent its own way: ydotool backspaces and retypes, IBus
+replaces a pre-edit region. The one thing callers must branch on is
+`supports_preedit()`, and only if they care how the text looks while it is
+still provisional.
+
+**ydotool never goes away** (spec 5.4). IBus commits into *text input
+contexts*; a keystroke is not a text commit, a clipboard paste is not a text
+commit, and a non-GNOME session has no IBus at all. `press_enter` is the
+first-class example: `commit_text("\\n")` inserts a newline character into the
+field, it does not press Return, so a shell never runs the command.
+"""
+
+
+class Injector:
+    """Backend-agnostic text injection.
+
+    Every method has a safe default, so a partial backend degrades rather than
+    crashing, and adding a method here does not break existing backends.
+    """
+
+    name = "base"
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+
+    def prepare(self):
+        """One-time backend startup. Called off the main thread at boot."""
+
+    def acquire(self):
+        """Bind an injection target for one utterance.
+
+        False means refuse — no target, or a target we must not type into
+        (a password field). Backends with no session concept return True.
+        """
+        return True
+
+    def end(self):
+        """Finish the current utterance cleanly. MUST be idempotent."""
+
+    def cancel(self):
+        """Abandon the current utterance, discarding anything provisional.
+
+        MUST be idempotent, and MUST leave the desktop no worse than it found
+        it even when called from an error path.
+        """
+
+    def recover(self):
+        """Clear wedged backend state. Called on shutdown and after faults."""
+
+    # ── capability ───────────────────────────────────────────────────────
+
+    def available(self):
+        """True if this backend can put text at the cursor right now."""
+        return False
+
+    def supports_preedit(self):
+        """True if provisional text goes to a volatile pre-edit region.
+
+        False means provisional text is really typed and must be really
+        retracted, which is what makes `send_backspaces` meaningful.
+        """
+        return False
+
+    # ── injection ────────────────────────────────────────────────────────
+
+    def commit(self, text):
+        """Put final `text` at the cursor. Returns True on success."""
+        raise NotImplementedError
+
+    def type_raw(self, text):
+        """Put `text` at the cursor with no focus-settle delay or fallback."""
+        raise NotImplementedError
+
+    def press_enter(self):
+        """Press Return — a KEY EVENT, never a text commit.
+
+        Backends that cannot generate key events must delegate this, not
+        approximate it with a newline character.
+        """
+        raise NotImplementedError
+
+    def send_backspaces(self, count):
+        """Retract `count` characters of provisional text already shown."""
+        raise NotImplementedError
+
+    def replace_text(self, old_text, new_text):
+        """Revise the provisional text from `old_text` to `new_text`."""
+        raise NotImplementedError
+
+    def set_preedit(self, text):
+        """Show `text` as provisional; "" clears it.
+
+        Only meaningful when `supports_preedit()` is True.
+        """
+        raise NotImplementedError
+
+    def paste(self, text):
+        """Deliver `text` as one block. Returns True on success."""
+        raise NotImplementedError

--- a/install.sh
+++ b/install.sh
@@ -175,7 +175,8 @@ mkdir -p "$SYSTEMD_USER_DIR"
 
 # Copy the service file and update ExecStart to use the actual project path
 if [[ -f "$PROJECT_DIR/gnome-speaks.service" ]]; then
-    sed "s|^ExecStart=.*|ExecStart=$SERVICE_EXEC|" \
+    sed -e "s|^ExecStart=.*|ExecStart=$SERVICE_EXEC|" \
+        -e "s|^ExecStopPost=.*|ExecStopPost=-$SERVICE_EXEC --restore-ime|" \
         "$PROJECT_DIR/gnome-speaks.service" > "$SYSTEMD_FILE"
     success "Installed systemd service to $SYSTEMD_FILE"
 else


### PR DESCRIPTION
Phase 2 of the IBus injection spec. A second backend that commits text over D-Bus as an IBus engine instead of synthesizing key events. **`ydotool` stays the default** — this is opt-in via `injection_method`.

## Why

A `CommitText` D-Bus call has no key-down/key-up pair, so it cannot leave a modifier stuck. The failure mode this project exists to eliminate — a wedged key with no hands free to clear it — becomes structurally impossible on this path rather than merely less likely.

## What's here

Built on `gi.repository.IBus`, not hand-rolled wire protocol, so libibus owns the two GVariant shapes that are silently wrong when you build them yourself (the 4-argument preedit update; variant-wrapped attribute lists). Runtime `register_component` — no root, no installed XML, no `ibus restart`, and the service keeps owning its own lifecycle.

Two details that are bugs in the implementation this was researched from, fixed here:
- **`layout="default"`**, not `"us"`. Hardcoding `us` silently switches a Dvorak/AZERTY/Colemak user's physical keyboard for every dictation session.
- **`do_process_key_event` returns `False`.** This is the single line that keeps the physical keyboard working while our engine is the global one.

Both focus spellings (`do_focus_in` *and* `do_focus_in_id`) are implemented — on ibus 1.5.34 the `_id` form is what actually arrives, and `has_focus_id=True` is what makes the daemon send it.

## The crash mitigations are release blockers, not polish

Phase 0 measured something worse than the spec originally assumed: dying between `SetGlobalEngine(ours)` and the restore leaves **no global engine at all**, and the daemon does not auto-revert. On a desktop where the keymap is itself delivered by an IBus engine, that can mean no working keyboard — strictly worse than the stuck key this replaces. So all four are here:

1. prior engine persisted to `$XDG_RUNTIME_DIR/gnome-speaks/prior-engine` **before** the swap (a breadcrumb written afterwards is missing exactly when it's needed);
2. `restore_prior_engine()` at service start, **unconditional** — deliberately not gated on `injection_method`, because the run that stranded the engine is not the run that cleans up, and by then the user may have flipped the config back to ydotool *because* their input is broken;
3. `ExecStopPost=… --restore-ime` in the unit, covering `systemctl restart` and OOM-kill (`-` prefixed so a failed restore never blocks the stop; `install.sh` rewrites the path alongside `ExecStart`);
4. a session watchdog, so a wedged STT backend cannot hold the IME hostage.

`restore_prior_engine()` is deliberately dependency-free — no config, no instance, no service state — because it runs before the backend is chosen and after the process is gone.

## Phase 1's seam paid off: the STT cycle is unchanged

Not one call site in the cycle changed. The seam's methods name *intent*, not mechanism, so the differences absorb inside the backend:

| seam method | ydotool | IBus |
|---|---|---|
| `replace_text(old, new)` | common-prefix diff, backspace tail, retype | `set_preedit(new)` — replacement is what the region is *for* |
| `send_backspaces(n)` | n key events | one idempotent preedit clear |
| `paste(text)` | clipboard + Ctrl+Shift+V | a commit; the round-trip disappears |
| `press_enter()` | `_type_raw("\n")` | **delegates to ydotool** |

`press_enter` is the exception that proves §5.4: `commit_text("\n")` inserts a newline *character*, so a shell never runs the command. It stays on a key-event backend permanently.

Commits coalesce (120 ms) so back-to-back loop-mode finals cannot race into "only the last one lands", with a whitespace join that restores separators without doubling them.

## Escape hatch

`injection_method` is hot-reloaded, so **editing that key alone** switches back — no restart, no keyboard, no extension. Every failure path (missing bindings, unreachable daemon, refused registration, refused swap, password field) falls back to ydotool, never to nothing.

## Verification

**No live `SetGlobalEngine` from any test.** The suite drives a mock bus and redirects `XDG_RUNTIME_DIR` so the real breadcrumb is never touched. Confirmed after the run: live global engine still `xkb:us::eng`, `gnome-speaks-stt` never registered with the daemon, no breadcrumb on the real path. The service was not restarted and port 7710 was never bound.

All six suites green, 5/5 runs each: `verify_queue_invariants`, `smoke_queue_ops`, `verify_chronicle_contract`, `verify_endpoints`, `verify_injector_seam`, and the new `verify_ibus_injector` (~55 checks) covering persist-before-swap ordering, PASSWORD/PIN refusal at acquire *and* re-checked mid-session, restore-once idempotency, the watchdog, breadcrumb replay, and the seam mapping above.

`--restore-ime` smoke-tested end to end: with a breadcrumb naming the current engine it reads the file, takes the already-correct path, consumes the breadcrumb, exits 0, binds no port, and leaves the live engine untouched.

One bug the tests caught and fixed: `auto` on a machine with no IBus was logging a *warning*, which would cry wolf on every non-GNOME session. It's an `info` now; an explicit `ibus` request still warns, because there the user asked for something they aren't getting.

## Not merged

Recommend driving it on `injection_method: "ibus"` for a while before `auto` becomes the default — spec §5.3 phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)