### PR TITLE
fix: subtitle progress reads its utterance's token, not the cancel wire

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,8 @@ No test suite. Validate changes by:
    `lucid-service-audit-repros` (queue invariants, dispatch gate, config),
    `lucid-chronicle-perf-repros` (chronicle contract, archive, HTTP endpoints),
    `lucid-cancel-tokens-repros` (cancel-token verdicts, stop vs stop_listening),
-   `lucid-subtitle-token-repros` (subtitle progress reads its utterance's token, not the wire),
+   `lucid-subtitle-token-repros` (subtitle progress reads its utterance's token, not the wire;
+   e4 is the composed cycle-then-reply case),
    `morpheus-injector-seam-repros` (Injector seam, IbusInjector),
    `lucid-version-cache-repros` (/api/version fork storm + realm-sigil contract).
    They import the service by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,10 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
   record this queue outcome, restart the loop — must read that operation's `CancelToken`, never the
   wire. Never reintroduce a bare `state._cancel_event.clear()` in a worker; go through
   `self._cancels` (`issue` → `begin` → `retire`), and retire on every exit or the token leaks into
-  the live set forever.
+  the live set forever. `CancelRegistry` is now the **only** place in the service that touches the
+  wire — #42 took the last two reads out of `_run_subtitle_progress` — so
+  `grep -n "_cancel_event" gnome-speaks-service.py` returning only that class and prose is a cheap
+  standing check that no new verdict is being read off the wire.
 - **`stop()` and `stop_listening()` both set `_stop_event` and mean opposite things**:
   `stop_listening()` is the dictation hotkey — end the utterance, **keep** the text.  `stop()` is the
   panic stop (D-Bus Stop, `POST /stop`, "cast stop", every user-speech preemption) — **abandon** it.
@@ -213,7 +216,10 @@ No test suite. Validate changes by:
    `lucid-service-audit-repros` (queue invariants, dispatch gate, config),
    `lucid-chronicle-perf-repros` (chronicle contract, archive, HTTP endpoints),
    `lucid-cancel-tokens-repros` (cancel-token verdicts, stop vs stop_listening),
-   `morpheus-injector-seam-repros` (Injector seam, IbusInjector). They import the service by
+   `lucid-subtitle-token-repros` (subtitle progress reads its utterance's token, not the wire),
+   `morpheus-injector-seam-repros` (Injector seam, IbusInjector),
+   `lucid-version-cache-repros` (/api/version fork storm + realm-sigil contract).
+   They import the service by
    path and need no running service, D-Bus, mic or port 7710. Run the suite(s) covering the
    area you touched before opening a PR.
 
@@ -229,8 +235,10 @@ No test suite. Validate changes by:
    GS_SVC_PATH=$SVC       python3 lucid-service-audit-repros/verify_queue_invariants.py
    GS_SVC_PATH=$SVC       python3 lucid-chronicle-perf-repros/verify_archive.py
    GS_SVC_PATH=$SVC       python3 lucid-cancel-tokens-repros/verify_cancel_invariants.py
+   bash lucid-subtitle-token-repros/run_all.sh $SVC
    GS_SVC_PATH=$SVC       python3 morpheus-injector-seam-repros/verify_injector_seam.py
    GS_WT=$(dirname $SVC)  python3 morpheus-injector-seam-repros/verify_ibus_injector.py
+   GS_SVC_PATH=$SVC       python3 lucid-version-cache-repros/verify_version_cache.py
    ```
 
    `verify_ibus_injector.py` is the exception: it imports `ibus_injector` as a module rather

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -1456,6 +1456,12 @@ class CancelRegistry:
 
     Lock order: the registry never calls back into the service, so its lock is
     always innermost (``_queue_current_lock -> registry`` is safe).
+
+    This class is the ONLY place in the service that touches
+    ``state._cancel_event``.  Everywhere else reads a token, so
+    ``grep -n "_cancel_event" gnome-speaks-service.py`` returning only this
+    class and prose is a usable check that no verdict is being taken from the
+    wire again (issue #42).
     """
 
     def __init__(self):
@@ -3348,20 +3354,33 @@ class GnomeSpeaksService:
         """Emit AudioLevel from TTS audio stream for badge VU effect."""
         GLib.idle_add(self._emit_audio_level, level)
 
-    def _run_subtitle_progress(self, text, estimated_duration, stop_event):
+    def _run_subtitle_progress(self, text, estimated_duration, stop_event,
+                               token):
         """Emit SubtitleUpdate signals every 200ms during TTS playback.
 
         Runs in a daemon thread alongside TTS. Respects pause and cancel.
+
+        The cancel it respects is its OWN utterance's verdict, never the
+        process-global wire (``state._cancel_event``). The wire belongs to
+        whichever operation last called ``CancelRegistry.begin()``, so reading
+        it here meant two wrong answers: another operation's cancel froze this
+        subtitle mid-word, and a later ``begin()`` lowering the wire let a
+        cancelled utterance still emit its 100 % "finished" frame. The token is
+        set once and never reset, so neither can happen (issue #42).
+
         Args:
             text: Full text being spoken.
             estimated_duration: Estimated speech duration in seconds.
             stop_event: threading.Event — set when TTS finishes.
+            token: CancelToken of the utterance being spoken — this thread's
+                only cancellation verdict. None means "no verdict available"
+                and is treated as not cancelled.
         """
         start_time = time.monotonic()
         pause_accumulated = 0.0
         pause_start = None
         while not stop_event.is_set():
-            if state._cancel_event.is_set():
+            if token is not None and token.cancelled:
                 break
             # Handle pause
             if state._pause_event.is_set():
@@ -3378,12 +3397,16 @@ class GnomeSpeaksService:
             GLib.idle_add(self._emit_subtitle_update, text, estimated_duration, pct)
             stop_event.wait(timeout=0.2)
 
-        # Final emission at 100%
-        if not state._cancel_event.is_set():
+        # Final emission at 100% — only if THIS utterance really finished.
+        if token is None or not token.cancelled:
             GLib.idle_add(self._emit_subtitle_update, text, estimated_duration, 100)
 
     def _subtitle_queue_worker(self, subtitle_q):
-        """Single subtitle thread that processes (text, duration) tuples from a queue.
+        """Single subtitle thread that processes subtitle items from a queue.
+
+        Items are ``(text, estimated_duration, stop_event, token)``; the token
+        travels with the sentence so each progress run judges by the reply's
+        own verdict rather than the shared wire (issue #42).
 
         Eliminates per-sentence thread creation overhead (~5-10ms each).
         Reads from subtitle_q until a None sentinel is received.
@@ -3392,8 +3415,9 @@ class GnomeSpeaksService:
             item = subtitle_q.get()
             if item is None:
                 break
-            text, estimated_duration, stop_event = item
-            self._run_subtitle_progress(text, estimated_duration, stop_event)
+            text, estimated_duration, stop_event, token = item
+            self._run_subtitle_progress(text, estimated_duration, stop_event,
+                                        token)
 
     def _speak_worker(self, text, voice=None, quality=None, output_file=None,
                       user_initiated=True, suppress_idle=False,
@@ -3437,7 +3461,7 @@ class GnomeSpeaksService:
             sub_stop = threading.Event()
             sub_thread = threading.Thread(
                 target=self._run_subtitle_progress,
-                args=(text, est_dur, sub_stop),
+                args=(text, est_dur, sub_stop, token),
                 daemon=True,
             )
             sub_thread.start()
@@ -3913,7 +3937,7 @@ class GnomeSpeaksService:
             sub_stop = threading.Event()
             sub_thread = threading.Thread(
                 target=self._run_subtitle_progress,
-                args=(text, est_dur, sub_stop),
+                args=(text, est_dur, sub_stop, token),
                 daemon=True,
             )
             sub_thread.start()
@@ -4330,7 +4354,12 @@ class GnomeSpeaksService:
             first_sentence = True
             spoke_anything = False
 
-            # Single subtitle thread for the entire conversation (Fix 7)
+            # Single subtitle thread for the entire conversation (Fix 7).
+            # cancel_token (issued at the first spoken sentence) rides the
+            # queue with every sentence, so a subtitle run judges by this
+            # reply's verdict and not the shared wire (issue #42). It is None
+            # until then, which _run_subtitle_progress reads as "not
+            # cancelled" — the same answer the wire gave before it is issued.
             subtitle_q = queue.Queue()
             subtitle_thread = threading.Thread(
                 target=self._subtitle_queue_worker,
@@ -4403,7 +4432,7 @@ class GnomeSpeaksService:
                     _sf = 22.0 if self._voice_quality == "fast" else 15.0
                     _sd = max(1.0, len(sentence) / _sf)
                     _ss = threading.Event()
-                    subtitle_q.put((sentence, _sd, _ss))
+                    subtitle_q.put((sentence, _sd, _ss, cancel_token))
                     speech_tts.tts(sentence, quality=self._voice_quality,
                                    speed=CONFIG.get("speed", 1.0),
                                    pitch=CONFIG.get("pitch", "default"),
@@ -4431,7 +4460,7 @@ class GnomeSpeaksService:
                 _sf = 22.0 if self._voice_quality == "fast" else 15.0
                 _sd = max(1.0, len(remainder) / _sf)
                 _ss = threading.Event()
-                subtitle_q.put((remainder, _sd, _ss))
+                subtitle_q.put((remainder, _sd, _ss, cancel_token))
                 speech_tts.tts(remainder, quality=self._voice_quality,
                                speed=CONFIG.get("speed", 1.0),
                                pitch=CONFIG.get("pitch", "default"),


### PR DESCRIPTION
Closes #42.

## What was wrong

PR #33 split the two jobs that had been riding on `state._cancel_event`: the **wire** interrupts a library call already in flight, the **`CancelToken`** is the verdict about a finished operation. Two reads of the wire survived that refactor in `_run_subtitle_progress`, and they were the last place in the service where a verdict was taken from a process-global bit.

They are wrong in opposite directions:

* **loop-top check** — breaks on *any* operation's cancel, so a stop or skip aimed somewhere else freezes this utterance's subtitle mid-word.
* **final check** — emits the 100 % "finished" frame whenever the wire happens to be down, and the next operation's `begin()` lowers it perfectly legitimately. So a **cancelled** utterance still reports completion: an item recorded `interrupted` in `GET /queue` shows the user a subtitle that ran to 100 %.

## The fix

Thread the utterance's own token through. `_run_subtitle_progress(text, est, stop_event, token)`; `_speak_worker` and `_talk_worker` hand over the token they already own; the streaming AI reply carries its `cancel_token` (one per reply, issued at its first spoken sentence) in the `subtitle_q` tuple, which `_subtitle_queue_worker` now unpacks. `None` reads as "not cancelled" — the same answer the wire gave before a token exists.

`CancelRegistry` is now the **only** place in the service that touches the wire, so `grep -n "_cancel_event" gnome-speaks-service.py` returning only that class and prose is a cheap standing check that no new verdict is being read off the wire. Recorded in the registry docstring and in CLAUDE.md's cancel-wire gotcha so the grep stays usable.

## Verification

New suite `lucid-subtitle-token-repros` (3 repros, reusing the `lucid-cancel-tokens-repros` harness; adds a `GLibSpy` that records `SubtitleUpdate` frames, since the harness runs no GLib main loop). **All three red on `origin/main`, all three green here**, stable over repeated runs:

| repro | on `origin/main` | on this branch |
|---|---|---|
| `e1` preempted queue item — real `stop(drain_queue=False)` + `speak()` path | frames `[0, 17, 35, 100]` — 100 % emitted for an item recorded `interrupted` | `[0, 17, 35]` |
| `e2` foreign cancel while this utterance runs | 0 further frames, no 100 % — subtitle frozen by someone else's cancel | 3 further frames, 100 % |
| `e3` streaming AI reply through `subtitle_q` | `[0, 20, 40, 100]` for a cancelled reply | `[0, 20, 40]` |

`e1`/`e3` widen one real window — a single frame's `GLib.idle_add` stalls, which is what publishing to a busy Shell main loop actually does — and both hold a `cancel → tts observes it → begin()` rendezvous so the interleaving is fixed rather than lucky. Both report **SETUP FAILURE** rather than a pass if the wire was not actually lowered, so `origin/main` cannot pass for the wrong reason. `e3` doubles as the regression guard on the `subtitle_q` tuple arity: a mismatch would kill the queue worker thread and silently take AI-reply subtitles with it.

Also green on this branch: `verify_queue_invariants`, `verify_archive`, `verify_cancel_invariants`, `verify_injector_seam`, `verify_ibus_injector`, `verify_wake_gate`, `lucid-dead-recorder-repros` (5/5), `verify_version_cache`, plus `py_compile`.

No service restart, no port 7710, no `~/.config` writes, no mic — JP is dictating on this desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)