### PR TITLE
fix: 5 prefs labels render BLANK — markup parsing eats the shortcut rows and the Privacy group title

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,40 @@ No test suite. Validate changes by:
    between runs. Get a baseline on `main` before blaming your branch, and wipe the suite's
    state dir if a second run disagrees with the first.
 
+8. **prefs.js changes: the broadway rig.** Lives in the same scratch dir as the suites above,
+   as `luna-prefs-async-repros/`. ⚠️ **`gnome-extensions prefs
+   gnome-speaks@jphein` CANNOT verify a worktree** -- it goes through the live shell and opens
+   the copy **installed** in `~/.local/share/gnome-shell/extensions`, so it renders the OLD
+   prefs.js and reports success. Item 5 does not cover this either: gnome-shell never loads
+   prefs.js at all (the prefs window is a separate process), so a clean headless shell says
+   nothing about it.
+
+   ```bash
+   cd ~/.claude/projects/-home-jp/scratch/gnome-speaks-dreamteam/luna-prefs-async-repros
+   ./run.sh ~/Projects/gnome-speaks-wt/<wt>/prefs.js                     # one file
+   ./run.sh ~/Projects/gnome-speaks-wt/<wt>/prefs.js /path/to/main.js    # + baseline diff
+   ```
+
+   It builds a **real, mapped `Adw.PreferencesWindow`** on a `gtk4-broadwayd` virtual display,
+   so **no window appears and no focus is stolen -- safe to run while JP is dictating**. `HOME`
+   is sandboxed and `GSETTINGS_BACKEND=memory` is forced, so a run can never write
+   `~/.config/speech-to-cli/config.json` or dconf. It reports per combo row: options and
+   selected index **synchronously** and again **after async probes land**; `WRITES` (must be
+   `none` -- swapping a `Gtk.StringList` moves `selected` and emits `notify::selected`, which
+   `_addComboRow` treats as a user choice, so a careless async fill rewrites the setting it is
+   still loading); and `BLANK_RENDERED`.
+
+   ⭐ **`BLANK_RENDERED` exists because a property snapshot cannot see a markup failure.** When
+   `set_markup` fails, the *property* keeps the string and the *label* is left EMPTY, so the
+   bug is invisible both in the code and in any check that reads properties. It flags anything
+   whose text is set but renders blank. On `main` before the markup fix it found 5 -- four shortcut rows
+   whose subtitles are raw accelerators (`<Super><Alt>space` parses as an unclosed tag) and the
+   `Privacy & Debug` group title.
+
+   **Always pass a baseline.** A run that CRASHED also produces "no new warnings", so `run.sh`
+   requires the harness to print `EXIT_CLEAN` before it believes any stderr comparison -- two
+   crashes have identical stderr and would otherwise read as a pass.
+
 ## Git
 
 Conventional commits (`feat:`, `fix:`, `refactor:`). Branch naming: `<type>/<short-description>`.

--- a/prefs.js
+++ b/prefs.js
@@ -751,7 +751,9 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         this._addCorrectionsRow(correctGroup);
 
         // ── Privacy & Debug ──
