### PR TITLE
fix: a dead recorder is reported once, keeps the words, and ends the session (#57, #48)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -2193,6 +2193,15 @@ class GnomeSpeaksService:
         # 1. Get prewarmed recorder (or start fresh) — reused across all
         #    cycles in loop mode.
         proc = _take_prewarmed_rec()
+        _stale_rc = proc.poll() if proc is not None else None
+        if _stale_rc is not None:
+            # The prewarm hands over whatever it started and never polls it
+            # again; pw-record exits immediately when the (on-demand USB) mic
+            # is absent.  Without this the session opens on a corpse and the
+            # failure below is diagnosed against a recorder that died minutes
+            # ago, in a different device state.
+            _log(f"prewarmed recorder already exited (rc={_stale_rc}), discarding")
+            proc = None
         if proc is None:
             try:
                 proc = subprocess.Popen(
@@ -2216,6 +2225,12 @@ class GnomeSpeaksService:
         cycle = 0
         user_text = ""       # set each cycle; needed in cleanup for conversation_mode check
         natural_end = False  # set each cycle; needed in cleanup for single-shot restart
+        # The recorder died under us -- USB mic yanked, pw-record gone.  A
+        # property of the SESSION, not of a cycle, and bound HERE beside the
+        # other two for the same reason: the WS-init failure `break` below
+        # leaves the cycle loop before any per-cycle state exists, and the
+        # cleanup after it reads this flag.
+        recorder_dead = threading.Event()
         failed = None
         try:
             # 2. Get persistent WebSocket (with exponential backoff retry).
@@ -2305,7 +2320,8 @@ class GnomeSpeaksService:
                 #    that is handled by the outer cleanup below.
                 def send_audio(_req_id=request_id, _raw_frames=raw_frames,
                                _end_word_event=end_word_event,
-                               _sender_done=sender_done):
+                               _sender_done=sender_done,
+                               _rec_dead=recorder_dead):
                     try:
                         # Calibrate noise threshold (cached — reads only 1 frame after first call)
                         energy_threshold, cal_frames = calibrate_noise(proc)
@@ -2345,6 +2361,29 @@ class GnomeSpeaksService:
                             chunk = proc.stdout.read(FRAME_BYTES)
                             if not chunk or len(chunk) < FRAME_BYTES:
                                 _log(f"recorder EOF at frame {total_frames}")
+                                # A short read on this pipe is EOF, and
+                                # pw-record closes stdout only when it exits --
+                                # but "the pipe went quiet" is not by itself
+                                # proof of a lost mic, so poll() is the
+                                # positive control for the claim.
+                                #
+                                # cancel_token is the only signal that says WE
+                                # asked for this death: stop() cancels every
+                                # live token BEFORE it kills the procs.
+                                # _stop_event cannot serve -- stop_listening()
+                                # sets it, and so does turn.end in single-shot
+                                # mode, which is exactly how the report ends up
+                                # masked by the session's own natural end.
+                                if not cancel_token.cancelled:
+                                    try:
+                                        proc.wait(timeout=0.5)
+                                    except subprocess.TimeoutExpired:
+                                        pass
+                                    _rc = proc.poll()
+                                    if _rc is not None:
+                                        _log(f"recorder exited rc={_rc}"
+                                             f" -- microphone lost")
+                                        _rec_dead.set()
                                 break
 
                             # Only buffer frames after speech starts (saves memory in loop idle)
@@ -2529,6 +2568,18 @@ class GnomeSpeaksService:
                     user_text = ""
                     break
 
+                # A recorder can also die without the sender seeing EOF: the
+                # cycle may have ended on the end word or the silence timeout
+                # first.  Latch it HERE, because _reap_recorder() in the
+                # cleanup below kills proc -- after that poll() can no longer
+                # tell a lost mic from a routine teardown.
+                if not recorder_dead.is_set() and not cancel_token.cancelled:
+                    _rc = proc.poll()
+                    if _rc is not None:
+                        _log(f"recorder gone outside EOF (rc={_rc})"
+                             f" -- microphone lost")
+                        recorder_dead.set()
+
                 if not user_text and raw_frames and not got_phrase:
                     _log(f"WS returned nothing, falling back to REST STT (frames={len(raw_frames)})")
                     user_text = _rest_stt_fallback(raw_frames, _log) or ""
@@ -2551,6 +2602,7 @@ class GnomeSpeaksService:
                         get_injector().send_backspaces(len(typed_partial[0]))
                     GLib.idle_add(self._emit_transcription_ready, user_text)
                     if (is_loop and not _stopping()
+                            and not recorder_dead.is_set()
                             and CONFIG.get("continuous_dictation", False)):
                         # Let the spell's spoken reply play before re-opening the mic
                         self._drain_speech_gap()
@@ -2571,7 +2623,8 @@ class GnomeSpeaksService:
                 # 9. Emit results and type/copy
                 # In loop mode, skip the "processing" flicker if nothing was said —
                 # just silently re-enter listening on the next cycle.
-                if is_loop and not user_text and not _stopping():
+                if (is_loop and not user_text and not _stopping()
+                        and not recorder_dead.is_set()):
                     if live_typing and typed_partial[0]:
                         get_injector().send_backspaces(len(typed_partial[0]))
                     _log("no speech in loop cycle, continuing")
@@ -2633,8 +2686,10 @@ class GnomeSpeaksService:
                         get_injector().send_backspaces(len(typed_partial[0]))
                     GLib.idle_add(self._emit_transcription_ready, "")
 
-                # 10. Decide whether to loop or exit
-                if is_loop and not _stopping():
+                # 10. Decide whether to loop or exit.  A dead recorder ends
+                # the session: there is nothing left to listen with, and the
+                # loop would otherwise read every EOF as "no speech" and spin.
+                if is_loop and not _stopping() and not recorder_dead.is_set():
                     # Re-check continuous_dictation in case user toggled it mid-session
                     if not CONFIG.get("continuous_dictation", False):
                         _log("continuous_dictation toggled off, exiting loop")
@@ -2657,8 +2712,23 @@ class GnomeSpeaksService:
             # ---------------------------------------------------------------
             self._reap_recorder(proc)
 
+        # Reported ONCE per session, and only here: after every exit above
+        # has already delivered whatever Azure did recognize.  A mic yanked
+        # mid-utterance must not cost the user the words that were already
+        # transcribed -- the report is additional to the text, never instead
+        # of it.  Gated on the token, not on _stopping(): by this point a
+        # single-shot turn.end has set _stop_event and would silence it.
+        if recorder_dead.is_set() and not cancel_token.cancelled:
+            log.warning("Recorder exited mid-session (cycle %d) -- microphone lost",
+                        cycle)
+            GLib.idle_add(self._emit_error,
+                          "Microphone disconnected — plug it in and press the hotkey")
+
         if failed is not None:
-            GLib.idle_add(self._emit_error, f"STT failed: {failed}")
+            # A dead recorder is upstream of most ways this cycle can raise;
+            # a second toast about the symptom buries the actionable one.
+            if not recorder_dead.is_set():
+                GLib.idle_add(self._emit_error, f"STT failed: {failed}")
             self._idle_after_stt()
             _schedule_warmup()
             return
@@ -2673,6 +2743,7 @@ class GnomeSpeaksService:
         # and continuous dictation is on, restart via start_listening (legacy path
         # for non-loop mode, e.g. conversation_mode toggled on mid-session).
         if (not is_loop and not cancel_token.cancelled
+                and not recorder_dead.is_set()
                 and CONFIG.get("continuous_dictation", False)
                 and (natural_end or not self._stop_event.is_set())):
             if natural_end:


### PR DESCRIPTION
Closes #57. Also closes #48 — this is the **one consolidated dead-recorder fix**; PR #62 was closed in favour of this one and its work is folded in here.

`pw-record` keeps stdout open until it exits, so an unplugged USB mic reaches `_streaming_stt_cycle` as a plain EOF. The cycle read that as an ordinary "no speech": in loop mode it re-entered listening on the dead pipe forever (**42 cycles in 6 s**, badge stuck on `listening`), and in single-shot it went quietly idle with **no `Error` at all**.

## The fix

**Classify the EOF against `cancel_token`, not `_stopping()`.** `cancel_token` is the only signal that means *we* asked for this death — `stop()` cancels every live token *before* `_raise_wire()` kills the procs (`gnome-speaks-service.py:1512-1516`). `_stop_event` cannot serve: `stop_listening()` sets it, and so does `turn_end` — which in single-shot is set *by the very EOF being classified*, so a `not _stopping()` gate silences itself. `poll()` is the positive control: a quiet pipe is not proof of a lost mic, an exited process is.

**Latch the verdict; never act on it inline.** The cycle delivers whatever Azure returned through the normal path (REST fallback, spellbook, post-processing, injector), and the microphone `Error` is emitted **once, after the `try/finally`** — additional to the text, never instead of it. A mic yanked mid-utterance must not cost the user the words already transcribed.

**Then leave.** The three `continue` points (spell reply, loop-idle "no speech", end-of-cycle) refuse to re-open a mic that is gone; single-shot `continuous_dictation` does not restart onto it. `_schedule_warmup()` still runs — and a prewarmed recorder that already exited is now discarded, so the next session diagnoses a live attempt rather than a corpse from minutes ago.

`recorder_dead` is bound above `while True:` beside `user_text`/`natural_end`: the WS-init failure `break` leaves the cycle loop before any per-cycle state exists. `_wake_watcher` is untouched — already fixed by #65.

## Verification

Repro suite in `scratch/gnome-speaks-dreamteam/lucid-dead-recorder-repros/` (`run_all.sh <service.py>`), run against four trees:

| repro | main | #72 old head | #62 head | **this** |
|---|---|---|---|---|
| e — single-shot + turn.end still reports | FAIL | **FAIL** | PASS | **PASS** |
| f — text recognized before the yank survives | FAIL | **FAIL** | FAIL | **PASS** |
| g — WS-init break has no unbound locals | PASS | PASS | **FAIL** | **PASS** |
| h — stale prewarmed recorder discarded | FAIL | PASS | PASS | **PASS** |
| i — healthy loop keeps looping *(negative control)* | PASS | PASS | PASS | **PASS** |
| d — loop-mode spin (cancel-tokens suite) | FAIL, 42 cycles | PASS | PASS | **PASS** |

`repro_g` reproduces #62's original `UnboundLocalError: cannot access local variable 'rec_dead'`, so the instrument is proven able to see the defect it guards. `repro_i` is the negative control — a liveness detector failing toward a false positive would end a healthy loop session on the first quiet cycle.

Also green: cancel-tokens 5/5, service-audit 6/6, chronicle-perf 4/4, injector-seam + IBus 2/2, and #68's `verify_wake_gate.py`. `py_compile` clean.

## For the reviewer

1. When the cycle *also* raised, the generic `STT failed:` toast is suppressed in favour of the microphone one — a dead recorder is upstream of most ways this cycle can raise. `log.exception` still records the traceback. **Deliberate change to #66's failure envelope.**
2. A death discovered *after* `cancel_token.cancelled` is silent: the user asked to stop. Consistent with the cancelled-discard semantics, but a judgement call.

**Not done** (unchanged from the original PR): `_take_prewarmed_rec` liveness in **speech-to-cli** (other repo; the in-service `poll()` discard covers the symptom), and dropping the prewarm on `_refresh_audio_detection` device changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
