### PR TITLE
refactor: name the seam's text path and key path apart

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -938,10 +938,13 @@ class YdotoolInjector(Injector):
     def commit(self, text):
         return type_at_cursor(text)
 
-    def type_raw(self, text):
+    def type_text(self, text):
         return _type_raw(text)
 
     def press_enter(self):
+        # Same underlying call as type_text for THIS backend only, because
+        # ydotool types and presses keys through one tool. They stay separate
+        # methods because no other backend can conflate them.
         return _type_raw("\n")
 
     def send_backspaces(self, count):
@@ -2251,7 +2254,7 @@ class GnomeSpeaksService:
                             # was live-typed, surgically fix the divergent tail.
                             if typed_partial[0] != user_text:
                                 get_injector().replace_text(typed_partial[0], user_text)
-                            get_injector().type_raw(" ")
+                            get_injector().type_text(" ")
                     elif live_typing:
                         get_injector().send_backspaces(len(typed_partial[0]))
                         time.sleep(0.02)

--- a/ibus_injector.py
+++ b/ibus_injector.py
@@ -622,8 +622,8 @@ class IbusInjector(Injector):
             self._arm_flush()
         return True
 
-    def type_raw(self, text):
-        # Text, not keys -- it goes through the same coalesced commit so the
+    def type_text(self, text):
+        # TEXT path: goes through the same coalesced commit so the
         # whitespace-join rule can stop it doubling a separator.
         return self.commit(text)
 

--- a/injector.py
+++ b/injector.py
@@ -86,15 +86,34 @@ class Injector:
         """Put final `text` at the cursor. Returns True on success."""
         raise NotImplementedError
 
-    def type_raw(self, text):
-        """Put `text` at the cursor with no focus-settle delay or fallback."""
+    def type_text(self, text):
+        """Put `text` at the cursor with no focus-settle delay or fallback.
+
+        TEXT path. See the two-category rule under `press_enter`.
+        """
         raise NotImplementedError
 
     def press_enter(self):
         """Press Return — a KEY EVENT, never a text commit.
 
-        Backends that cannot generate key events must delegate this, not
-        approximate it with a newline character.
+        ── The two-category rule ────────────────────────────────────────
+        Methods on this seam fall into exactly two kinds, and they must
+        never be merged:
+
+          TEXT  — commit / type_text / set_preedit / replace_text / paste.
+                  These mean "put these characters in the field". An IBus
+                  backend serves them with commit_text.
+
+          KEYS  — press_enter. This means "press this key". IBus CANNOT
+                  serve it: commit_text("\n") inserts a newline character
+                  into the field, so a shell never runs the command. A
+                  backend without key events must DELEGATE, never
+                  approximate.
+
+        This is why ydotool stays reachable permanently rather than being
+        a transition scaffold. If a future change is tempted to fold
+        `press_enter` into `type_text` because "it is just a newline" --
+        that is the bug this comment exists to stop.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
Closes the naming clause of the Phase 2 amendment. **No behavior change** — three method renames and a docstring that a future sweep will actually read.

## The rule, written where it will be read

`type_raw` → `type_text`, and the two-category rule now lives next to `press_enter`:

| category | methods | how IBus serves it |
|---|---|---|
| **TEXT** | `commit`, `type_text`, `set_preedit`, `replace_text`, `paste` | `commit_text` |
| **KEYS** | `press_enter` | **it cannot** — must delegate |

`commit_text("\n")` inserts a newline *character* into the field. A shell never runs the command.

## Why a rename is worth a PR

`type_raw` read like it could be either. The change that breaks hands-free Enter under IBus is not an exotic mistake — it is the plausible-looking cleanup that notices `press_enter` and `type_text` do the same thing on the ydotool backend and folds them together. They *do* do the same thing there, because ydotool types and presses keys through one tool; the comment on `YdotoolInjector.press_enter` now says so explicitly, and says why they stay separate anyway.

This is also the concrete reason ydotool is a permanent peer backend rather than a transition scaffold (spec §5.4, "non-text targets") — previously an assertion in a spec, now a method signature.

## Enforced, not just documented

`verify_injector_seam.py` gains a section that fails if the two are ever merged:

```
[4b] text path and key path stay distinct
  ok   press_enter is its own method, not an alias of type_text
  ok   YdotoolInjector keeps them distinct
  ok   base Injector.press_enter() raises NotImplementedError
  ok   the seam exposes no generic 'type_raw' any more
```

It also now pins the restore-on-start ordering that the amendment promoted to a requirement — recovery must not sit behind a daemon thread, since the state it recovers from is *no input method at all*:

```
  ok   restore-on-start runs BEFORE the _init_typing thread starts
  ok   restore-on-start is not buried inside prepare()
```

Both of those were already true on `main` (they landed in #30); the checks stop them quietly regressing.

## Verification

All six suites green, 5/5 runs each. No live `SetGlobalEngine`; confirmed after the run that the global engine is still `xkb:us::eng`, `gnome-speaks-stt` is not registered with the daemon, and no breadcrumb exists on the real path. Service not restarted, port 7710 never bound. Leak scan 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)