### PR TITLE
perf: re-land the /api/version payload cache (#53, overwritten by e55e619)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -4731,6 +4731,13 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
     _voices_cache = (None, 0.0)
     _VOICES_CACHE_TTL = 300  # 5 minutes
 
+    # /api/version payload, built once on the first request (see
+    # _handle_version).  No TTL: the git facts in it describe the code this
+    # process loaded, so they cannot change while it runs.  ThreadingHTTPServer
+    # can land two pollers at once, hence the lock.
+    _version_cache = None
+    _version_cache_lock = threading.Lock()
+
     def log_message(self, format, *args):
         """Route HTTP log messages through the existing logger instead of stderr."""
         log.debug("HTTP %s", format % args)
@@ -5007,7 +5014,27 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
 
     def _handle_version(self):
         """GET /api/version — realm-sigil version contract (falls back to a
-        minimal payload when realm-sigil isn't installed)."""
+        minimal payload when realm-sigil isn't installed).
+
+        The payload is built once and reused.  hash/branch/dirty describe the
+        code this process loaded and cannot change while it runs, so deriving
+        them per request forked three git processes — one of them a full
+        working-tree scan — on every poll of the status board (#53).  Only
+        `uptime` is live, and it is refreshed *in place* so the key order the
+        realm-sigil contract ships with is untouched.
+        """
+        cls = SpeechHTTPHandler
+        with cls._version_cache_lock:
+            if cls._version_cache is None:
+                cls._version_cache = self._build_version_payload()
+            payload = dict(cls._version_cache)
+        payload["uptime"] = int(time.time() - _SERVICE_START_TIME)
+        self._send_json(payload)
+
+    @staticmethod
+    def _build_version_payload():
+        """The once-per-process half of /api/version: three git reads, the
+        realm-sigil call, and the host facts."""
         import socket as _socket
         repo_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -5043,7 +5070,7 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
             payload = {"name": "gnome-speaks", "version": hash_,
                        "hash": hash_, "branch": branch, "dirty": dirty,
                        "uptime": uptime}
-        self._send_json(payload)
+        return payload
 
     def _handle_status(self):
         svc = self.service


### PR DESCRIPTION
Closes #53 · re-lands #75 · refs #59

## This is not a new fix — it is #75, put back

#75 merged as `577a05f`. One commit later, `e55e619` removed `_version_cache`, `_version_cache_lock` and `_build_version_payload` as plain deletions. `/api/version` went back to forking three git processes per request, one of them a full `git status --porcelain` tree scan, on every poll.

`[measured]` 20 requests: **3** forks at `577a05f`, **60** on main. 8 threads × 25 requests: **3** vs **600**.

## The mechanism — a diff taken across a moved base

Established by @lucid-offline-handoff, who owned it and dug out the ordering evidence. **My first account of this was wrong** — I inferred a stale editor buffer from the commit message. It was not that, and the real one is worse, because every step looks correct:

The work was re-applied with a patch generated as `git diff origin/main HEAD`, where `origin/main` had **already advanced to `577a05f`** while `HEAD` was a branch tip based on the older `79594dd`.

> **A diff from a moved base to a stale tip necessarily contains the reversal of everything merged in between.**

That patch carried two reversals: *undo #70* — harmless, the same patch re-implemented that content — and *undo #53*, silent, because nothing re-implemented it. `git apply --index` then did exactly what it was asked. No stale file, no conflict, no warning.

Ordering evidence: the command immediately after generating the patch was `git reset --hard origin/main`, printing `HEAD is now at 577a05f`, with no fetch in between — so the base had already moved when the diff was taken. `git log --oneline 79594dd..577a05f` lists exactly #70's two commits and #53's two; of those four only #53 lacked a re-implementation. Blast radius **derived**, and it agrees with the sampled sweep below.

**The correct guards are upstream of any content check:**
- Never use `git diff <moved-base> <stale-tip>` as a re-apply patch. Use the branch's **own** base: `git diff <branch-base> <tip>` — or `rebase`/`cherry-pick`, which exist for exactly this and would have left #53 untouched. *(This PR re-applies via `git diff 2614ec6^ 2614ec6`, a commit against its own parent — the correct form.)*
- Never `head` a diff you are about to commit. `--stat`, then every hunk header, to the end.

## ⚠️ Why hours of green checks missed it

Every ancestry instrument reported success while the code was gone:

```
git merge-base --is-ancestor 2614ec6 origin/main   -> YES      (true, and useless)
git branch --contains 2614ec6                      -> main     (true, and useless)
git log | grep -i revert                           -> nothing  (there IS no revert commit)
gh pr view 75                                      -> MERGED   (true, and useless)
issue #53                                          -> closed   (false, and believed)
```

**Reachability is not content.** The instrument that sees it — now a standing post-merge check — is `git log -S"<distinctive symbol>" --oneline origin/main`. It is a backstop, not the fix; the fix is the patch-form guard above.

## Blast radius — contained

| commit | added lines checked | missing on main |
|---|---|---|
| `2614ec6` (#53) | 8 | **7 — clobbered** |
| `e55e619` (mic outage) | 19 | 0 |
| `b5444f2` (subtitle token) | 21 | 0 |

One victim. #70/#77 content is intact (9/9 offline repros on main), so nothing else needs redoing.

## 📄 Main currently documents a command that fails on main

#53's CLAUDE.md note **survived** the revert — so `main` tells the reader to run `verify_version_cache.py` while the code it verifies is gone. `[measured] exit=1` on main right now. Independently confirmed, not taken on report.

The docs are ahead of the code, and the next person to follow them gets a failure that reads as a fresh regression in whatever they happen to be holding. **This PR makes the documentation true again; nothing in the docs needs changing.** Worth naming in #53 so it doesn't ambush anyone before this lands.

## Content fidelity

The `_handle_version` region is **byte-identical to `577a05f`'s** (61 lines, diffed), and outside it the only change is the cache attribute block. Rebased twice during review (#61, then #84); after each, both directions were re-checked — my symbols present, and every distinctive line of `b260f17`, `75c6b40` and `6325efa` intact, **with the probe baselined against `origin/main`** (a revert's restored lines are indistinguishable from new work in a bare `diff | grep '^+'`, which produced one false accusation before the baseline was added).

## The suite now proves it discriminates

It had two pre-fix reference points and no known-good one, so it could agree with itself forever while testing nothing. A two-sided control now runs on every invocation:

```
PASS  positive/negative control: 577a05f known-GOOD must PASS  --  3 forks / 20 requests
PASS  positive/negative control: 7eaeb02 known-BAD  must FAIL  -- 60 forks / 20 requests
```

`577a05f` is pinned as a literal, not a symbolic ref: it is currently the only commit where this behavior is correct, so anything resolved at runtime would silently become a second pre-fix reference.

## Gates — re-run on the twice-rebased head, not carried over

Swept runner **26/26**, offline A–I **all green**, version-cache suite (incl. both controls) **exit 0**, `verify_wake_gate` **24/24**, `py_compile` clean, leak scan **0** — the scanner verified against a planted string first, after an earlier run returned a confident zero from an empty `git diff` because `git apply -3` had staged the change.

Not exercised live: JP is dictating on this desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
