### PR TITLE
fix: acquire the D-Bus name before probing PipeWire (#50)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -4748,18 +4748,6 @@ def main():
         get_injector().prepare()
     threading.Thread(target=_init_typing, daemon=True).start()
 
-    # Detect audio output device and auto-enable echo cancellation
-    _refresh_audio_detection()
-    dev_type = CONFIG.get("_detected_output", "unknown")
-    ec_present = has_echo_cancel()
-    if ec_present and dev_type == "headphones":
-        CONFIG["enable_echo_cancel"] = True
-        log.info("Auto-enabled echo cancellation (headphones + PipeWire EC detected)")
-    log.info("Audio output: %s, echo_cancel=%s, half_duplex=%s",
-             dev_type, ec_present, CONFIG.get("half_duplex", False))
-
-    # Prewarm recorder, WebSocket, and HTTP session so first call is instant
-    _prewarm_recorder()
     # Pre-warm STT WebSocket and TTS HTTP connection in background
     def _prewarm_connections():
         try:
@@ -4780,8 +4768,30 @@ def main():
 
     # Create service and handler
     service = GnomeSpeaksService()
-    service._audio_detected = True  # startup detection already ran above
     handler = DBusHandler(service)
+
+    # Detect audio output, auto-enable echo cancellation, and prewarm the
+    # recorder in background. These shell out to wpctl/pw-dump/pw-cli (3 s
+    # timeout each) and measured 3.9 s at login while PipeWire was still
+    # coming up; run synchronously they held back Gio.bus_own_name and the
+    # HTTP bind, so systemd (Type=dbus) and the extension saw no service for
+    # the whole window (#50). start_listening()/speak() lazily refresh
+    # detection via _audio_detected until this finishes, and every helper
+    # here is lock-guarded, so a hotkey racing the thread is harmless.
+    def _init_audio():
+        _refresh_audio_detection()
+        dev_type = CONFIG.get("_detected_output", "unknown")
+        ec_present = has_echo_cancel()
+        if ec_present and dev_type == "headphones":
+            CONFIG["enable_echo_cancel"] = True
+            log.info("Auto-enabled echo cancellation (headphones + PipeWire EC detected)")
+        log.info("Audio output: %s, echo_cancel=%s, half_duplex=%s",
+                 dev_type, ec_present, CONFIG.get("half_duplex", False))
+        service._audio_detected = True
+        # Prewarm recorder so the first listen is instant. Same order as the
+        # old synchronous startup: detection and the EC decision first.
+        _prewarm_recorder()
+    threading.Thread(target=_init_audio, daemon=True).start()
 
     # Set up main loop
     loop = GLib.MainLoop()


### PR DESCRIPTION
Closes #50

main() ran `_refresh_audio_detection()`, `has_echo_cancel()` and `_prewarm_recorder()` synchronously before `Gio.bus_own_name` and the HTTP bind (3 s subprocess timeout each; 3.92 s measured at login while PipeWire was coming up). With `Type=dbus` that meant no service visible to systemd or the extension for the whole window.

**Fix:** run the three probes in a daemon thread next to `_init_typing`, same order as before, and have the thread set `service._audio_detected = True` when done. Until then `start_listening()`/`speak()` use their existing lazy-refresh path. All helpers are lock-guarded in speech-to-cli (`_auto_detect_lock`, `_prewarmed_rec_lock`, memoized `_has_echo_cancel`), so a hotkey racing the thread is safe.

Verified: `py_compile` passes. No test suite in this repo (per CLAUDE.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Audio detection and recorder initialization now run in the background during startup.
  * Service bus ownership and HTTP binding can complete without waiting for audio initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->