### PR TITLE
fix: shortcut subtitles and 'Privacy & Debug' heading rendered blank — markup parse failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,58 @@ No test suite. Validate changes by:
    between runs. Get a baseline on `main` before blaming your branch, and wipe the suite's
    state dir if a second run disagrees with the first.
 
+8. **prefs.js changes: the broadway rig.** Lives in the same scratch dir as the suites above,
+   as `luna-prefs-async-repros/`. ⚠️ **`gnome-extensions prefs
+   gnome-speaks@jphein` CANNOT verify a worktree** -- it goes through the live shell and opens
+   the copy **installed** in `~/.local/share/gnome-shell/extensions`, so it renders the OLD
+   prefs.js and reports success. Item 5 does not cover this either: gnome-shell never loads
+   prefs.js at all (the prefs window is a separate process), so a clean headless shell says
+   nothing about it.
+
+   ```bash
+   cd ~/.claude/projects/-home-jp/scratch/gnome-speaks-dreamteam/luna-prefs-async-repros
+   ./run.sh ~/Projects/gnome-speaks-wt/<wt>/prefs.js                     # one file
+   ./run.sh ~/Projects/gnome-speaks-wt/<wt>/prefs.js /path/to/main.js    # + baseline diff
+   ```
+
+   It builds a **real, mapped `Adw.PreferencesWindow`** on a `gtk4-broadwayd` virtual display,
+   so **no window appears and no focus is stolen -- safe to run while JP is dictating**. `HOME`
+   is sandboxed and `GSETTINGS_BACKEND=memory` is forced, so a run can never write
+   `~/.config/speech-to-cli/config.json` or dconf. It reports per combo row: options and
+   selected index **synchronously** and again **after async probes land**; `WRITES` (must be
+   `none` -- swapping a `Gtk.StringList` moves `selected` and emits `notify::selected`, which
+   `_addComboRow` treats as a user choice, so a careless async fill rewrites the setting it is
+   still loading); and `BLANK_RENDERED`.
+
+   ⭐ **`BLANK_RENDERED` exists because a property snapshot cannot see a markup failure.** When
+   `set_markup` fails, the *property* keeps the string and the *label* is left EMPTY, so the
+   bug is invisible both in the code and in any check that reads properties. It flags anything
+   whose text is set but renders blank. On `main` before the markup fix it found 5 -- four shortcut rows
+   whose subtitles are raw accelerators (`<Super><Alt>space` parses as an unclosed tag) and the
+   `Privacy & Debug` group title.
+
+   **Always pass a baseline.** A run that CRASHED also produces "no new warnings", so `run.sh`
+   requires the harness to print `EXIT_CLEAN` before it believes any stderr comparison -- two
+   crashes have identical stderr and would otherwise read as a pass.
+
+   **Exit contract:** 0 = both runs completed; 1 = a run did not complete, or the branch emits
+   MORE warnings than the baseline. A differing stderr is **not** failure -- a fix is supposed
+   to change stderr, and keying the exit code on `diff` made a successful run report 1.
+
+   **Isolation contract** -- the same shape the service-side suites enforce, and none of it is
+   optional:
+   - Everything a run writes lives under `run-$$` and is deleted on exit. **No fixed paths**,
+     so two rigs running at once cannot share a sandbox, a schema dir, or a broadway socket
+     (the display number is per-PID and probed until one binds). Verified by running two
+     concurrently: distinct dirs, distinct displays, identical verdicts, no leftovers.
+   - The `config.json` handed to prefs.js is a **rig-owned fixture with pinned keys**.
+     `~/.config/speech-to-cli/config.json` is **never read** -- an earlier version copied it
+     and let 47 of JP's live keys steer the verdict, and cached that copy forever behind an
+     `if [ ! -f ]`. Device ids in the fixture come from live `wpctl`, so the "config names a
+     device" path is exercised on any machine.
+   - `HOME` and `GSETTINGS_BACKEND=memory` are exported into the gjs child only, never into
+     the calling shell, so a run cannot write the real config or dconf.
+
 ## Git
 
 Conventional commits (`feat:`, `fix:`, `refactor:`). Branch naming: `<type>/<short-description>`.

--- a/prefs.js
+++ b/prefs.js
@@ -751,7 +751,9 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         this._addCorrectionsRow(correctGroup);
 
         // ── Privacy & Debug ──
