### PR TITLE
docs: document injection_method, the secure gate, and the Desktop D-Bus seam (#43)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
 - **Disposed notification sources**: During shell init/restart, `MessageTray` `source-added` can fire with already-disposed `FdoNotificationDaemonSource` objects. Any signal connection on them crashes the shell. Always wrap `source.connect()` in try-catch and listen for `source-removed` to drop references before GC disposes them.
 - **Azure content filter**: Avoid `[SYSTEM:]` prefix in system prompts -- Azure GPT content filter blocks it.
 - **speech-to-cli `load_config()` whitelists keys**: unknown config.json keys are silently dropped. Adding a config key means adding it to the whitelist in `state.py` too, or the feature reads a default forever. Scope: this only binds keys the **Python** side reads -- keys consumed only by extension.js (`subtitles_user`, `subtitles_tts`) bypass it entirely, since GJS parses config.json raw. Don't "fix" their absence from `state.py`, and don't assume a working extension key means the Python side can see it.
-- **`Shell.Eval` is dead** (returns `(false,'')`; Introspect/Screenshot are AccessDenied) -- `_get_focused_app()` is silently a no-op (#7). Desktop actuation needs D-Bus methods exported from extension.js.
+- **`Shell.Eval` is dead** (returns `(false,'')`; Introspect/Screenshot are AccessDenied) -- the service cannot ask the compositor anything directly (#7). The replacement is the `org.gnome.Speaks.Desktop` interface **exported by extension.js** (`GetFocusedApp` → `wm_class, title`), which `_get_focused_app()` calls via `gdbus`; it works only while the extension is loaded and returns `None` headless. Any further desktop actuation goes the same way: a method on that interface, answered from inside the Shell.
 - **Public repo**: LAN hostnames/IPs, the HA domain, and the wake-word model name (it's the wake phrase) never enter git -- they live in `~/.config/speech-to-cli/config.json` and the user spellbook overlay. Scan patch history before pushing.
 - **systemctl scope trap**: this file prescribes `systemctl --user` for the voice service — but `systemctl --user is-active <system-unit>` answers `inactive` with **exit 0** for units that live in the system scope (e.g. litrpg-engine on this machine). A confidently wrong answer; check the scope before believing "inactive", and never build a health check or spell on the --user reading of a system unit.
 - **Speech-queue state ownership**: `_speak_token` fences playback cleanup -- a preempted worker must not reset state it no longer owns. Keep the token claims when adding new speech paths.
@@ -180,6 +180,14 @@ No test suite. Validate changes by:
 5. Shell-side changes: headless session (`--nested` is dead on 50, see gotchas) --
    `dbus-run-session -- gnome-shell --headless --virtual-monitor 1280x720`, then
    enable/disable/re-enable and require **zero** JS errors, shell CRITICALs, and St warnings.
+6. Service-side changes: the de-facto verification bar is the four scratch repro suites under
+   `~/.claude/projects/-home-jp/scratch/gnome-speaks-dreamteam/` -- `lucid-service-audit-repros`
+   (queue invariants, dispatch gate, config), `lucid-chronicle-perf-repros` (chronicle contract,
+   archive, HTTP endpoints), `lucid-cancel-tokens-repros` (cancel-token verdicts, stop vs
+   stop_listening), `morpheus-injector-seam-repros` (Injector seam, IbusInjector). Each script
+   imports the service from `GS_SVC_PATH=<path to gnome-speaks-service.py>` (defaults to the main
+   checkout, so point it at your worktree) and needs no running service or D-Bus. Run the suite(s)
+   covering the area you touched before opening a PR.
 
 ## Git
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,14 +180,45 @@ No test suite. Validate changes by:
 5. Shell-side changes: headless session (`--nested` is dead on 50, see gotchas) --
    `dbus-run-session -- gnome-shell --headless --virtual-monitor 1280x720`, then
    enable/disable/re-enable and require **zero** JS errors, shell CRITICALs, and St warnings.
-6. Service-side changes: the de-facto verification bar is the four scratch repro suites under
-   `~/.claude/projects/-home-jp/scratch/gnome-speaks-dreamteam/` -- `lucid-service-audit-repros`
-   (queue invariants, dispatch gate, config), `lucid-chronicle-perf-repros` (chronicle contract,
-   archive, HTTP endpoints), `lucid-cancel-tokens-repros` (cancel-token verdicts, stop vs
-   stop_listening), `morpheus-injector-seam-repros` (Injector seam, IbusInjector). Each script
-   imports the service from `GS_SVC_PATH=<path to gnome-speaks-service.py>` (defaults to the main
-   checkout, so point it at your worktree) and needs no running service or D-Bus. Run the suite(s)
-   covering the area you touched before opening a PR.
+6. Wake-word secure gate: `python3 verify_wake_gate.py` from the checkout root -- no env vars,
+   no desktop, no daemon (it imports `ibus_injector` from its own directory). 24 checks; exit 0
+   means all passed.
+7. Service-side changes: the de-facto verification bar is the scratch repro suites under
+   `~/.claude/projects/-home-jp/scratch/gnome-speaks-dreamteam/`, one directory per audit --
+   `lucid-service-audit-repros` (queue invariants, dispatch gate, config),
+   `lucid-chronicle-perf-repros` (chronicle contract, archive, HTTP endpoints),
+   `lucid-cancel-tokens-repros` (cancel-token verdicts, stop vs stop_listening),
+   `morpheus-injector-seam-repros` (Injector seam, IbusInjector). They import the service by
+   path and need no running service, D-Bus, mic or port 7710. Run the suite(s) covering the
+   area you touched before opening a PR.
+
+   **Always pass the path explicitly; never trust a suite's default.** Only
+   `lucid-cancel-tokens-repros` defaults to the main checkout. `lucid-service-audit-repros`,
+   `lucid-chronicle-perf-repros` and `morpheus-injector-seam-repros` default to
+   `~/Projects/gnome-speaks-wt/<audit-name>/` worktrees that no longer exist, so an
+   unqualified run dies with `FileNotFoundError` on that path instead of testing anything.
+
+   ```bash
+   SVC=~/Projects/gnome-speaks-wt/<your-worktree>/gnome-speaks-service.py
+   cd ~/.claude/projects/-home-jp/scratch/gnome-speaks-dreamteam
+   GS_SVC_PATH=$SVC       python3 lucid-service-audit-repros/verify_queue_invariants.py
+   GS_SVC_PATH=$SVC       python3 lucid-chronicle-perf-repros/verify_archive.py
+   GS_SVC_PATH=$SVC       python3 lucid-cancel-tokens-repros/verify_cancel_invariants.py
+   GS_SVC_PATH=$SVC       python3 morpheus-injector-seam-repros/verify_injector_seam.py
+   GS_WT=$(dirname $SVC)  python3 morpheus-injector-seam-repros/verify_ibus_injector.py
+   ```
+
+   `verify_ibus_injector.py` is the exception: it imports `ibus_injector` as a module rather
+   than loading the service by path, so it reads **`GS_WT` (a checkout *directory*)** and
+   ignores `GS_SVC_PATH` entirely -- passing only `GS_SVC_PATH` gets you
+   `ModuleNotFoundError: No module named 'ibus_injector'`.
+
+   Exit 0 = clean. A non-zero exit is a failed check -- in the `repro_*` scripts that means
+   the bug the repro was written for is still present, which is the point of running them.
+   **A red suite is not automatically your fault**: some scripts are open-bug repros that are
+   red on `main` by design, and several keep state under `/tmp/<suite>/` that is not reset
+   between runs. Get a baseline on `main` before blaming your branch, and wipe the suite's
+   state dir if a second run disagrees with the first.
 
 ## Git
 

--- a/README.md
+++ b/README.md
@@ -263,11 +263,18 @@ by voice):
 
 Every failure — an unknown value, missing `gir1.2-ibus-1.0`, no `ibus-daemon`,
 registration refused — falls back to ydotool, never to nothing: losing dictation to a
-misconfigured key is worse than ignoring the key. The IBus engine refuses to type into
-password fields, but **only on X11/XWayland**: on native Wayland the field's content-type
-never reaches IBus, so the refusal cannot fire. `press_enter` ("cast run it") always goes
-through a key-event backend, since committing `"\n"` inserts a character rather than
-pressing Enter.
+misconfigured key is worse than ignoring the key.
+
+The IBus engine also refuses to type into a field the application **declares** as a
+password or PIN — on X11 and on native Wayland alike. This refusal is always on whenever
+IBus is the engine; it is not the same thing as `wake_word_secure_gate`, which is a
+separate, stricter rule that applies only to hands-free sessions
+([Only Type Into Known Fields](#wake-word)). It carries the same limit either way: a field
+that declares nothing arrives as purpose `0`, hints `0` — identical to a field that
+declares FREE_FORM — so a hand-rolled password box that declares nothing is not detected.
+
+`press_enter` ("cast run it") always goes through a key-event backend, since committing
+`"\n"` inserts a character rather than pressing Enter.
 
 ### Prosody
 
@@ -555,9 +562,9 @@ not. With this on, a wake-word-opened session types only into a *focused* field
 that the application has **not** declared as password or PIN — otherwise
 nothing is typed (no live partials either) and the service says "Unknown field
 — press the hotkey to dictate here". The verdict is taken once, when the
-session opens, and survives loop restarts. It needs the IBus **Typing Engine**
-(`injection_method: "ibus"` or `"auto"`); the virtual keyboard never learns
-anything about its target.
+session opens, and survives loop restarts. It needs the IBus
+[Typing Engine](#typing-engine) (`injection_method: "ibus"` or `"auto"`); the
+virtual keyboard never learns anything about its target.
 
 Read the guarantee narrowly — it is *refuse the declared*, not *allow only the
 vouched-for*:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ GNOME Speaks has several modes that can be combined for different workflows:
 
 ### Type Mode (default)
 
-Click the badge or press `Super+Alt+Space` → speak → text is typed at the cursor position. Click again, say "over", or pause for silence to stop. The transcription appears character-by-character as you speak (live typing via ydotool).
+Click the badge or press `Super+Alt+Space` → speak → text is typed at the cursor position. Click again, say "over", or pause for silence to stop. The transcription appears character-by-character as you speak (live typing through the [typing engine](#typing-engine) — the ydotool virtual keyboard by default, or the IBus input method).
 
 ### AI Mode
 
@@ -169,6 +169,13 @@ sudo systemctl enable --now ydotool.service
 
 The service auto-detects whether `ydotoold` is running and adjusts accordingly.
 
+#### IBus (alternative typing engine)
+
+Instead of faking keystrokes, the service can type as an IBus input method
+(`injection_method: "ibus"`, see [Typing engine](#typing-engine)). It needs the
+GObject bindings — `gir1.2-ibus-1.0` on Debian/Ubuntu — and a running `ibus-daemon`
+(GNOME's default). ydotool stays required: every IBus failure falls back to it.
+
 ## Installation
 
 ### Quick install
@@ -241,6 +248,26 @@ Create `~/.config/speech-to-cli/config.json`:
 | `language` | STT/TTS language code |
 
 You can get a free Azure Speech key at [Azure Portal](https://portal.azure.com) — the free tier includes 500K characters/month for TTS and 5 hours/month for STT.
+
+### Typing engine
+
+`injection_method` in `~/.config/speech-to-cli/config.json` picks how dictated text
+reaches the cursor (also the *Typing Engine* row in preferences, or "cast typing engine"
+by voice):
+
+| Value | How it types |
+|-------|--------------|
+| `ydotool` (default) | Virtual keyboard via `/dev/uinput` — synthesizes key events |
+| `ibus` | Registers as an IBus input method and commits text over D-Bus — no key can stick |
+| `auto` | IBus when the daemon is reachable, otherwise ydotool |
+
+Every failure — an unknown value, missing `gir1.2-ibus-1.0`, no `ibus-daemon`,
+registration refused — falls back to ydotool, never to nothing: losing dictation to a
+misconfigured key is worse than ignoring the key. The IBus engine refuses to type into
+password fields, but **only on X11/XWayland**: on native Wayland the field's content-type
+never reaches IBus, so the refusal cannot fire. `press_enter` ("cast run it") always goes
+through a key-event backend, since committing `"\n"` inserts a character rather than
+pressing Enter.
 
 ### Prosody
 


### PR DESCRIPTION
Closes #43

Docs-only drift fix from the injection work (#30-#34, 11c8f60):

- **README**: new *Typing engine* subsection under Configuration (`injection_method`: `ydotool` · `ibus` · `auto`, every failure falls back to ydotool, password-field refusal qualified to X11/XWayland); IBus (`gir1.2-ibus-1.0`) listed under System tools; `wake_word_secure_gate` paragraph next to the wake-word keys; Type Mode no longer says "via ydotool" unconditionally.
- **CLAUDE.md**: the `Shell.Eval` gotcha now says `_get_focused_app()` calls `org.gnome.Speaks.Desktop.GetFocusedApp` (exported by extension.js) and works only with the extension loaded; Testing points at the four scratch repro suites and `GS_SVC_PATH`.

No code, no restart, no config edits. Leak-scanned the added lines (no hosts/IPs/domains/wake phrase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)