### PR TITLE
fix: 'cast typing engine' leaves auto and reports the real backend (#56)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -3128,12 +3128,21 @@ class GnomeSpeaksService:
             self._save_config_flag("read_notifications", new)
             return "The notification herald is %s." % ("on" if new else "off")
         elif op == "injection_toggle":
-            cur = CONFIG.get("injection_method", "ydotool")
-            new = "ydotool" if cur == "ibus" else "ibus"
+            # The spell is the voice-recoverable way out of an IBus trial, so
+            # "auto" (which may already be on IBus) must leave to ydotool, not
+            # re-request ibus and change nothing (#56). Unknown values are
+            # ydotool in _make_injector(), so they toggle to ibus.
+            cur = str(CONFIG.get("injection_method") or "ydotool").strip().lower()
+            new = "ydotool" if cur in ("ibus", "auto") else "ibus"
             self._save_config_flag("injection_method", new)
-            if new == "ibus":
+            # Report what was actually built, not what was asked for: an
+            # "ibus" request falls back to ydotool when IBus is unreachable.
+            if get_injector().name == "ibus":
                 return ("Typing through the input method — no key can stick. "
                         "Say the same words to go back.")
+            if new == "ibus":
+                return ("The input method is unreachable — still typing "
+                        "through the virtual keyboard.")
             return "Typing through the virtual keyboard."
         elif op == "press_enter":
             # Hands-free Enter. Deliberately a SPELL ("cast run it") and not


### PR DESCRIPTION
Closes #56

`_spell_ctx_dbus("injection_toggle")` now:

- maps `auto` → `ydotool` (and `ibus` → `ydotool`), so the spell is a working escape hatch from an IBus trial regardless of how IBus was selected; `ydotool`/unset/unknown → `ibus` as before.
- phrases the reply from `get_injector().name` rather than the config string it just wrote. When `ibus` was requested but the backend fell back to ydotool (IBus unreachable or not importable), it says "The input method is unreachable — still typing through the virtual keyboard." instead of claiming "no key can stick".

The reply block is written line-identical to the one on `fix/cast-typing-engine-swaps-the-inj` (#46) so the two rebase cleanly; the new part is the `new =` mapping.

**Verification** — added a `[6] typing-engine spell` block to the out-of-tree harness `~/.claude/projects/-home-jp/scratch/gnome-speaks-dreamteam/morpheus-injector-seam-repros/verify_injector_seam.py` (the path the issue names; not tracked in this repo). It redirects `CONFIG_PATH` to a temp file and asserts the real `~/.config/speech-to-cli/config.json` is untouched.

- against `main`: 6 FAIL (auto→ibus; "no key can stick" while on ydotool, both with IBus unreachable and with no IBus backend)
- against this branch: ALL SEAM CHECKS PASSED (blocks 1–6)

`py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