-        const privGroup = new Adw.PreferencesGroup({title: 'Privacy & Debug'});
+        // Group titles are markup-parsed and have no use-markup toggle, so a
+        // bare '&' blanked this heading entirely. Renders as 'Privacy & Debug'.
+        const privGroup = new Adw.PreferencesGroup({title: 'Privacy &amp; Debug'});
         page.add(privGroup);
 
         this._addEntryRow(privGroup, 'Save Spoken Audio To', 'save_audio_dir', '',
@@ -1124,10 +1126,22 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         const shortcuts = this._settings.get_strv(settingsKey);
         const currentShortcut = shortcuts.length > 0 ? shortcuts[0] : 'Disabled';
 
+        // An accelerator like `<Super><Alt>space` is not Pango markup, but
+        // AdwActionRow parses its subtitle as markup, so `<Super>` reads as an
+        // unclosed tag and the label is left EMPTY -- the row silently stopped
+        // showing the user their own keybinding.
+        //
+        // Two non-obvious parts, both measured; do not "tidy" either away:
+        //   1. `use_markup` governs the subtitle too, not just the title.
+        //   2. The subtitle must be assigned AFTER construction. Passing it in
+        //      the same literal still warns and still blanks, whichever order
+        //      the properties are written in -- construct-time property order
+        //      is not ours to choose.
         const row = new Adw.ActionRow({
             title: title,
-            subtitle: currentShortcut,
+            use_markup: false,
         });
+        row.subtitle = currentShortcut;
 
         const editButton = new Gtk.Button({
             label: 'Change',


### PR DESCRIPTION
Follow-up to #76, which baselined these five `Gtk-WARNING`s on `main`.

## They are not log noise — they are five blank labels

When GTK's `set_markup` fails it leaves the label **empty**. The *property* keeps its string, which is why this is invisible when reading the code **and** invisible to any check that reads properties. Walking to the rendered `Gtk.Label` and calling `get_text()`:

| element | property holds | user actually sees |
|---|---|---|
| shortcut row subtitle | `"<Super><Alt>space"` | **`""`** |
| group title | `"Privacy & Debug"` | **`""`** |

So on `main`, **with stock default settings**:

- **All four Dictation shortcut rows show a blank subtitle** — a user cannot see what their own keybinding is. `_addShortcutRow` puts the raw GSettings accelerator in the subtitle, and `AdwActionRow` parses subtitles as markup, so `<Super>` reads as an unclosed tag.
- **The `Privacy & Debug` group heading is unlabeled** — group titles are markup-parsed and a bare `&` fails the parse.

Both reproduce from schema defaults, so this is every user, not a local config quirk.

## The fixes, and the two non-obvious parts

**Shortcut rows:** `use_markup: false` on the row, subtitle assigned **after** construction. Two things here are measured, not reasoned about, and both are commented in-place so they don't get tidied away:

1. `use_markup` governs the **subtitle** as well as the title (the property is documented in terms of the title).
2. The subtitle must be assigned after construction. Passing it in the same constructor literal **still warns and still blanks, whichever order the properties are written in** — construct-time property order is not ours to choose. The "obvious" one-liner (`use_markup: false` alongside `subtitle:`) looks correct and leaves all four warnings firing.

This also makes the Change dialog's later `row.subtitle = val` safe. Escaping at the call site would not have: there are **two** write sites, and missing the second reintroduces the bug silently.

**Group title:** escaped to `Privacy &amp; Debug`. `AdwPreferencesGroup` has no use-markup property (`'use_markup' in group === false`), so escaping is the only route. Renders identically to before.

## Deliberately NOT changed

- **The Change dialog body**, `Enter a keyboard shortcut (e.g. <Super><Alt>space):`. It *looks* like the same bug and is not — `AdwAlertDialog:body-use-markup` defaults to **false**, so it renders correctly today. Measured: escaping it renders the literal `&lt;Super&gt;&lt;Alt&gt;space`, i.e. the reflex fix would have *introduced* the bug it appears to have.
- **The `Voice & Sound` and `Wake & Spells` page titles.** Page titles are not markup-parsed — confirmed by their absence from a warning run that was firing for other strings in the same pass, so that is a proven-live instrument, not a blind zero.

## Verification

Run with the prefs rig from #76, against merged `main` as baseline:

| | baseline (`main`) | branch |
|---|---|---|
| `BLANK_RENDERED` | **5** | **none** |
| Gtk/Adw warnings | **5** | **0** |
| branch stderr | — | **entirely empty** |
| `WRITES` | none | none |

`BLANK_RENDERED` is a new generic check added to the rig for this: it flags anything whose text is set but renders blank, with no per-row knowledge. It **independently rediscovers exactly the five blanked labels on `main`**, so the branch's `none` is a proven-live zero rather than an unproven one. `WRITES none` on both confirms #76's combo-row guard still holds.

Also adds the rig to **CLAUDE.md §Testing as item 8**, including the trap that makes it necessary: `gnome-extensions prefs gnome-speaks@jphein` goes through the live shell and opens the copy **installed** in `~/.local/share/gnome-shell/extensions`, so it renders the OLD prefs.js and reports success — it cannot verify a worktree. Item 5's headless shell doesn't cover it either, since gnome-shell never loads prefs.js at all.