### PR TITLE
fix: wake gate decides once per session and accepts FREE_FORM fields (#47)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -1865,7 +1865,13 @@ class GnomeSpeaksService:
         If quick=True, skip config reload and audio detection refresh.
         Used for tight loop restarts where config hasn't changed.
         """
-        self._wake_initiated = bool(wake)
+        # A wake-word session stays a wake-word session across quick (loop)
+        # restarts; only a fresh start -- a deliberate hotkey press -- clears
+        # the flag, because that press is the user vouching for the target.
+        if wake:
+            self._wake_initiated = True
+        elif not quick:
+            self._wake_initiated = False
         # Prevent concurrent STT threads from rapid clicks.
         # For quick (loop) restarts, briefly wait for the old thread to finish
         # since the loop restart fires before the thread fully exits.
@@ -2136,6 +2142,14 @@ class GnomeSpeaksService:
                        and not CONFIG.get("conversation_mode", False)
                        and get_injector().available())
         use_lexical = CONFIG.get("terminal_mode", False)
+
+        # spec §4.3: the wake gate is decided ONCE per session, up front.
+        # Partials are injected before any final exists, so asking only at
+        # the final would let live typing leak text into a field the gate
+        # then refuses; a refusal must hold for every path in this session.
+        wake_blocked = self._wake_gate_blocks()
+        if wake_blocked:
+            live_typing = False
 
         # ---------------------------------------------------------------
         # Main cycle loop — runs once in single-shot mode, loops in
@@ -2472,7 +2486,10 @@ class GnomeSpeaksService:
 
                 # Type at cursor (dictation mode) or just copy to clipboard
                 if CONFIG.get("dictation_mode", True):
-                    if live_typing and (is_loop or CONFIG.get("skip_final_paste", False)):
+                    if wake_blocked:
+                        # Verdict given at session start; nothing reaches the cursor.
+                        log.debug("Wake-word gate: transcript withheld")
+                    elif live_typing and (is_loop or CONFIG.get("skip_final_paste", False)):
                         if is_loop and typed_partial[0]:
                             # Final correction: if Azure's final differs from what
                             # was live-typed, surgically fix the divergent tail.
@@ -2482,9 +2499,8 @@ class GnomeSpeaksService:
                     elif live_typing:
                         get_injector().send_backspaces(len(typed_partial[0]))
                         time.sleep(0.02)
-                        if not self._wake_gate_blocks():
-                            get_injector().paste(user_text)
-                    elif not self._wake_gate_blocks():
+                        get_injector().paste(user_text)
+                    else:
                         get_injector().commit(user_text)
                 else:
                     if live_typing and typed_partial[0]:

--- a/ibus_injector.py
+++ b/ibus_injector.py
@@ -540,7 +540,9 @@ class IbusInjector(Injector):
 
     def purpose_known(self):
         eng = self._engine
-        return bool(eng is not None and eng.focused and eng.purpose
+        # FREE_FORM is 0, so the purpose value itself can never be the
+        # signal -- what matters is that SetContentType actually arrived.
+        return bool(eng is not None and eng.focused and eng.saw_content_type
                     and not eng.is_secure())
 
     def acquire(self):


### PR DESCRIPTION
Closes #47

Three holes in the opt-in `wake_word_secure_gate` (11c8f60):

1. **Streaming path never gated.** Partials were injected via `replace_text` before the gate was asked, and the loop / `skip_final_paste` final branch never called `_wake_gate_blocks` at all. The gate is now decided once per session, right after `live_typing` is computed (the call runs `acquire()` so content-type can arrive); a refusal sets `live_typing = False` and withholds the final on every branch.
2. **`purpose_known()` refused every ordinary field.** It required `eng.purpose` truthy, but `IBus.InputPurpose.FREE_FORM == 0` (verified against the installed typelib). It now keys on `saw_content_type`.
3. **Loop restarts lifted the gate.** `start_listening(quick=True)` reset `_wake_initiated` to False. Quick restarts now carry the flag; only a fresh (hotkey) start clears it.

Default remains off; no user config change. `py_compile` passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)