-        const privGroup = new Adw.PreferencesGroup({title: 'Privacy & Debug'});
+        // Group titles are markup-parsed and have no use-markup toggle, so a
+        // bare '&' blanked this heading entirely. Renders as 'Privacy & Debug'.
+        const privGroup = new Adw.PreferencesGroup({title: 'Privacy &amp; Debug'});
         page.add(privGroup);
 
         this._addEntryRow(privGroup, 'Save Spoken Audio To', 'save_audio_dir', '',
@@ -1124,10 +1126,22 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         const shortcuts = this._settings.get_strv(settingsKey);
         const currentShortcut = shortcuts.length > 0 ? shortcuts[0] : 'Disabled';
 
+        // An accelerator like `<Super><Alt>space` is not Pango markup, but
+        // AdwActionRow parses its subtitle as markup, so `<Super>` reads as an
+        // unclosed tag and the label is left EMPTY -- the row silently stopped
+        // showing the user their own keybinding.
+        //
+        // Two non-obvious parts, both measured; do not "tidy" either away:
+        //   1. `use_markup` governs the subtitle too, not just the title.
+        //   2. The subtitle must be assigned AFTER construction. Passing it in
+        //      the same literal still warns and still blanks, whichever order
+        //      the properties are written in -- construct-time property order
+        //      is not ours to choose.
         const row = new Adw.ActionRow({
             title: title,
-            subtitle: currentShortcut,
+            use_markup: false,
         });
+        row.subtitle = currentShortcut;
 
         const editButton = new Gtk.Button({
             label: 'Change',


### PR DESCRIPTION
Rebased onto current `main` (65bd57b). Supersedes #80, which was branched off 0521506 before #77 landed.

## The defect

Four Dictation shortcut rows show a **blank** subtitle, and the **`Privacy & Debug` group heading is unlabeled** — with stock default settings, so this is every user, not a local config quirk. A user cannot see what their own keybinding is.

The five `Gtk-WARNING`s baselined in #76 are the *symptom*. The cause is that when `set_markup` fails, GTK leaves the label **empty** while the *property* keeps its string — which is why this was invisible in the code review and invisible to any check that reads properties.

- `_addShortcutRow` puts the raw GSettings accelerator in the subtitle, and `AdwActionRow` parses subtitles as markup, so `<Super><Alt>space` reads as an unclosed tag.
- Group titles are markup-parsed and a bare `&` fails the parse.

## Evidence — property vs `get_text()` on the rendered label

**Before (main 65bd57b):**
```
RENDERED subtitle property="<Super><Alt>space" -> get_text()="" <<BLANK>>
RENDERED subtitle property="<Super><Alt>c"     -> get_text()="" <<BLANK>>
RENDERED subtitle property="<Super><Alt>r"     -> get_text()="" <<BLANK>>
RENDERED subtitle property="<Super><Alt>v"     -> get_text()="" <<BLANK>>
RENDERED title    property="Privacy & Debug"   -> get_text()="" <<BLANK>>
```

**After:**
```
RENDERED subtitle property="<Super><Alt>space"  -> get_text()="<Super><Alt>space" MATCHES
RENDERED subtitle property="<Super><Alt>c"      -> get_text()="<Super><Alt>c"     MATCHES
RENDERED subtitle property="<Super><Alt>r"      -> get_text()="<Super><Alt>r"     MATCHES
RENDERED subtitle property="<Super><Alt>v"      -> get_text()="<Super><Alt>v"     MATCHES
RENDERED title    property="Privacy &amp; Debug"-> get_text()="Privacy & Debug"   MATCHES
```

| | baseline (`main`) | branch |
|---|---|---|
| `BLANK_RENDERED` | **5** | **none** |
| Gtk/Adw warnings | **5** | **0** |
| branch stderr | — | **entirely empty** |
| `WRITES` | none | none (#76's combo guard still holds) |

## The fix, and the two non-obvious parts

**Shortcut rows:** `use_markup: false` on the row, subtitle assigned **after** construction. Both parts are measured and commented in place so neither gets tidied away:

1. `use_markup` governs the **subtitle** as well as the title (the libadwaita property is documented in terms of the title).
2. The subtitle must be assigned after construction. Passing it in the same constructor literal **still warns and still blanks, whichever order the properties are written in** — construct-time property order is not ours to choose. The natural one-liner (`use_markup: false` sitting next to `subtitle:`) looks correct and leaves all four warnings firing.

Chosen over escaping at the call site because there are **two** write sites — the constructor and `row.subtitle = val` in the Change dialog — and missing the second reintroduces the bug silently. This closes the write path instead of patching call sites.

**Group title:** escaped to `Privacy &amp; Debug`. `AdwPreferencesGroup` has no use-markup property, so escaping is the only route. Renders identically to before.

## Deliberately NOT changed

- **The Change dialog body**, `Enter a keyboard shortcut (e.g. <Super><Alt>space):`. It looks like the same defect and is not: `AdwAlertDialog:body-use-markup` defaults **false**, so it renders correctly today, and escaping it renders the literal `&lt;Super&gt;&lt;Alt&gt;space`. The reflex fix would have *introduced* the bug it appears to have. It also never appears in a harness run at all, since the dialog is only constructed on click.
- **`Voice & Sound` / `Wake & Spells` page titles.** Page titles are not markup-parsed — confirmed by their absence from a run that *was* firing for other strings in the same pass, so a proven-live instrument rather than a blind zero.
- **Human-readable accelerators** (`Gtk.accelerator_get_label()` → `Alt+Super+Space`) are a separate UX call and deliberately out of scope here; the Change dialog prefills and expects the raw `<Super><Alt>space` syntax, so the two would disagree.

## CLAUDE.md §Testing item 8

Included here because it is how this fix is proven. Documents the rig's `run.sh`, the `EXIT_CLEAN` guard (a run that *crashed* also produces "no new warnings" — two crashes have identical stderr and would otherwise read as a pass), and the trap that makes the rig necessary: `gnome-extensions prefs gnome-speaks@jphein` goes through the live shell and opens the copy **installed** in `~/.local/share/gnome-shell/extensions`, so it renders the OLD prefs.js and reports success. Item 5's headless shell doesn't cover it either — gnome-shell never loads prefs.js at all.

`BLANK_RENDERED` is new to the rig for this PR: it flags anything whose text is set but renders blank, generically, with no per-row knowledge. It independently rediscovers exactly the five blanked labels on `main`, which is what makes the branch's `none` a proven-live zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of the Privacy group title when it contains an ampersand.
  * Corrected shortcut row subtitles so accelerator strings display properly without being interpreted as markup.

* **Documentation**
  * Added testing guidance for verifying preferences changes in a sandboxed Broadway environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->