### PR TITLE
fix(prefs): stop markup parsing blanking the shortcut rows and Privacy group title

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,58 @@ No test suite. Validate changes by:
    between runs. Get a baseline on `main` before blaming your branch, and wipe the suite's
    state dir if a second run disagrees with the first.
 
+8. **prefs.js changes: the broadway rig.** Lives in the same scratch dir as the suites above,
+   as `luna-prefs-async-repros/`. ⚠️ **`gnome-extensions prefs
+   gnome-speaks@jphein` CANNOT verify a worktree** -- it goes through the live shell and opens
+   the copy **installed** in `~/.local/share/gnome-shell/extensions`, so it renders the OLD
+   prefs.js and reports success. Item 5 does not cover this either: gnome-shell never loads
+   prefs.js at all (the prefs window is a separate process), so a clean headless shell says
+   nothing about it.
+
+   ```bash
+   cd ~/.claude/projects/-home-jp/scratch/gnome-speaks-dreamteam/luna-prefs-async-repros
+   ./run.sh ~/Projects/gnome-speaks-wt/<wt>/prefs.js                     # one file
+   ./run.sh ~/Projects/gnome-speaks-wt/<wt>/prefs.js /path/to/main.js    # + baseline diff
+   ```
+
+   It builds a **real, mapped `Adw.PreferencesWindow`** on a `gtk4-broadwayd` virtual display,
+   so **no window appears and no focus is stolen -- safe to run while JP is dictating**. `HOME`
+   is sandboxed and `GSETTINGS_BACKEND=memory` is forced, so a run can never write
+   `~/.config/speech-to-cli/config.json` or dconf. It reports per combo row: options and
+   selected index **synchronously** and again **after async probes land**; `WRITES` (must be
+   `none` -- swapping a `Gtk.StringList` moves `selected` and emits `notify::selected`, which
+   `_addComboRow` treats as a user choice, so a careless async fill rewrites the setting it is
+   still loading); and `BLANK_RENDERED`.
+
+   ⭐ **`BLANK_RENDERED` exists because a property snapshot cannot see a markup failure.** When
+   `set_markup` fails, the *property* keeps the string and the *label* is left EMPTY, so the
+   bug is invisible both in the code and in any check that reads properties. It flags anything
+   whose text is set but renders blank. On `main` before the markup fix it found 5 -- four shortcut rows
+   whose subtitles are raw accelerators (`<Super><Alt>space` parses as an unclosed tag) and the
+   `Privacy & Debug` group title.
+
+   **Always pass a baseline.** A run that CRASHED also produces "no new warnings", so `run.sh`
+   requires the harness to print `EXIT_CLEAN` before it believes any stderr comparison -- two
+   crashes have identical stderr and would otherwise read as a pass.
+
+   **Exit contract:** 0 = both runs completed; 1 = a run did not complete, or the branch emits
+   MORE warnings than the baseline. A differing stderr is **not** failure -- a fix is supposed
+   to change stderr, and keying the exit code on `diff` made a successful run report 1.
+
+   **Isolation contract** -- the same shape the service-side suites enforce, and none of it is
+   optional:
+   - Everything a run writes lives under `run-$$` and is deleted on exit. **No fixed paths**,
+     so two rigs running at once cannot share a sandbox, a schema dir, or a broadway socket
+     (the display number is per-PID and probed until one binds). Verified by running two
+     concurrently: distinct dirs, distinct displays, identical verdicts, no leftovers.
+   - The `config.json` handed to prefs.js is a **rig-owned fixture with pinned keys**.
+     `~/.config/speech-to-cli/config.json` is **never read** -- an earlier version copied it
+     and let 47 of JP's live keys steer the verdict, and cached that copy forever behind an
+     `if [ ! -f ]`. Device ids in the fixture come from live `wpctl`, so the "config names a
+     device" path is exercised on any machine.
+   - `HOME` and `GSETTINGS_BACKEND=memory` are exported into the gjs child only, never into
+     the calling shell, so a run cannot write the real config or dconf.
+
 ## Git
 
 Conventional commits (`feat:`, `fix:`, `refactor:`). Branch naming: `<type>/<short-description>`.

--- a/prefs.js
+++ b/prefs.js
@@ -751,7 +751,9 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         this._addCorrectionsRow(correctGroup);
 
         // ── Privacy & Debug ──
-        const privGroup = new Adw.PreferencesGroup({title: 'Privacy & Debug'});
+        // Group titles are markup-parsed and have no use-markup toggle, so a
+        // bare '&' blanked this heading entirely. Renders as 'Privacy & Debug'.
+        const privGroup = new Adw.PreferencesGroup({title: 'Privacy &amp; Debug'});
         page.add(privGroup);
 
         this._addEntryRow(privGroup, 'Save Spoken Audio To', 'save_audio_dir', '',
@@ -1124,10 +1126,22 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         const shortcuts = this._settings.get_strv(settingsKey);
         const currentShortcut = shortcuts.length > 0 ? shortcuts[0] : 'Disabled';
 
+        // An accelerator like `<Super><Alt>space` is not Pango markup, but
+        // AdwActionRow parses its subtitle as markup, so `<Super>` reads as an
+        // unclosed tag and the label is left EMPTY -- the row silently stopped
+        // showing the user their own keybinding.
+        //
+        // Two non-obvious parts, both measured; do not "tidy" either away:
+        //   1. `use_markup` governs the subtitle too, not just the title.
+        //   2. The subtitle must be assigned AFTER construction. Passing it in
+        //      the same literal still warns and still blanks, whichever order
+        //      the properties are written in -- construct-time property order
+        //      is not ours to choose.
         const row = new Adw.ActionRow({
             title: title,
-            subtitle: currentShortcut,
+            use_markup: false,
         });
+        row.subtitle = currentShortcut;
 
         const editButton = new Gtk.Button({
             label: 'Change',


### PR DESCRIPTION
Re-opens #80 verbatim (same prefs.js diff, rebased onto post-#77 main). #80 was closed by accident: `gh pr merge --delete-branch` hit GitHub's "base branch was modified" race, refused the merge, but still deleted the branch.

Fix: build the four keybinding rows and the "Privacy & Debug" group with construct-then-assign so GTK never parses `<Super><Alt>…` / `&` as Pango markup (markup failure keeps the property but blanks the rendered label). Also adds CLAUDE.md §Testing item 8 (prefs rig: `luna-prefs-async-repros/run.sh`, BLANK_RENDERED walk).

Verification (prefs rig, gtk4-broadwayd): baseline BLANK_RENDERED 5 / Gtk warnings 5 → branch BLANK_RENDERED none / 0 warnings / stderr empty / WRITES none / EXIT_CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)