### PR TITLE
fix: the streaming AI reply honors begin()'s refusal

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -4432,7 +4432,6 @@ class GnomeSpeaksService:
                 spoken in full (#79).
                 """
                 nonlocal cancel_token, first_sentence
-                self._set_state("speaking")
                 # One object claims playback AND carries the verdict.
                 cancel_token = self._cancels.issue("ai-reply")
                 self._speak_token = cancel_token
@@ -4440,6 +4439,11 @@ class GnomeSpeaksService:
                     log.info("AI reply cancelled before its first note — "
                              "nothing spoken")
                     return False
+                # Only now: announcing "speaking" for a reply that will never
+                # be spoken puts the badge in the same disagreement the token
+                # exists to prevent. The queue hold does not depend on this —
+                # _hold_user_speech() has held since the turn began.
+                self._set_state("speaking")
                 # On headphones, prewarm recorder during TTS
                 if not CONFIG.get("half_duplex", False):
                     _schedule_warmup()

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -4418,6 +4418,33 @@ class GnomeSpeaksService:
             in_type_tag = False # True while inside <type>...</type>
             first_sentence = True
             spoke_anything = False
+            aborted = False     # begin() refused: a stop beat the first note
+
+            def _claim_playback():
+                """Issue this reply's token and take the wire.
+
+                False means begin() refused because a stop landed between the
+                claim and the first note. Every other path in the service
+                treats that as "never even start" (_speak_worker returns
+                "interrupted" without playing, _streaming_stt_cycle returns
+                before opening the mic); this one used to ignore the answer and
+                speak anyway, so a reply the user had already stopped was
+                spoken in full (#79).
+                """
+                nonlocal cancel_token, first_sentence
+                self._set_state("speaking")
+                # One object claims playback AND carries the verdict.
+                cancel_token = self._cancels.issue("ai-reply")
+                self._speak_token = cancel_token
+                if not self._cancels.begin(cancel_token):
+                    log.info("AI reply cancelled before its first note — "
+                             "nothing spoken")
+                    return False
+                # On headphones, prewarm recorder during TTS
+                if not CONFIG.get("half_duplex", False):
+                    _schedule_warmup()
+                first_sentence = False
+                return True
 
             # Single subtitle thread for the entire conversation (Fix 7).
             # cancel_token (issued at the first spoken sentence) rides the
@@ -4479,17 +4506,9 @@ class GnomeSpeaksService:
                     if not sentence:
                         continue
 
-                    if first_sentence:
-                        # Transition to speaking state on first sentence
-                        self._set_state("speaking")
-                        # One object claims playback AND carries the verdict.
-                        cancel_token = self._cancels.issue("ai-reply")
-                        self._speak_token = cancel_token
-                        self._cancels.begin(cancel_token)
-                        # On headphones, prewarm recorder during TTS
-                        if not CONFIG.get("half_duplex", False):
-                            _schedule_warmup()
-                        first_sentence = False
+                    if first_sentence and not _claim_playback():
+                        aborted = True
+                        break
 
                     spoke_anything = True
                     log.info("Streaming TTS sentence: %s", sentence[:80])
@@ -4508,17 +4527,19 @@ class GnomeSpeaksService:
                     if self._stop_event.is_set():
                         break
 
+                if aborted:
+                    break
+
             # Speak any remaining buffered text after stream ends
             remainder = buffer.strip()
-            if remainder and not self._stop_event.is_set():
-                if first_sentence:
-                    self._set_state("speaking")
-                    cancel_token = self._cancels.issue("ai-reply")
-                    self._speak_token = cancel_token
-                    self._cancels.begin(cancel_token)
-                    if not CONFIG.get("half_duplex", False):
-                        _schedule_warmup()
-                    first_sentence = False
+            # Decided once: _stop_event could otherwise flip between a guard
+            # that claims playback and a guard that speaks.
+            speak_remainder = (bool(remainder) and not aborted
+                               and not self._stop_event.is_set())
+            if speak_remainder and first_sentence and not _claim_playback():
+                aborted = True
+                speak_remainder = False
+            if speak_remainder:
                 spoke_anything = True
                 log.info("Streaming TTS remainder: %s", remainder[:80])
                 GLib.idle_add(self._emit_partial_transcription, remainder)


### PR DESCRIPTION
Closes #79.

## The self-catch worth reading first

My first version of the fix guarded the remainder block with `if remainder and not aborted:` — silently dropping the `not self._stop_event.is_set()` check the original had. That would have introduced a **new** bug, in the exact code I was fixing, in the "speaks when it should not" direction: a stopped reply would have spoken its remainder. Caught in my own diff review; the guard is now computed once as `speak_remainder`. **Splitting one guard into two is where a condition gets lost.**

## What was wrong

`CancelRegistry.begin()` returns False for exactly one reason: the token was cancelled between `issue()` and `begin()` — a stop landed in the claim window. Every other path treats that as *never even start*:

```
_speak_worker          -> outcome "interrupted", not a note played
_streaming_stt_cycle   -> "cancelled before it began", mic never opened
```

`_stream_conversation_worker` called `begin()` at **both** of its playback sites and discarded the answer. Because `begin()` correctly declines to lower the wire when it refuses, the reply was then spoken *with the cancel wire raised* — the one state the token design exists to make unambiguous.

**Measured on `origin/main`: a stop issued before the first note still produced the ENTIRE reply** — `['Alpha', 'Beta']`, both the in-loop sentence and the post-stream remainder.

### The second site is the one that matters in practice

A reply with no sentence terminator never reaches the in-loop claim at all — it is spoken by the post-stream remainder block, which carried its own copy of the ignored `begin()`. That is the **short answer** case: "Yes", "42", "Done" — the bulk of voice replies. Fixing only the first site would have looked fixed and left that broken.

### Three observers, one root cause

On main (post-#78) a stopped reply is **three-way inconsistent**: audio plays, subtitle is silent (the reply token is cancelled, so #78 correctly suppresses frames), and the badge says `speaking` because `_claim_playback` set the state *before* `begin()`. Fixing two of the three would have left the badge lying on its own, so the state transition moved after a successful `begin()`. The repros record the **transition list**, not the final state — a flicker is invisible to a post-hoc read.

## The fix

One `_claim_playback()` closure used by both sites, so the contract is single-sourced. A refusal sets `aborted`, which breaks the **token-stream** loop as well as the sentence loop and suppresses the remainder.

## Verification

New suite `lucid-begin-refused-repros` (`run_all.sh <service.py>`), reusing the shared harness and #78's `GLibSpy`:

| repro | `origin/main` 15dd402 | this branch |
|---|---|---|
| `j` stop in the claim window, first-sentence site | audio `['Alpha','Beta']`, badge `['speaking','idle']` → FAIL | none / `['idle']` |
| `k` same, remainder-only reply (short answer) | audio `['Alpha']`, badge `['speaking','idle']` → FAIL | none / `['idle']` |
| `l` **regression guard**, uncancelled reply | PASS | PASS — identical numbers |

`l` is deliberately green on **both** sides — `['Alpha','Beta']` spoken, 8 subtitle frames, 1 assistant turn in history, no leaked token, final state `idle`. It guards the failure a user would notice first: a fix that stops speaking replies nobody cancelled.

The claim window is **forced, not raced** — a hook on `issue()` runs the registry's own `cancel_all()` inside the window every time — and both repros report **SETUP FAILURE** (exit 2), never a pass, if the hook did not fire or the token was not cancelled.

**Gates on this head** (base `15dd402`, swept harness, run serially): unified runner **26/26** · `j/k/l` **3/3** · `lucid-offline-handoff-repros` **A–I 9/9** · `verify_wake_gate` · `py_compile`.

⚠️ `verify_version_cache.py` exits 1 on this head — **and byte-identically on `origin/main`**. It is a pre-existing regression unrelated to this PR: #77 removed `_build_version_payload`/`_version_cache` (added by #75), so `/api/version` forks three git processes per request again. Reported separately; not touched here.