### PR TITLE
perf: take the prefs Audio page's 8 blocking spawns off the GTK main thread (#54)

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -92,11 +92,15 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         this._settings = this.getSettings();
         this._saveTimeoutId = null;
         this._ccaSaveTimeoutId = null;
+        // Cancels any async system probe still in flight when the window
+        // closes, so its callback never touches a destroyed row.
+        this._probeCancellable = new Gio.Cancellable();
 
         window.set_default_size(720, 860);
         window.set_search_enabled(true);
 
         window.connect('close-request', () => {
+            this._probeCancellable.cancel();
             this._flushConfigSave();
             this._flushCcaConfigSave();
             return false;
@@ -667,9 +671,6 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         });
 
         // ── Audio Devices ──
-        const sinks = this._enumeratePipeWireDevices('sinks');
-        const sources = this._enumeratePipeWireDevices('sources');
-
         const devGroup = new Adw.PreferencesGroup({title: 'Audio Devices'});
         page.add(devGroup);
 
@@ -685,8 +686,25 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         }
         this._addComboRow(devGroup, 'Player', 'player', playerOptions, 'auto');
 
-        this._addComboRow(devGroup, 'Speaker', 'speaker_sink',
-            [['', 'System Default'], ...sinks], '');
+        // Speaker and Microphone are filled in when the async `wpctl status`
+        // below answers. Until then the row offers System Default plus a
+        // stand-in for whatever the config already names — a row that shows
+        // "System Default" while the config says otherwise is a row lying
+        // about the current setting.
+        const pendingOptions = configKey => {
+            const saved = this._config[configKey];
+            const options = [['', 'System Default']];
+            if (saved !== undefined && saved !== null && String(saved) !== '')
+                options.push([String(saved), 'Current device — checking…']);
+            return options;
+        };
+
+        const speakerWhat = 'Where speech comes out.';
+        const micWhat = 'Where dictation is heard from.';
+
+        const speakerRow = this._addComboRow(devGroup, 'Speaker', 'speaker_sink',
+            pendingOptions('speaker_sink'), '');
+        speakerRow.subtitle = `${speakerWhat} Looking for devices…`;
 
         const recorderOptions = [['auto', 'Auto-detect']];
         for (const [cmd, label] of [
@@ -698,8 +716,14 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         }
         this._addComboRow(devGroup, 'Recorder', 'recorder', recorderOptions, 'auto');
 
-        this._addComboRow(devGroup, 'Microphone', 'mic_source',
-            [['', 'System Default'], ...sources], '');
+        const micRow = this._addComboRow(devGroup, 'Microphone', 'mic_source',
+            pendingOptions('mic_source'), '');
+        micRow.subtitle = `${micWhat} Looking for devices…`;
+
+        this._enumeratePipeWireDevicesAsync((sinks, sources) => {
+            this._fillDeviceRow(speakerRow, sinks, speakerWhat);
+            this._fillDeviceRow(micRow, sources, micWhat);
+        });
 
         const duplexRow = this._addComboRow(devGroup, 'Speak While Listening', 'half_duplex', [
             ['auto', 'Auto — speakers take turns, headphones overlap'],
@@ -823,7 +847,7 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
     // ═══════════════════════════════════════════════════════════════════
 
     _addComboRow(group, title, configKey, options, defaultValue) {
-        const values = options.map(o => o[0]);
+        let values = options.map(o => o[0]);
         const labels = options.map(o => o[1]);
 
         const currentValue = this._config[configKey] ?? defaultValue;
@@ -837,7 +861,14 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
             selected: selectedIdx,
         });
 
+        // Raised only while the model is swapped programmatically (an async
+        // probe landing). Swapping a model moves `selected`, and that
+        // notify is not a user choice — letting it reach the config would
+        // silently rewrite the very setting the row is still loading.
+        let suppressWrite = false;
+
         row.connect('notify::selected', () => {
+            if (suppressWrite) return;
             const idx = row.get_selected();
             if (idx >= 0 && idx < values.length) {
                 const val = values[idx];
@@ -847,6 +878,22 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
                     this._setConfigValue(configKey, val);
             }
         });
+
+        // Replace the option list in place, re-selecting whatever the config
+        // holds. Safe to call at any time; writes nothing.
+        row._gsSetOptions = newOptions => {
+            values = newOptions.map(o => o[0]);
+            const value = this._config[configKey] ?? defaultValue;
+            let idx = values.findIndex(v => String(v) === String(value));
+            if (idx < 0) idx = 0;
+            suppressWrite = true;
+            try {
+                row.model = Gtk.StringList.new(newOptions.map(o => o[1]));
+                row.selected = idx;
+            } finally {
+                suppressWrite = false;
+            }
+        };
 
         group.add(row);
         return row;
@@ -1177,16 +1224,54 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
     // ═══════════════════════════════════════════════════════════════════
 
     /**
-     * Enumerate PipeWire sinks or sources by parsing `wpctl status`.
+     * Run `wpctl status` off the main loop — ONCE — and hand both device
+     * lists to the callback. `wpctl` can take arbitrarily long when
+     * PipeWire is busy (at login, say), and this used to run twice
+     * synchronously while the prefs window waited to paint.
+     *
+     * The callback never fires after the window closes. Any failure
+     * (wpctl missing, non-zero exit) yields empty lists — exactly what the
+     * old synchronous probe did.
+     */
+    _enumeratePipeWireDevicesAsync(callback) {
+        let proc;
+        try {
+            proc = Gio.Subprocess.new(['wpctl', 'status'],
+                Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE);
+        } catch (e) {
+            callback([], []);   // wpctl not installed
+            return;
+        }
+
+        proc.communicate_utf8_async(null, this._probeCancellable, (obj, res) => {
+            if (this._probeCancellable.is_cancelled()) return;
+            let output = '';
+            try {
+                const [, stdout] = obj.communicate_utf8_finish(res);
+                if (obj.get_successful()) output = stdout ?? '';
+            } catch (e) {
+                output = '';    // wpctl died — empty lists, as before
+            }
+            callback(this._parsePipeWireDevices(output, 'sinks'),
+                this._parsePipeWireDevices(output, 'sources'));
+        });
+    }
+
+    /** Swap an audio-device row's placeholder list for the probed one. */
+    _fillDeviceRow(row, devices, what) {
+        row._gsSetOptions([['', 'System Default'], ...devices]);
+        row.subtitle = devices.length
+            ? `${what} Default: System Default`
+            : `${what} No PipeWire devices found — using the system default.`;
+    }
+
+    /**
+     * Pull PipeWire sinks or sources out of `wpctl status` output.
      * Returns [[nodeId, label], ...] suitable for _addComboRow.
      */
-    _enumeratePipeWireDevices(type) {
+    _parsePipeWireDevices(output, type) {
         const devices = [];
         try {
-            const [ok, stdout, stderr, exitCode] = GLib.spawn_command_line_sync('wpctl status');
-            if (!ok || exitCode !== 0) return devices;
-
-            const output = new TextDecoder('utf-8').decode(stdout);
             const lines = output.split('\n');
 
             const header = type === 'sinks' ? 'Sinks:' : 'Sources:';
@@ -1228,18 +1313,17 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
                 }
             }
         } catch (e) {
-            // wpctl not available — return empty list
+            // Unparseable output — return empty list
         }
         return devices;
     }
 
+    /**
+     * PATH lookup with no fork — `which` used to be spawned synchronously
+     * six times before the Audio page could paint.
+     */
     _commandExists(cmd) {
-        try {
-            const [ok, stdout, stderr, exitCode] = GLib.spawn_command_line_sync(`which ${cmd}`);
-            return ok && exitCode === 0;
-        } catch (e) {
-            return false;
-        }
+        return GLib.find_program_in_path(cmd) !== null;
     }
 
     // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #54.

## What was wrong

Building the Advanced page ran **eight synchronous process spawns on the GTK main thread** before the prefs window could paint — `wpctl status` twice (identical output, parsed twice) and `which <cmd>` six times.

Measured warm on this machine:

| | blocking cost |
|---|---|
| `2x wpctl status` | 19–20 ms |
| `6x which` | 6.0 ms |
| **total, before** | **~26 ms** |
| `6x GLib.find_program_in_path` | **0.1 ms** |
| `wpctl status` (async) | **0 ms** |

And ~26 ms is only the warm figure — a sync spawn has no timeout, so this is unbounded whenever PipeWire is busy (at login, say). The prefs window is where `injection_method` and the wake gate get flipped, so a hitch there is felt.

## What changed (prefs.js only, no new dependencies)

- **`_commandExists` → `GLib.find_program_in_path`.** No fork at all; six spawns become a PATH stat. Verified to agree with `which(1)` on all six commands, plus a known-absent control so the check is proven able to return false.
- **`_enumeratePipeWireDevices(type)` splits into fetch + parse:** `_enumeratePipeWireDevicesAsync` (one `Gio.Subprocess` + `communicate_utf8_async`) and the pure `_parsePipeWireDevices(output, type)`. One spawn instead of two, off the main loop. **The parse loop is byte-identical to `origin/main`** (`diff` of the extracted 39 lines: no change).
- **Speaker/Microphone render immediately** with a `Looking for devices…` subtitle and fill in when the probe answers. The placeholder carries a stand-in entry for whatever the config already names, and keeps it *selected* — a row showing "System Default" while the config says otherwise is a row lying about the current setting, and the whole point of this issue is that the window in which it lies can be long.
- **`_addComboRow` gains `_gsSetOptions` + a `suppressWrite` guard.** This is the subtle one: swapping a `Gtk.StringList` moves `selected`, which emits `notify::selected`, which the existing handler treats as a user choice. Without the guard the async fill would **silently rewrite the very setting it was still loading**.
- **The in-flight probe is cancelled on `close-request`,** so its callback can never touch a destroyed row.

Row subtitles carry the explanation (searchable), and the explanatory half is present from the first frame rather than appearing only after the probe — libadwaita search matches subtitles, so a placeholder-only subtitle would be a temporary hole in search.

## Behavior parity

Every failure path keeps the old behavior exactly — wpctl missing, wpctl exiting non-zero, or a saved device that has since disappeared all leave the row on System Default and **write nothing to config**.

## Verification

`node --check prefs.js` clean. Beyond that, `gnome-extensions prefs` loads the *installed* copy, not the worktree, so it cannot verify this change. Instead the page was built in a **real, mapped `Adw.PreferencesWindow`** driven by a standalone harness on a `gtk4-broadwayd` display (nothing touches the live session), with a sandboxed `HOME` and `GSETTINGS_BACKEND=memory`, and with **`origin/main` run through the identical harness as the baseline**:

| check | result |
|---|---|
| Final option lists | identical to `origin/main` |
| Selected indices (saved sink `63` / source `65`) | identical to `origin/main` |
| Config writes during async fill | **none** (guard holds) |
| stderr vs `origin/main` | **byte-identical** — zero new Gtk/Adw warnings |
| Window closed mid-probe | callback suppressed, no crash, no warnings |
| `wpctl` exits 1 (PipeWire down) | empty lists, honest subtitle, saved value **not** wiped |
| `wpctl` absent | `Gio.Subprocess.new` throws → `callback([], [])` (branch proven reachable) |

Note the baseline run surfaced **5 pre-existing** `Gtk-WARNING`s on `main` (keybinding markup ×4, `Privacy & Debug` unescaped ampersand ×1). They are untouched here and are not caused by this change — flagging them as a possible separate issue.