### PR TITLE
perf: cache the /api/version payload instead of forking git per request

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,9 @@ No test suite. Validate changes by:
    `lucid-service-audit-repros` (queue invariants, dispatch gate, config),
    `lucid-chronicle-perf-repros` (chronicle contract, archive, HTTP endpoints),
    `lucid-cancel-tokens-repros` (cancel-token verdicts, stop vs stop_listening),
-   `morpheus-injector-seam-repros` (Injector seam, IbusInjector). They import the service by
+   `morpheus-injector-seam-repros` (Injector seam, IbusInjector),
+   `lucid-version-cache-repros` (/api/version fork storm + realm-sigil contract).
+   They import the service by
    path and need no running service, D-Bus, mic or port 7710. Run the suite(s) covering the
    area you touched before opening a PR.
 
@@ -225,6 +227,7 @@ No test suite. Validate changes by:
    GS_SVC_PATH=$SVC       python3 lucid-cancel-tokens-repros/verify_cancel_invariants.py
    GS_SVC_PATH=$SVC       python3 morpheus-injector-seam-repros/verify_injector_seam.py
    GS_WT=$(dirname $SVC)  python3 morpheus-injector-seam-repros/verify_ibus_injector.py
+   GS_SVC_PATH=$SVC       python3 lucid-version-cache-repros/verify_version_cache.py
    ```
 
    `verify_ibus_injector.py` is the exception: it imports `ibus_injector` as a module rather

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -4579,6 +4579,13 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
     _voices_cache = (None, 0.0)
     _VOICES_CACHE_TTL = 300  # 5 minutes
 
+    # /api/version payload, built once on the first request (see
+    # _handle_version).  No TTL: the git facts in it describe the code this
+    # process loaded, so they cannot change while it runs.  ThreadingHTTPServer
+    # can land two pollers at once, hence the lock.
+    _version_cache = None
+    _version_cache_lock = threading.Lock()
+
     def log_message(self, format, *args):
         """Route HTTP log messages through the existing logger instead of stderr."""
         log.debug("HTTP %s", format % args)
@@ -4855,7 +4862,27 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
 
     def _handle_version(self):
         """GET /api/version — realm-sigil version contract (falls back to a
-        minimal payload when realm-sigil isn't installed)."""
+        minimal payload when realm-sigil isn't installed).
+
+        The payload is built once and reused.  hash/branch/dirty describe the
+        code this process loaded and cannot change while it runs, so deriving
+        them per request forked three git processes — one of them a full
+        working-tree scan — on every poll of the status board (#53).  Only
+        `uptime` is live, and it is refreshed *in place* so the key order the
+        realm-sigil contract ships with is untouched.
+        """
+        cls = SpeechHTTPHandler
+        with cls._version_cache_lock:
+            if cls._version_cache is None:
+                cls._version_cache = self._build_version_payload()
+            payload = dict(cls._version_cache)
+        payload["uptime"] = int(time.time() - _SERVICE_START_TIME)
+        self._send_json(payload)
+
+    @staticmethod
+    def _build_version_payload():
+        """The once-per-process half of /api/version: three git reads, the
+        realm-sigil call, and the host facts."""
         import socket as _socket
         repo_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -4891,7 +4918,7 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
             payload = {"name": "gnome-speaks", "version": hash_,
                        "hash": hash_, "branch": branch, "dirty": dirty,
                        "uptime": uptime}
-        self._send_json(payload)
+        return payload
 
     def _handle_status(self):
         svc = self.service


### PR DESCRIPTION
Closes #53

## The waste

`_handle_version` derived `hash` / `branch` / `dirty` on **every** GET by forking three git processes, the third being a full working-tree scan:

```
git -C <repo> rev-parse --short HEAD
git -C <repo> rev-parse --abbrev-ref HEAD
git -C <repo> status --porcelain      <- scans the whole tree
```

Measured on this checkout (warm cache): 2.5 + 2.6 + 3.8 ms ≈ **9 ms and 3 forks per request**, out of a long-lived desktop service that also owns a PipeWire recorder and a GLib main loop. Under a status-board poller that is a standing fork storm — and the answer never changes: those facts describe the code *this process loaded*.

## The fix

Split the derivation into `_build_version_payload()` and cache the result on the handler class, next to the existing `_voices_cache`. No TTL — nothing it records can change without a service restart. The build is guarded by a lock because the server is a `ThreadingHTTPServer` and two pollers can land at once.

`uptime` is still live: it is refreshed **in place** on a shallow copy, so the realm-sigil key order is untouched. The realm-sigil-absent fallback is cached the same way and keeps a live `uptime` too.

Lazy (first request) rather than at service start, deliberately: a user service started at login should not pay a `git status` nobody asked for.

## Is realm-sigil where the forks are?

**No.** `realm_sigil.version_dict()` is pure — it does no I/O and shells out to nothing; it only formats the values it is handed. Every fork was at this call site, so the caching belongs here.

Worth flagging separately, though: `realm_sigil/handler.py` has the *same* uncached three-fork `_git_info()` and, unlike this code, **no `timeout=`** on the `subprocess.run` calls — so any project wired up with `make_version_response()` / `version_handler()` has this bug plus a hang risk. gnome-speaks does not use that module. Library-side issue for the realm-sigil repo, not fixed here.

## Verification

New repro suite, `scratch/gnome-speaks-dreamteam/lucid-version-cache-repros` (imports the service by path; no running service, D-Bus, mic or port 7710 — `subprocess` is swapped for a counting shim inside the module under test only):

| check | origin/main | this branch |
|---|---|---|
| 20 sequential requests | **60** git processes (20 tree scans) | **3** |
| 8 threads x 25 requests | **600** git processes | **3** |
| payload vs origin/main, field for field | — | identical apart from `uptime`/`pid`/`built`/`started` |
| key order | — | identical |
| `uptime` still tracks service life | — | yes (advances without re-forking) |
| realm-sigil-absent fallback | 3 forks/request | 3 total, `uptime` still live |

The suite is red on `origin/main` and green here (positive control run both ways).

Existing suites, all green on this file, run serially: `verify_queue_invariants`, `verify_archive`, `verify_cancel_invariants`, `verify_injector_seam`, `verify_ibus_injector`, `verify_wake_gate`, `lucid-dead-recorder-repros/run_all.sh`. `py_compile` clean.

Touches only `_handle_version` and the handler's class attributes — no overlap with the `_streaming_stt_cycle` work in #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)