### PR TITLE
test: keep verify_wake_gate off the real IBus breadcrumb

### DIFF
--- a/verify_wake_gate.py
+++ b/verify_wake_gate.py
@@ -6,17 +6,45 @@ speech queue all mocked out. Exit code 0 = every check passed.
 
     python3 verify_wake_gate.py
 """
+import atexit
 import importlib.util
 import os
 import re
+import shutil
 import sys
+import tempfile
 import threading
 import types
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
 
+# Redirect the IBus runtime dir BEFORE importing the backend, the way
+# verify_ibus_injector.py already does. Nothing in this file currently reaches
+# write_prior_engine() -- it only constructs IbusInjector and calls
+# purpose_known(), which is pure attribute reads -- so this is a guard against
+# what a future check might do, not a fix for a live leak.
+#
+# It is worth the four lines because of the blast radius: ibus_injector's
+# _state_dir() reads $XDG_RUNTIME_DIR at CALL time, so any check that grew as
+# far as acquire() would silently write the developer's REAL prior-engine
+# breadcrumb -- and on a desktop whose keymap comes from an IBus engine, a
+# bungled restore leaves no working keyboard (see CLAUDE.md, "IBus crash state
+# is 'no input method', not 'the wrong one'"). A test must not be able to reach
+# that file at all.
+_RUNTIME = tempfile.mkdtemp(prefix="verify-wake-gate-")
+os.environ["XDG_RUNTIME_DIR"] = _RUNTIME
+atexit.register(shutil.rmtree, _RUNTIME, True)
+
 import ibus_injector  # noqa: E402
+
+# Prove the redirect took, rather than trusting it: _state_dir() is evaluated
+# per call, so this also catches a later import order change.
+_crumb = os.path.realpath(ibus_injector.prior_engine_path())
+if not _crumb.startswith(os.path.realpath(_RUNTIME) + os.sep):
+    raise SystemExit(
+        f"refusing to run: prior-engine path {_crumb!r} is outside the "
+        f"test runtime dir {_RUNTIME!r}")
 
 failures = []
 


### PR DESCRIPTION
`verify_wake_gate.py` imports `ibus_injector` and constructs a real `IbusInjector`.

**To be clear about the premise: there is no live leak.** The file only calls `purpose_known()`, which is pure attribute reads — `write_prior_engine()`, `clear_prior_engine()`, `restore_prior_engine()` and `acquire()` are never reached. I raised this as an unverified concern during the harness sweep and it is verified as **not present** on today's code. This is a guard against what a future check might do.

It earns its four lines on blast radius. `ibus_injector._state_dir()` reads `$XDG_RUNTIME_DIR` at **call time**, so any check that grew as far as `acquire()` would write the developer's **real** prior-engine breadcrumb — and on a desktop whose keymap comes from an IBus engine, a bungled restore leaves no working keyboard (CLAUDE.md: *"IBus crash state is 'no input method', not 'the wrong one'"*). A test should not be *able* to reach that file. `verify_ibus_injector.py` already redirects the same variable, so this also makes the two files consistent.

**The assertion is the actual point.** The redirect depends on import order, which is one edit away from breaking silently, so the file now proves `prior_engine_path()` resolves inside the temp dir instead of trusting that it does.

## Verification

Passes: `rc=0`, all checks ok.

Negative control — with the redirect line replaced by `pass`, the guard fires and names the real path it would otherwise have used:

```
refusing to run: prior-engine path '/run/user/1000/gnome-speaks/prior-engine'
is outside the test runtime dir '/tmp/verify-wake-gate-dcxkoo__'
```

That confirms both that the assertion is live and that the hazard it guards is the real breadcrumb, not a hypothetical one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)