### PR TITLE
fix: commit the IBus pre-edit when keeping live text (#45)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -2473,12 +2473,21 @@ class GnomeSpeaksService:
                 # Type at cursor (dictation mode) or just copy to clipboard
                 if CONFIG.get("dictation_mode", True):
                     if live_typing and (is_loop or CONFIG.get("skip_final_paste", False)):
+                        inj = get_injector()
                         if is_loop and typed_partial[0]:
                             # Final correction: if Azure's final differs from what
                             # was live-typed, surgically fix the divergent tail.
                             if typed_partial[0] != user_text:
-                                get_injector().replace_text(typed_partial[0], user_text)
-                            get_injector().type_text(" ")
+                                inj.replace_text(typed_partial[0], user_text)
+                            # Separator before the next utterance. A pre-edit
+                            # backend's coalescer restores its own between
+                            # commits; typing one here would double it.
+                            if not inj.supports_preedit():
+                                inj.type_text(" ")
+                        # Keep the live text: on ydotool it is already really
+                        # typed (no-op); on IBus it is still a volatile pre-edit
+                        # that end() would DISCARD at idle, so commit it (#45).
+                        inj.finalize(user_text)
                     elif live_typing:
                         get_injector().send_backspaces(len(typed_partial[0]))
                         time.sleep(0.02)

--- a/ibus_injector.py
+++ b/ibus_injector.py
@@ -756,6 +756,13 @@ class IbusInjector(Injector):
         # whitespace-join rule can stop it doubling a separator.
         return self.commit(text)
 
+    def finalize(self, text):
+        # The partials only ever lived in the pre-edit, and end() clears that
+        # region rather than committing it -- so a keep-live-text utterance
+        # must be committed here or it never reaches the field (#45). The
+        # engine's commit clears the pre-edit first, so nothing doubles.
+        return self.commit(text)
+
     def press_enter(self):
         # A KEY EVENT. commit_text("\n") puts a newline character in the field
         # and no shell ever runs the command, so this must not be a commit.

--- a/injector.py
+++ b/injector.py
@@ -53,6 +53,18 @@ class Injector:
         """
         return True
 
+    def finalize(self, text):
+        """The utterance is over and `text` is its final form; make the live
+        text stick.
+
+        Called by the keep-live-text path (loop mode, skip_final_paste)
+        instead of `commit`, because the caller has already been showing
+        `text` provisionally.  A key-event backend really typed it, so there
+        is nothing left to do -- this default.  A pre-edit backend has only
+        ever shown it in a volatile region that `end()`/`cancel()` DISCARD,
+        so it must commit here or the whole utterance vanishes (#45).
+        """
+
     def end(self):
         """Finish the current utterance cleanly. MUST be idempotent."""
 


### PR DESCRIPTION
Closes #45

With `injection_method=ibus` and `skip_final_paste` (default True), the keep-live-text branch did nothing for the IBus backend: every partial went to the volatile pre-edit, and `_set_state('idle') -> end()` cleared it (single-shot) or `type_text(' ')` superseded it with a lone space (loop). The whole utterance vanished.

**Fix**
- `injector.py`: new seam method `finalize(text)` — no-op default (key-event backends really typed the text).
- `ibus_injector.py`: `finalize` = `commit(text)`; the engine's commit clears the pre-edit first, so nothing doubles.
- `gnome-speaks-service.py` step 9: the keep-live-text branch calls `finalize(user_text)` on both the single-shot and loop paths, and only types the loop separator on non-pre-edit backends (the IBus coalescer restores its own between commits).

**Verification** (FakeEngine driving `IbusInjector`, same call sequence as step 9):
- single-shot: commits `['hello']` (main: `[]`)
- loop, two utterances: commits `['hello world', ' second']` (main: `[' ', ' ']`)
- `py_compile` clean on all three files. ydotool paths are behaviour-identical (finalize is a no-op there, separator still typed).