### PR TITLE
chore: move every repro suite into the repo as tests/repros (#59)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,16 @@ schemas/gschemas.compiled
 build/
 builddir/
 dist/
+
+# Per-run sandboxes created BESIDE a suite's own script. The prefs rig writes
+# run-<pid>/ next to run.sh, which was outside any repo in scratch and is
+# inside the checkout since #59 -- so every run left the tree dirty. The
+# cleanup trap does not survive SIGKILL, and this fleet has had OOM cascades,
+# which is exactly when a run dies hard and leaves a sandbox (holding a config
+# fixture) untracked in the tree. Wildcarded across suites, not named for the
+# rig, so any suite adopting the convention is covered too.
+#
+# NOTE the `schemas/gschemas.compiled` line above does NOT help here: it
+# contains a slash, so it is anchored to the repo root and never matches the
+# one compiled at tests/repros/*/run-*/fakeext/schemas/.
+tests/repros/*/run-*/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,9 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
 
 ## Testing
 
-No test suite. Validate changes by:
+No unit-test framework, by choice -- the repro suites in `tests/repros/` are plain
+scripts that exit 0 or 1. Validate changes by:
+
 1. Restarting the service (`systemctl --user restart gnome-speaks.service`)
 2. Checking logs (`journalctl --user -u gnome-speaks.service -f`)
 3. Testing via D-Bus (`dbus-send`) or keyboard shortcuts
@@ -236,51 +238,41 @@ No test suite. Validate changes by:
 6. Wake-word secure gate: `python3 verify_wake_gate.py` from the checkout root -- no env vars,
    no desktop, no daemon (it imports `ibus_injector` from its own directory). 24 checks; exit 0
    means all passed.
-7. Service-side changes: the de-facto verification bar is the scratch repro suites under
-   `~/.claude/projects/-home-jp/scratch/gnome-speaks-dreamteam/`, one directory per audit --
-   `lucid-service-audit-repros` (queue invariants, dispatch gate, config),
-   `lucid-chronicle-perf-repros` (chronicle contract, archive, HTTP endpoints),
-   `lucid-cancel-tokens-repros` (cancel-token verdicts, stop vs stop_listening),
-   `lucid-subtitle-token-repros` (subtitle progress reads its utterance's token, not the wire;
-   e4 is the composed cycle-then-reply case),
-   `morpheus-injector-seam-repros` (Injector seam, IbusInjector),
-   `lucid-version-cache-repros` (/api/version fork storm + realm-sigil contract).
-   They import the service by
-   path and need no running service, D-Bus, mic or port 7710. Run the suite(s) covering the
-   area you touched before opening a PR.
+7. **Service-side changes: `tests/repros/run_all.sh` is the verification bar.**
 
-   **Always pass the path explicitly; never trust a suite's default.** Only
-   `lucid-cancel-tokens-repros` defaults to the main checkout. `lucid-service-audit-repros`,
-   `lucid-chronicle-perf-repros` and `morpheus-injector-seam-repros` default to
-   `~/Projects/gnome-speaks-wt/<audit-name>/` worktrees that no longer exist, so an
-   unqualified run dies with `FileNotFoundError` on that path instead of testing anything.
+```sh
+tests/repros/run_all.sh                       # the service in this repo
+tests/repros/run_all.sh /path/to/service.py   # a worktree, or an extracted SHA
+```
 
-   ```bash
-   SVC=~/Projects/gnome-speaks-wt/<your-worktree>/gnome-speaks-service.py
-   cd ~/.claude/projects/-home-jp/scratch/gnome-speaks-dreamteam
-   GS_SVC_PATH=$SVC       python3 lucid-service-audit-repros/verify_queue_invariants.py
-   GS_SVC_PATH=$SVC       python3 lucid-chronicle-perf-repros/verify_archive.py
-   GS_SVC_PATH=$SVC       python3 lucid-cancel-tokens-repros/verify_cancel_invariants.py
-   bash lucid-subtitle-token-repros/run_all.sh $SVC
-   GS_SVC_PATH=$SVC       python3 morpheus-injector-seam-repros/verify_injector_seam.py
-   GS_WT=$(dirname $SVC)  python3 morpheus-injector-seam-repros/verify_ibus_injector.py
-   GS_SVC_PATH=$SVC       python3 lucid-version-cache-repros/verify_version_cache.py
-   ```
+Run it before opening a PR that touches `gnome-speaks-service.py`. It needs no
+running service, no D-Bus, no microphone and no port 7710; it exits non-zero if
+any suite fails. `GS_SVC_PATH` is the only input and the runner sets it -- the
+worktree dir and the scratch dir are derived, so there is nothing to pass by
+hand and no default that can silently point at a tree that no longer exists.
+Per-suite detail, the pinned baseline SHA each suite discriminates against, and
+why `version-cache` is expected red are in `tests/repros/README.md`.
 
-   `verify_ibus_injector.py` is the exception: it imports `ibus_injector` as a module rather
-   than loading the service by path, so it reads **`GS_WT` (a checkout *directory*)** and
-   ignores `GS_SVC_PATH` entirely -- passing only `GS_SVC_PATH` gets you
-   `ModuleNotFoundError: No module named 'ibus_injector'`.
+Two hazards these suites are built to avoid, both measured on 2026-09-06 --
+keep them in mind before adding a suite, and read `tests/repros/README.md`
+before changing one:
 
-   Exit 0 = clean. A non-zero exit is a failed check -- in the `repro_*` scripts that means
-   the bug the repro was written for is still present, which is the point of running them.
-   **A red suite is not automatically your fault**: some scripts are open-bug repros that are
-   red on `main` by design, and several keep state under `/tmp/<suite>/` that is not reset
-   between runs. Get a baseline on `main` before blaming your branch, and wipe the suite's
-   state dir if a second run disagrees with the first.
+- **Never a fixed scratch path.** Suites shared absolute state dirs, and two
+  agents running one suite at once corrupted each other; the failure looked
+  exactly like a service regression and nearly got a good commit reverted.
+  Scratch is per-PID, and reset/cleanup only ever touch a directory the running
+  process created.
+- **Never JP's live config.** `state.load_config()` reads
+  `~/.config/speech-to-cli/config.json` at import, and `_reload_config_flags()`
+  re-reads it *mid-run* for every `_SYNC_FLAGS` key -- so pinning a key after
+  `load()` is undone at the next `start_listening()`. The harnesses rebuild
+  `CONFIG` from the service's own defaults and repoint `CONFIG_PATH` at a
+  scratch file, then assert that `CHRONICLE_PATH`/`CONFIG_PATH`/`XDG_STATE_HOME`
+  all resolve inside it.
 
-8. **prefs.js changes: the broadway rig.** Lives in the same scratch dir as the suites above,
-   as `luna-prefs-async-repros/`. ⚠️ **`gnome-extensions prefs
+8. **prefs.js changes: the broadway rig.** Lives with the other suites in the repo,
+   as `tests/repros/prefs-rig/` (GJS/bash, not python -- it is never
+   collected by `run_all.sh`'s python path; the runner invokes its `run.sh`). ⚠️ **`gnome-extensions prefs
    gnome-speaks@jphein` CANNOT verify a worktree** -- it goes through the live shell and opens
    the copy **installed** in `~/.local/share/gnome-shell/extensions`, so it renders the OLD
    prefs.js and reports success. Item 5 does not cover this either: gnome-shell never loads
@@ -288,9 +280,17 @@ No test suite. Validate changes by:
    nothing about it.
 
    ```bash
-   cd ~/.claude/projects/-home-jp/scratch/gnome-speaks-dreamteam/luna-prefs-async-repros
-   ./run.sh ~/Projects/gnome-speaks-wt/<wt>/prefs.js                     # one file
-   ./run.sh ~/Projects/gnome-speaks-wt/<wt>/prefs.js /path/to/main.js    # + baseline diff
+   cd tests/repros/prefs-rig
+   # Paths must be ABSOLUTE: harness.js imports the file as a module URI, and a
+   # relative path resolves against the rig dir, not your shell -- it fails with
+   # `ImportError: Unable to load file async from: file://../prefs.js`.
+   ./run.sh /abs/path/to/prefs.js                          # one file
+   # + baseline diff. The baseline is the branch's MERGE BASE, never a moving
+   # origin/main. Extract it to a real temp dir -- a placeholder in a `>`
+   # redirect is a footgun, and the block above has already cd'd into the rig:
+   BASE=$(mktemp -d)
+   git show $(git merge-base origin/main HEAD):prefs.js > $BASE/prefs.js
+   ./run.sh /abs/path/to/prefs.js $BASE/prefs.js
    ```
 
    It builds a **real, mapped `Adw.PreferencesWindow`** on a `gtk4-broadwayd` virtual display,

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -1,0 +1,158 @@
+# Repro suites
+
+Plain Python scripts, **no test framework** (project rule). Each exits `0` when
+clean and `1` when the defect it describes is present. Each imports the real
+`gnome-speaks-service.py` in-process with the microphone, the WebSocket, D-Bus,
+the injector and the network stubbed, so a run touches no device, no port and
+nothing on the developer's live desktop.
+
+```sh
+tests/run-repros.sh                       # the service in this repo
+tests/run-repros.sh /path/to/service.py   # a worktree, or an extracted SHA
+```
+
+## Env contract
+
+`GS_SVC_PATH` — the `gnome-speaks-service.py` under test — is the **only** input
+a suite needs, and `run-repros.sh` sets it. Everything else is derived:
+
+| | |
+|---|---|
+| worktree dir (sibling modules: `spellbook.py`, `injector.py`, `ibus_injector.py`) | `dirname(GS_SVC_PATH)`; `GS_WT` overrides it only to mix trees deliberately |
+| scratch / state | per-PID under this repo's gitignored `tmp/repros/`; `GS_REPRO_SCRATCH` pins it, and a pinned dir is never reset or deleted by a suite |
+| `SPEECH_ENGINE_PATH` | `~/Projects/speech-to-cli` unless set (see CLAUDE.md, External Dependencies) |
+
+Two rules the suites enforce on themselves, both learned the hard way on
+2026-09-06:
+
+* **No fixed scratch path.** Suites used to share absolute dirs, and two agents
+  running one suite at once corrupted each other — *two concurrent runs of
+  `verify_chronicle_contract.py` both failed with bogus mismatches while each
+  alone passed.* It reads exactly like a service regression. Worse, a suite
+  that `rmtree`s its dir at start makes the best-behaved run the most
+  destructive one: a "clean" start deletes a peer's live directory. Reset and
+  cleanup are therefore gated on *this process having created the dir*.
+* **No live config.** `state.load_config()` reads
+  `~/.config/speech-to-cli/config.json` at import and `_reload_config_flags()`
+  re-reads it **mid-run** for every `_SYNC_FLAGS` key, so pinning keys after
+  `load()` is silently undone at the next `start_listening()`. The harnesses
+  call `_isolate_config(mod)`, which rebuilds `CONFIG` from the service's own
+  defaults plus an explicit `CONFIG_PINS` dict and repoints `CONFIG_PATH` at a
+  scratch file — so the live file can be neither read nor written — then
+  `assert_isolated(mod)`, which **raises** unless `CHRONICLE_PATH`,
+  `CONFIG_PATH` and `XDG_STATE_HOME` all resolve inside the scratch dir.
+
+## Baselines are pinned SHAs, never branch names
+
+A suite that diffs against a moving ref goes vacuous the moment its fix merges:
+it starts comparing the fix to itself and passes forever. **Pin to a branch's
+merge base, never to "current main"** — a fast-moving main manufactures false
+regressions. To confirm a suite still detects what it was written for:
+
+```sh
+git archive <baseline-sha> | tar -x -C /tmp/base   # disposable
+tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
+```
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `service-audit` | #18–#20 | `7899ccb` | derived (`merge^1`), not re-run |
+| `chronicle-perf` | #22 / #27 | `6a1ecae` | derived (`merge^1`), not re-run |
+| `injector-seam` | #24 | `ea47ff1` | derived (`merge^1`), not re-run |
+| `cancel-tokens` | #21 / #33 | `66edc79` | **verified** — 4 of 5 fail |
+| `dead-recorder` | #57, #48 / #72 | `e863b2c` | **verified** — e, f, h fail; g, i pass |
+| `offline-handoff` | #49 / #70 | `70ff468` | **verified** — pre-#70 *and* pre-#72 |
+| `subtitle-token` | #42 / #78 | `65bd57b` | e1–e4 fail |
+| `begin-refused` | #79 / #84 | `15dd402`, `f290d7e` | j, k fail — **l stays green on both sides** |
+| `pin-lifecycle` | #46 ×#57 | `15dd402` | compound X: X1 FAIL, X2 PASS, X3 FAIL |
+| `version-cache` | #53 / #85 | two-sided, below | `577a05f` passes, `7eaeb02` fails |
+| `prefs-rig` | #82 | merge base of the branch | more warnings than baseline = fail |
+
+"derived" means the SHA is the merge commit's first parent — the main tip
+immediately before the fix, correct by construction but not re-run. The method
+was validated on `cancel-tokens`, whose SHA was independently recorded in that
+work's findings.
+
+### Three traps in this table, all of them earned
+
+**`begin-refused`'s `l` is green on both sides, and that is correct.** It is a
+regression guard against a fix that stops speaking replies nobody cancelled —
+the failure a user notices before any of the ones j and k catch. A future reader
+seeing it green on main is the most likely person to delete it. Don't.
+
+**`offline-handoff` is `70ff468`, not `79594dd`.** `79594dd` already contains
+#72 (`git merge-base --is-ancestor 848b855 79594dd` → yes), so against it case I
+fails for **one** reason — the offline exit doesn't exist yet, so the WS error
+fires instead of the mic report — not two. `70ff468` is pre-#70 *and* pre-#72.
+"Fails for two reasons" is the kind of note that stops someone investigating one
+reason too early.
+
+**`version-cache` needs two references, and here is why.** #53's fix merged as
+`577a05f`; `e55e619` then deleted the hunk as plain deletions — a stale-buffer
+write, no revert commit — so main went green and silently back to red before
+#85 re-landed it. A suite with only *pre-fix* references can agree with itself
+forever while testing nothing, which is exactly what this one did. It now runs a
+two-sided control on every invocation: `GOOD_REF=577a05f` must pass,
+`BAD_REF=7eaeb02` must fail (`GS_GOOD_REF`/`GS_BAD_REF` override). **Keep those
+literal SHAs.** Anything resolved at runtime can silently become a second
+pre-fix reference and put the suite back where it started.
+
+## Exit codes
+
+`0` clean · `1` the defect is present · `2` **SETUP FAILURE** — the repro could
+not create the window it needed (a stalled `idle_add`, a hook that never fired),
+so it is reporting neither a pass nor a bug. Several repros in `subtitle-token`
+and `begin-refused` force a narrow window and then *check the window was hit*;
+two early drafts passed on unfixed builds before that check existed. **A rewrite
+that collapses `2` into `0` or `1` silently restores the ability to pass for the
+wrong reason.**
+
+### The pipeline-exit-status trap, in both directions
+
+Both forms have bitten this tree, and the **silent** one is the dangerous half:
+
+* `cmd | grep PAT | tail -1 && return` — **fails silently.** `tail` exits `0`
+  on empty input, so the pipeline "succeeds" whether or not `grep` matched, the
+  first branch is always taken, and every summary comes out blank. Nothing
+  reports an error; you just stop being told anything. Capture into a variable
+  and test it for content instead.
+* a runner whose last command is a `diff` or `grep` — **fails loudly**, and
+  returns `1` on a *successful* run (a fix is supposed to change stderr). At
+  least someone notices, usually when they gate CI on it.
+
+Same root cause: taking a pipeline's exit status as the answer to a question it
+never answered. `$?` after a pipe reads the LAST command, not the interesting
+one — that form once reported two red suites as green here.
+
+## Instruments that must survive a refactor
+
+* **`subtitle-token/subtitle_spy.py: GLibSpy`** — the harness runs no GLib main
+  loop, so `_emit_subtitle_update` callbacks queue and never fire. A subtitle
+  assertion written without the shim reads an empty list, measures nothing and
+  **passes**. It is the instrument, not a convenience.
+* **`assert_isolated()`** — the harness version proves the *paths* are
+  redirected; `subtitle_spy.assert_isolated()` delegates to it and adds the
+  other half, that the CONFIG *pins actually took*. A path can be redirected
+  correctly while a pin is silently missing, and `terminal_mode` really is
+  `True` on the developer desktop. Keep both halves if these are ever folded
+  together.
+* **`prefs-rig` containment comes from `GLib.get_home_dir()` honouring `$HOME`**,
+  not from its monkeypatched writers. The stubs are a *reporting* mechanism (they
+  produce the `WRITES` line), not the safety mechanism — proven by
+  `probe_write_containment.js`, which removes the stub and drives the real
+  writer with a sentinel. So deleting a stub to exercise a save path is safe.
+* **`offline-handoff` case H** replaces `stt.wyoming.transcribe` and never
+  restores it; it is safe only because `build()` re-stubs it every call. Case G
+  restores `_rest_stt_fallback` explicitly because `build()` does *not*. The
+  runner gives each case its own process so this is irrelevant rather than
+  merely currently-true — if stub ownership ever moves into the harness, check H
+  before trusting it.
+
+## prefs-rig is not python
+
+`prefs-rig/` is a GJS/bash rig (`run.sh` → `gjs` + `gtk4-broadwayd`) testing
+`prefs.js`: 10 files, zero `.py`, by design. A `*.py` inventory returns a false
+negative on it and a python collector must never try to import it. Its exit
+contract is its own: **0** = both runs completed; **1** = a run did not
+complete, or the branch emits *more* warnings than the baseline. A **differing
+stderr is not a failure** — a fix is supposed to change stderr.

--- a/tests/repros/begin-refused/repro_j_first_sentence.py
+++ b/tests/repros/begin-refused/repro_j_first_sentence.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Issue #79: a stop in the claim window must abandon the AI reply, not speak it.
+
+_stream_conversation_worker called CancelRegistry.begin() and threw the answer
+away, at both of its playback sites.  begin() returns False for exactly one
+reason -- the token was cancelled between issue() and begin(), i.e. a stop
+landed in the claim window -- and every other path in the service treats that
+as "never even start":
+
+    _speak_worker           -> outcome "interrupted", not a note played
+    _streaming_stt_cycle    -> "cancelled before it began", mic never opened
+
+The AI reply spoke anyway.  Worse, begin() correctly leaves the wire UP when it
+refuses, so the reply was spoken with a raised cancel wire -- the state the
+whole token design exists to make unambiguous.
+
+This repro drives the real worker and asserts the two halves of the service
+agree, which is the user-visible contract: after a stop, NO audio and NO
+subtitle frames.
+
+exit 0 = nothing spoken, nothing subtitled; 1 = the stop was ignored; 2 = setup.
+"""
+import sys
+import threading
+import time
+
+import shim
+import harness
+import subtitle_spy
+
+
+def main():
+    print(f"service under test: {shim.SVC_PATH}")
+    mod, events, _inj = harness.load(fake_tts_seconds=3.0)
+    subtitle_spy.assert_isolated(mod)
+    spy = subtitle_spy.install_spy(mod)
+    svc = harness.make_service(mod)
+    states = shim.record_states(svc)
+
+    subtitle_spy.scenario(mod, conversation_mode=True)
+    # Two tokens so a complete sentence is produced inside the stream loop --
+    # the first-sentence claim site, not the remainder site.
+    mod.stream_chat = lambda **kw: iter(["Alpha one. ", "Beta two. "])
+
+    hook = shim.stop_in_the_claim_window(svc)
+
+    t = threading.Thread(target=svc._conversation_worker,
+                         args=("hello",), daemon=True)
+    t.start()
+    t.join(timeout=20.0)
+    if t.is_alive():
+        print("  ! the worker never finished")
+        return 2
+
+    time.sleep(0.3)   # let any late subtitle frame land before asserting none
+
+    if not hook["fired"]:
+        print("  ! SETUP FAILURE — the claim window was never reached")
+        return 2
+    token = hook["token"]
+    if not token.cancelled:
+        print("  ! SETUP FAILURE — the token was not cancelled in the window")
+        return 2
+
+    spoken = [tag for kind, tag, _ts in events if kind == "start"]
+    frames = spy.frames
+    leaked = svc._cancels.live()
+
+    print(f"  stop landed inside the claim window: {hook['fired']}")
+    print(f"  begin() would refuse (token cancelled): {token.cancelled}")
+    print(f"  audio half    — sentences sent to TTS: {spoken or 'none'}")
+    print(f"  subtitle half — frames emitted:        "
+          f"{[(t_[:12], p) for t_, p, _ in frames] or 'none'}")
+    print(f"  live tokens left in the registry:      {leaked or 'none'}")
+    print(f"  badge half    — state transitions:     {states}")
+
+    bad = []
+    if spoken:
+        bad.append(f"{len(spoken)} sentence(s) spoken after the stop: {spoken}")
+    if frames:
+        bad.append(f"{len(frames)} subtitle frame(s) emitted after the stop")
+    if leaked:
+        bad.append(f"leaked tokens: {leaked}")
+    if "speaking" in states:
+        bad.append("the badge announced 'speaking' for a reply that was "
+                   f"never spoken (transitions: {states})")
+    if bad:
+        print("\nFAIL: begin() refused and the reply played anyway —")
+        for b in bad:
+            print(f"  - {b}")
+        return 1
+    print("\nPASS: the stop in the claim window abandoned the reply — no audio, "
+          "no subtitle frames, no leaked token.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/begin-refused/repro_k_remainder.py
+++ b/tests/repros/begin-refused/repro_k_remainder.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Issue #79, second claim site: the REMAINDER-only reply.
+
+A reply that never produces a sentence boundary (no . ! ?) skips the in-loop
+claim entirely and is spoken by the post-stream remainder block, which had its
+own copy of the ignored begin().  Fixing only the first site would leave the
+short-answer case -- "Yes", "42", "Done" -- still speaking after a stop, and
+short answers are exactly what a voice assistant emits most.
+
+Same contract as repro_j: after a stop in the claim window, NO audio and NO
+subtitle frames.
+
+exit 0 = nothing spoken, nothing subtitled; 1 = the stop was ignored; 2 = setup.
+"""
+import sys
+import threading
+import time
+
+import shim
+import harness
+import subtitle_spy
+
+
+def main():
+    print(f"service under test: {shim.SVC_PATH}")
+    mod, events, _inj = harness.load(fake_tts_seconds=3.0)
+    subtitle_spy.assert_isolated(mod)
+    spy = subtitle_spy.install_spy(mod)
+    svc = harness.make_service(mod)
+    states = shim.record_states(svc)
+
+    subtitle_spy.scenario(mod, conversation_mode=True)
+    # One token, no sentence terminator followed by whitespace, so
+    # _split_sentences yields nothing and the whole reply falls to the
+    # post-stream remainder block -- the SECOND claim site.
+    mod.stream_chat = lambda **kw: iter(["Alpha one"])
+
+    hook = shim.stop_in_the_claim_window(svc)
+
+    t = threading.Thread(target=svc._conversation_worker,
+                         args=("hello",), daemon=True)
+    t.start()
+    t.join(timeout=20.0)
+    if t.is_alive():
+        print("  ! the worker never finished")
+        return 2
+
+    time.sleep(0.3)   # let any late subtitle frame land before asserting none
+
+    if not hook["fired"]:
+        print("  ! SETUP FAILURE — the claim window was never reached")
+        return 2
+    token = hook["token"]
+    if not token.cancelled:
+        print("  ! SETUP FAILURE — the token was not cancelled in the window")
+        return 2
+
+    spoken = [tag for kind, tag, _ts in events if kind == "start"]
+    frames = spy.frames
+    leaked = svc._cancels.live()
+
+    print(f"  stop landed inside the claim window: {hook['fired']}")
+    print(f"  begin() would refuse (token cancelled): {token.cancelled}")
+    print(f"  audio half    — sentences sent to TTS: {spoken or 'none'}")
+    print(f"  subtitle half — frames emitted:        "
+          f"{[(t_[:12], p) for t_, p, _ in frames] or 'none'}")
+    print(f"  live tokens left in the registry:      {leaked or 'none'}")
+    print(f"  badge half    — state transitions:     {states}")
+
+    bad = []
+    if spoken:
+        bad.append(f"{len(spoken)} sentence(s) spoken after the stop: {spoken}")
+    if frames:
+        bad.append(f"{len(frames)} subtitle frame(s) emitted after the stop")
+    if leaked:
+        bad.append(f"leaked tokens: {leaked}")
+    if "speaking" in states:
+        bad.append("the badge announced 'speaking' for a reply that was "
+                   f"never spoken (transitions: {states})")
+    if bad:
+        print("\nFAIL: begin() refused and the reply played anyway —")
+        for b in bad:
+            print(f"  - {b}")
+        return 1
+    print("\nPASS: the stop in the claim window abandoned the reply — no audio, "
+          "no subtitle frames, no leaked token.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/begin-refused/repro_l_healthy_reply.py
+++ b/tests/repros/begin-refused/repro_l_healthy_reply.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Issue #79 regression guard: an UNCANCELLED reply still speaks everything.
+
+The fix reroutes both claim sites through one _claim_playback() and adds an
+`aborted` flag plus a precomputed `speak_remainder`.  Every one of those is a
+chance to stop speaking a reply nobody cancelled -- the failure mode a user
+would notice long before the one the fix is about.
+
+So this asserts the happy path in full: the in-loop sentence AND the
+post-stream remainder both reach TTS, subtitles flow, the reply lands in
+history, and no token leaks.
+
+Unlike repro_j/repro_k this is NOT a bug repro -- it must pass on origin/main
+and on the branch.  A red here on either side is a real regression.
+
+exit 0 = the reply was spoken in full; 1 = something was dropped; 2 = setup.
+"""
+import sys
+import threading
+import time
+
+import shim
+import harness
+import subtitle_spy
+
+
+def main():
+    print(f"service under test: {shim.SVC_PATH}")
+    mod, events, _inj = harness.load(fake_tts_seconds=0.4)
+    subtitle_spy.assert_isolated(mod)
+    spy = subtitle_spy.install_spy(mod)
+    svc = harness.make_service(mod)
+    states = shim.record_states(svc)
+
+    subtitle_spy.scenario(mod, conversation_mode=True)
+    # "Alpha one." completes inside the loop; "Beta two" falls to the
+    # remainder block -- both claim sites exercised in one reply.
+    mod.stream_chat = lambda **kw: iter(["Alpha one. ", "Beta two"])
+
+    t = threading.Thread(target=svc._conversation_worker,
+                         args=("hello",), daemon=True)
+    t.start()
+    t.join(timeout=20.0)
+    if t.is_alive():
+        print("  ! the worker never finished")
+        return 2
+    time.sleep(0.3)
+
+    spoken = [tag for kind, tag, _ts in events if kind == "start"]
+    frames = len(spy.frames)
+    leaked = svc._cancels.live()
+    with svc._conversation_lock:
+        history = list(svc._conversation_history)
+    replied = [h for h in history if h.get("role") == "assistant"]
+
+    print(f"  sentences sent to TTS:        {spoken}")
+    print(f"  subtitle frames emitted:      {frames}")
+    print(f"  assistant turns in history:   {len(replied)}")
+    print(f"  live tokens left:             {leaked or 'none'}")
+    print(f"  final state:                  {svc.current_state!r}")
+    print(f"  state transitions:            {states}")
+
+    bad = []
+    if "Alpha" not in spoken:
+        bad.append("the in-loop sentence was never spoken")
+    if "Beta" not in spoken:
+        bad.append("the post-stream remainder was never spoken")
+    if frames == 0:
+        bad.append("no subtitle frames at all")
+    if not replied:
+        bad.append("the reply never reached conversation history")
+    if leaked:
+        bad.append(f"leaked tokens: {leaked}")
+    if "speaking" not in states:
+        bad.append(f"never announced 'speaking' for a real reply "
+                   f"(transitions: {states})")
+    if svc.current_state != "idle":
+        bad.append(f"did not return to idle (state={svc.current_state!r})")
+    if bad:
+        print("\nFAIL: an uncancelled reply was not delivered in full —")
+        for b in bad:
+            print(f"  - {b}")
+        return 1
+    print("\nPASS: the uncancelled reply was spoken in full, subtitled, "
+          "recorded, and left no token behind.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/begin-refused/run_all.sh
+++ b/tests/repros/begin-refused/run_all.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Usage: ./run_all.sh /path/to/gnome-speaks-service.py
+set -u
+# Default to the service in THIS checkout: tests/repros/<suite>/ -> repo root,
+# so a bare run tests the tree you are standing in.
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+SVC="${1:-$REPO/gnome-speaks-service.py}"
+cd "$(dirname "$0")" || exit 2
+rc=0
+for f in repro_j_first_sentence.py repro_k_remainder.py repro_l_healthy_reply.py; do
+    echo "=== $f ==="
+    GS_SVC_PATH="$SVC" python3 "$f"; s=$?
+    echo "--- exit $s"
+    [ $s -ne 0 ] && rc=$s
+done
+exit $rc

--- a/tests/repros/begin-refused/shim.py
+++ b/tests/repros/begin-refused/shim.py
@@ -1,0 +1,70 @@
+"""Path shim for the issue #79 repros.
+
+Reuses two existing, already-hardened pieces instead of forking them:
+  * cancel-tokens/harness.py -- per-PID scratch, _isolate_config,
+    the fake TTS that honours the global wire, the RecordingInjector.
+  * lucid-subtitle-token-repros/subtitle_spy.py -- GLibSpy (the harness runs no
+    GLib main loop, so SubtitleUpdate frames are otherwise invisible) and
+    assert_isolated (runtime proof the config pins are in effect).
+"""
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+for _d in ("cancel-tokens", "subtitle-token"):
+    sys.path.insert(0, os.path.join(_ROOT, _d))
+
+import harness            # noqa: E402
+import subtitle_spy       # noqa: E402
+
+SVC_PATH = harness.SVC_PATH
+
+
+def stop_in_the_claim_window(svc, label="ai-reply"):
+    """Make a stop land between issue() and begin() for the next `label`.
+
+    That window is real and narrow: _stream_conversation_worker issues the
+    reply's token, publishes it as _speak_token, and only then calls begin().
+    A stop arriving in between is exactly what begin() returning False MEANS.
+    Rather than race for it, hook issue() so the cancel happens inside the
+    window every time.
+
+    The cancel is the registry call stop() itself makes (cancel_all writes a
+    verdict on every live token, then raises the wire); going through the
+    registry rather than svc.stop() avoids the worker thread joining itself.
+
+    Returns a dict with 'fired' so the repro can prove the window was hit
+    instead of assuming it.
+    """
+    state = {"fired": False, "token": None}
+    real_issue = svc._cancels.issue
+
+    def hooked(lbl):
+        token = real_issue(lbl)
+        if lbl == label and not state["fired"]:
+            state["fired"] = True
+            state["token"] = token
+            svc._cancels.cancel_all()
+        return token
+
+    svc._cancels.issue = hooked
+    return state
+
+
+def record_states(svc):
+    """Capture every _set_state transition, in order.
+
+    The badge is a third half that has to agree with the other two: a reply
+    that is never spoken must never announce "speaking". Reading the FINAL
+    state cannot see a flicker, so record the transitions instead.
+    """
+    seen = []
+    real = svc._set_state
+
+    def spy(state, *a, **kw):
+        seen.append(state)
+        return real(state, *a, **kw)
+
+    svc._set_state = spy
+    return seen

--- a/tests/repros/cancel-tokens/harness.py
+++ b/tests/repros/cancel-tokens/harness.py
@@ -1,0 +1,402 @@
+"""Shared harness for the cancel-token repros (issue #21).
+
+Same discipline as ../service-audit/harness.py: import the real
+gnome-speaks-service.py in-process with every dangerous seam stubbed.  No
+audio, no network, no mic, no D-Bus, no port 7710, no ~/.config writes, no
+service restart.
+
+Differences from the audit harness:
+  * scratch lives in the repo's gitignored tmp/, keyed by PID (never /tmp,
+    which is a RAM-backed tmpfs on this workstation)
+  * get_injector() is replaced by a RecordingInjector, so "did a transcript
+    reach the cursor?" is a fact we can assert on instead of a stub no-op
+  * the fake TTS honours the *global* wire (state._cancel_event) exactly like
+    speech_tts.tts does -- the whole point is that the wire is shared
+
+Run any repro with:
+    GS_SVC_PATH=<path to a gnome-speaks-service.py> python3 <script>
+exit 0 = clean, exit 1 = bug present.
+"""
+import atexit
+import contextlib
+import glob
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import time
+
+# ---------------------------------------------------------------------------
+# ISOLATION -- read this before changing any path or CONFIG line below.
+#
+# Two external inputs used to decide these repros' verdicts, and both produced
+# results that read as product regressions:
+#
+# 1. JP's LIVE ~/.config/speech-to-cli/config.json.  state.load_config() reads
+#    it at import, so CONFIG started as ~47 live desktop keys (terminal_mode
+#    and wake_word are True on this machine right now).  Worse,
+#    _reload_config_flags() RE-READS that file mid-run and overwrites CONFIG
+#    for every key in _SYNC_FLAGS, so a pin applied after load() is silently
+#    clobbered unless the repro also stubs that method; and _save_config_flag()
+#    WRITES it.  _isolate_config() below cuts all three wires.
+#
+# 2. Another agent running these same suites.  Every scratch path used to be a
+#    fixed absolute directory, so two processes shared one chronicle file.
+#    MEASURED: two concurrent runs of verify_chronicle_contract.py both fail
+#    with 'equivalence [...]' mismatches; each alone passes.  Hence SCRATCH is
+#    keyed by PID and removed at exit.
+#
+# CONCURRENCY, precisely (an earlier note here overstated this):
+#   * verify_ibus_injector.py rmtree()s a FIXED runtime dir at import, so two
+#     concurrent runs OF IT destroy each other's breadcrumb -- that is the
+#     mechanism behind the one '[9] GetGlobalEngine raises' flake observed on
+#     2026-09-06, not an interaction with verify_wake_gate.py.  Now per-PID.
+#   * UNVERIFIED, flagged: the in-repo verify_wake_gate.py imports
+#     ibus_injector WITHOUT redirecting XDG_RUNTIME_DIR, so anything in it that
+#     reaches acquire() would write JP's REAL prior-engine breadcrumb -- which
+#     is also what verify_ibus_injector's check [12] asserts must not exist.
+# ---------------------------------------------------------------------------
+
+# ENV CONTRACT (unified 2026-09-06): GS_SVC_PATH is the ONE input -- the
+# service.py file under test. The worktree dir is DERIVED from its dirname,
+# so sibling modules (spellbook, injector, ibus_injector) always come from
+# the same tree as the service. GS_WT overrides the dir only if you really
+# mean to mix trees. Defaults to the main checkout; the old defaults pointed
+# at ~/Projects/gnome-speaks-wt/<name>/ worktrees that no longer exist, so a
+# bare run died with FileNotFoundError instead of testing anything.
+# Repo-relative by construction: this file lives at
+# tests/repros/<suite>/<file>.py, so four dirnames reach the repo root. #59:
+# the old defaults were absolute paths into ~/Projects/gnome-speaks-wt/<name>/
+# worktrees that no longer existed, so a bare run died with FileNotFoundError
+# instead of testing anything.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+# Scratch lives in the repo's gitignored tmp/, keyed by PID. Never a fixed
+# shared path: two agents running a suite at once used to corrupt each other
+# and it read exactly like a service regression.
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+SVC_PATH = os.environ.get("GS_SVC_PATH", SVC_DEFAULT)
+WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
+
+# get(), never setdefault(): setdefault EXPORTS the path, so any child python
+# this suite spawns would inherit the PARENT's dir and its atexit would delete
+# the still-running parent's scratch out from under it.
+_PINNED = os.environ.get("GS_REPRO_SCRATCH")
+SCRATCH = _PINNED or os.path.join(SCRATCH_ROOT, f"cancel-repros-{os.getpid()}")
+STATE_DIR = os.path.join(SCRATCH, "state")
+os.environ["XDG_STATE_HOME"] = STATE_DIR        # BEFORE the module computes
+                                                # CHRONICLE_PATH from it
+if _PINNED is None:
+    # Only ever reset and remove a directory THIS process created. A dir the
+    # caller pinned belongs to the caller.
+    shutil.rmtree(SCRATCH, ignore_errors=True)  # a verdict must never depend
+    atexit.register(shutil.rmtree, SCRATCH, True)   # on who ran here before
+os.makedirs(STATE_DIR, exist_ok=True)
+
+
+def _sweep_stale_scratch():
+    """Remove scratch dirs whose owning process is gone.
+
+    atexit does NOT run when `timeout` SIGTERMs a run, which is exactly how
+    these are usually killed -- so the PID-keyed dirs accumulate. Only a dir
+    whose PID no longer exists is touched, so a live sibling run is never
+    swept out from under itself.
+    """
+    import re
+    for d in glob.glob(os.path.join(os.path.dirname(SCRATCH), "*-repros-*")):
+        m = re.search(r"-repros-(\d+)$", d)
+        if not m or d == SCRATCH:
+            continue
+        try:
+            os.kill(int(m.group(1)), 0)      # signal 0: liveness probe only
+        except ProcessLookupError:
+            shutil.rmtree(d, ignore_errors=True)
+        except PermissionError:
+            pass                              # someone else's live process
+        except Exception:
+            pass
+
+
+_sweep_stale_scratch()
+os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+
+
+class RecordingInjector:
+    """Stands in for the ydotool/IBus backends; records instead of typing."""
+
+    name = "recording"
+
+    def __init__(self):
+        self.commits = []       # [(text, monotonic)]
+        self.pastes = []
+        self.typed = []
+        self.preedits = []
+        self.backspaces = 0
+        self.enters = 0
+
+    # -- lifecycle (no-ops) ------------------------------------------------
+    def prepare(self):
+        return True
+
+    def acquire(self):
+        return True
+
+    def end(self):
+        return True
+
+    def cancel(self):
+        return True
+
+    def recover(self):
+        return True
+
+    def available(self):
+        return True
+
+    def supports_preedit(self):
+        return False
+
+    # -- text paths --------------------------------------------------------
+    def commit(self, text):
+        self.commits.append((text, time.monotonic()))
+        return True
+
+    def finalize(self, text):
+        # The keep-live-text path (#45/#64). A key-event backend already typed
+        # it; a pre-edit backend must commit here or end() DISCARDS it. Either
+        # way the text stuck, so the fake records it as delivered. Missing this
+        # method made any repro reaching step 9's keep-live-text branch die
+        # with AttributeError instead of returning a verdict.
+        self.commits.append((text, time.monotonic()))
+        return True
+
+    def purpose_known(self):
+        return False
+
+    def type_text(self, text):
+        self.typed.append((text, time.monotonic()))
+        return True
+
+    def paste(self, text):
+        self.pastes.append((text, time.monotonic()))
+        return True
+
+    def set_preedit(self, text):
+        self.preedits.append((text, time.monotonic()))
+        return True
+
+    def replace_text(self, old_text, new_text):
+        self.commits.append((new_text, time.monotonic()))
+        return True
+
+    def send_backspaces(self, count):
+        self.backspaces += count
+        return True
+
+    def press_enter(self):
+        self.enters += 1
+        return True
+
+    # -- assertions --------------------------------------------------------
+    def all_text(self):
+        """Every way a transcript can reach the cursor, oldest first."""
+        return sorted(self.commits + self.pastes + self.typed, key=lambda p: p[1])
+
+
+
+# Every key below is pinned because a repro's verdict depends on it. Nothing
+# here may be read from JP's live config -- see the ISOLATION note above.
+CONFIG_PINS = {
+    "key": "test-key",              # speak() bails out early without one
+    "wake_word": False,             # the wake watcher must never open the mic
+    "wake_word_model": "",
+    "wake_word_secure_gate": False, # #55: gates live_typing for the session
+    "continuous_dictation": False,  # is_loop -- picks the whole cycle shape
+    "conversation_mode": False,
+    "dictation_mode": True,
+    "terminal_mode": False,         # use_lexical: rewrites text before asserts
+    "skip_final_paste": False,      # picks finalize() vs paste() in step 9
+    "injection_method": "ydotool",
+    "read_notifications": False,
+    "llm_thinking": False,
+    "spiel_provider": False,        # a second D-Bus name on the session bus
+    "debug": False,                 # else every run appends to /tmp/speech-debug.log
+    "live_subtitles": False,
+    "phrase_list": [],
+    "wyoming_host": "",             # no LAN fallback from a test
+    "chronicle": False,
+}
+
+
+
+REAL_STATE = os.path.join(os.path.expanduser("~/.local/state"), "gnome-speaks")
+
+
+
+@contextlib.contextmanager
+def config_scope(mod, **overrides):
+    """Run ONE scenario with its own CONFIG flags, restored afterwards.
+
+    Every load() in a process hands back the SAME dict -- `from state import
+    CONFIG` binds one shared object across the service, audio, stt, speech_tts
+    and wyoming -- so two scenarios in one process silently clobber each
+    other's flags, and the second one's verdict describes the first one's
+    configuration. Snapshot/restore rather than forking, so the repro stays
+    debuggable in one process:
+
+        with harness.config_scope(mod, continuous_dictation=True):
+            ...                      # loop-mode scenario
+        # flags are back to the pinned baseline here
+    
+
+    Three traps a scenario can hit that produce a GREEN run while measuring the
+    WRONG code path -- all three found by lucid-pin-lifecycle, and all three
+    cost an hour each to rediscover:
+
+    1. `_reload_config_flags()` restores conversation_mode=False at
+       start_listening(), so a conversation-mode scenario silently takes the
+       DICTATION path (send_backspaces + paste), the reply path never runs, and
+       the repro still prints a paste and looks like it passed. The CONFIG_PATH
+       redirect in _isolate_config() closes this -- the reload re-reads OUR
+       file and re-applies OUR pins -- but only for flags that are IN
+       CONFIG_PINS. Put a scenario's flags there or in config_scope(), never in
+       a bare CONFIG[...] assignment after load().
+    2. In SINGLE-SHOT, turn_end sets _stop_event and
+       _stream_conversation_worker aborts on it before stream_chat is ever
+       called. Any reply-path scenario needs loop mode, and should assert
+       stream_chat was actually invoked so it cannot pass while testing
+       something else.
+    3. Production calls _conversation_worker SYNCHRONOUSLY from inside
+       _streaming_stt_cycle, so the cycle's `finally` -- and its injector
+       release -- runs after the reply. A scenario that starts the worker on
+       its OWN thread has no such release and will report a stranded backend
+       that production does not have.
+    """
+    saved = dict(mod.CONFIG)
+    mod.CONFIG.update(overrides)
+    try:
+        yield mod.CONFIG
+    finally:
+        mod.CONFIG.clear()
+        mod.CONFIG.update(saved)
+
+
+def assert_isolated(mod):
+    """Prove the module under test cannot reach JP's live state, BEFORE any
+    scenario runs.
+
+    CHRONICLE_PATH is computed at MODULE IMPORT from $XDG_STATE_HOME, so this
+    only holds if the env var was set before exec_module -- which is easy to
+    break by moving an import. The chronicle archive and the rotated
+    generations are derived from CHRONICLE_PATH at call time, so pinning it
+    pins them too. Raises rather than warns: a repro that has quietly attached
+    itself to the real ledger must not be allowed to report a verdict.
+    """
+    root = os.path.realpath(SCRATCH)
+    checks = {
+        "CHRONICLE_PATH": getattr(mod, "CHRONICLE_PATH", None),
+        "CONFIG_PATH": getattr(mod, "CONFIG_PATH", None),
+        "XDG_STATE_HOME": os.environ.get("XDG_STATE_HOME"),
+    }
+    for name, value in checks.items():
+        if value is None:
+            raise AssertionError(f"{name} is unset -- cannot prove isolation")
+        real = os.path.realpath(value)
+        if not (real == root or real.startswith(root + os.sep)):
+            raise AssertionError(
+                f"{name}={value!r} resolves OUTSIDE the isolated scratch "
+                f"{SCRATCH!r} -- refusing to run")
+        if os.path.realpath(REAL_STATE) in (real, os.path.dirname(real)):
+            raise AssertionError(f"{name} points at JP's live state dir")
+    return True
+
+
+def _isolate_config(mod):
+    """Rebuild CONFIG from the service's OWN defaults plus CONFIG_PINS.
+
+    CONFIG is mutated IN PLACE: `from state import CONFIG` means audio, stt,
+    speech_tts and wyoming all hold the same dict object, so rebinding
+    mod.CONFIG would isolate the service module and miss every other one.
+    CONFIG_PATH is repointed at a file holding exactly the same values, so
+    _reload_config_flags() re-reading it is a no-op and _save_config_flag()
+    can never touch JP's real file.
+    """
+    real_defaults = mod.state.DEFAULTS_PATH
+    try:
+        mod.state.DEFAULTS_PATH = os.path.join(SCRATCH, "absent-config.json")
+        baseline = mod.state.load_config()
+    finally:
+        mod.state.DEFAULTS_PATH = real_defaults
+    baseline.update(CONFIG_PINS)
+    path = os.path.join(SCRATCH, "config.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(baseline, f)
+    mod.CONFIG_PATH = path
+    mod.CONFIG.clear()
+    mod.CONFIG.update(baseline)
+    return baseline
+
+
+def load(fake_tts_seconds=1.0):
+    """Import the module under test with the dangerous seams neutralized."""
+    sys.path.insert(0, os.path.dirname(SVC_PATH))  # sibling spellbook.py etc.
+    spec = importlib.util.spec_from_file_location("gsvc_under_test", SVC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["gsvc_under_test"] = mod
+    spec.loader.exec_module(mod)  # main() is __main__-guarded; nothing starts
+
+    _isolate_config(mod)   # BEFORE anything reads CONFIG
+    assert_isolated(mod)   # and prove it, before any scenario
+
+    mod._schedule_warmup = lambda *a, **k: None
+    mod._refresh_audio_detection = lambda *a, **k: None
+    mod._prewarm_recorder = lambda *a, **k: None
+    mod.clipboard_write = lambda *a, **k: True
+
+    injector = RecordingInjector()
+    mod.get_injector = lambda: injector
+
+    events = []          # (kind, tag, monotonic)
+    t0 = time.monotonic()
+
+    def fake_tts(text, **kw):
+        tag = text.split()[0]
+        events.append(("start", tag, time.monotonic() - t0))
+        deadline = time.monotonic() + fake_tts_seconds
+        while time.monotonic() < deadline:
+            if mod.state._cancel_event.is_set():
+                events.append(("cancel", tag, time.monotonic() - t0))
+                return {"spoken": False, "cancelled": True}
+            time.sleep(0.01)
+        events.append(("end", tag, time.monotonic() - t0))
+        return {"spoken": True}
+
+    mod.speech_tts.tts = fake_tts
+    return mod, events, injector
+
+
+def make_service(mod):
+    svc = mod.GnomeSpeaksService()
+    svc._audio_detected = True
+    svc.play_sound = lambda *a, **k: True
+    return svc
+
+
+def outcome_of(svc, item_id):
+    """Terminal outcome recorded for a queue item id, or None."""
+    for rec in list(svc._queue_recent):
+        if rec.get("id") == item_id:
+            return rec.get("outcome")
+    return None
+
+
+def wait_for(pred, timeout=10.0, interval=0.01):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return True
+        time.sleep(interval)
+    return False

--- a/tests/repros/cancel-tokens/repro_a_outcome_mislabel.py
+++ b/tests/repros/cancel-tokens/repro_a_outcome_mislabel.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Issue #21 consequence (a): a preempted queue item is recorded 'done'.
+
+THE INTERLEAVING (all real code; only the width of one window is nudged)
+
+  1. The dispatcher is playing queue item AAA.  speech_tts.tts polls the
+     process-global wire, state._cancel_event.
+  2. Something cancels: /skip, POST /stop, or -- the case here -- the user
+     speaking, which runs stop(drain_queue=False) -> state.cancel_active().
+  3. AAA's tts returns {"cancelled": True}.  _speak_worker's finally then runs
+     (HTTP progress reset, state read, _schedule_warmup) BEFORE the dispatcher
+     gets to classify the outcome.
+  4. In that window the preempting user worker enters _speak_worker and runs
+     `state._cancel_event.clear()`.  The wire is now down.
+  5. The dispatcher finally reaches `if state._cancel_event.is_set()` and
+     reads False -> records AAA as "done".
+
+  GET /queue therefore tells an agent its utterance was spoken in full when it
+  was cut off mid-word.  The window is real (a lock, a state read, a warmup
+  schedule); this script widens it deterministically by making the already
+  stubbed _schedule_warmup take 250 ms, and starts the preempting user speech
+  the instant AAA's tts observes the cancel.
+
+exit 0 = every preempted item labelled "interrupted"; exit 1 = mislabelled.
+"""
+import sys
+import threading
+import time
+
+import harness
+
+ATTEMPTS = 3
+WARMUP_STALL = 0.25
+
+
+def attempt(n):
+    mod, events, _inj = harness.load(fake_tts_seconds=3.0)
+    svc = harness.make_service(mod)
+
+    # Model the real cost of _speak_worker's finally.  The dispatcher cannot
+    # classify the outcome until this returns.
+    mod._schedule_warmup = lambda *a, **k: time.sleep(WARMUP_STALL)
+
+    item_id, _pos, _dropped = svc.enqueue_speech(f"AAA{n} queue item")
+
+    if not harness.wait_for(lambda: any(k == "start" for k, _t, _ts in events), 5.0):
+        print("  ! dispatcher never started the item")
+        return None, False
+
+    time.sleep(0.3)
+
+    preempt_started = threading.Event()
+
+    def preempt():
+        # The real user path: hold, stop(drain_queue=False), new _speak_worker
+        # whose entry clears the wire.
+        preempt_started.set()
+        svc.speak(f"BBB{n} user speech")
+
+    # Fire the user preempt the moment AAA's tts observes the cancel, so its
+    # entry-clear lands inside AAA's finally.
+    def on_cancel():
+        harness.wait_for(
+            lambda: any(k == "cancel" for k, _t, _ts in events), 5.0)
+        preempt()
+
+    t = threading.Thread(target=on_cancel, daemon=True)
+    t.start()
+    svc.stop(drain_queue=False)          # what a /skip or user preempt does
+    preempt_started.wait(5.0)
+
+    harness.wait_for(lambda: harness.outcome_of(svc, item_id) is not None, 5.0)
+    outcome = harness.outcome_of(svc, item_id)
+
+    saw_cancel = any(k == "cancel" for k, _t, _ts in events)
+    mod.state.cancel_active()            # let BBB end early; keep the run short
+    time.sleep(0.2)
+    return outcome, saw_cancel
+
+
+def main():
+    print(f"service under test: {harness.SVC_PATH}")
+    bad = 0
+    for n in range(1, ATTEMPTS + 1):
+        outcome, saw_cancel = attempt(n)
+        if not saw_cancel:
+            print(f"  attempt {n}: SETUP FAILURE — tts never observed the cancel")
+            return 2
+        ok = outcome == "interrupted"
+        if not ok:
+            bad += 1
+        print(f"  attempt {n}: cancelled mid-play -> outcome={outcome!r} "
+              f"{'OK' if ok else 'MISLABELLED (expected interrupted)'}")
+    print(f"\nmislabelled: {bad}/{ATTEMPTS}")
+    if bad:
+        print("FAIL: a cancelled utterance is reported to /queue as 'done'.")
+        return 1
+    print("PASS: every preempted item is labelled 'interrupted'.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/cancel-tokens/repro_b_transcript_after_stop.py
+++ b/tests/repros/cancel-tokens/repro_b_transcript_after_stop.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Issue #21 consequence (b): a transcript is typed at the cursor AFTER stop.
+
+_batch_stt_worker does:
+
+    state._cancel_event.clear()
+    result = stt_dispatch(mode=mode)
+    if result.get("cancelled"): ... return
+    user_text = result.get("text", "")
+    ...
+    get_injector().commit(user_text)          # <-- lands at the cursor
+
+The ONLY cancellation signal it consults is `result["cancelled"]`, i.e. the
+library's own verdict, and the library derives that verdict from the single
+process-global wire `state._cancel_event`.  Two schedules defeat it:
+
+  B1 -- cancel arrives after the library's last check.
+        stt_fixed() (speech-to-cli stt.py:680) checks is_cancelled() exactly
+        once, right after the recorder exits, and then does a POST to Azure
+        with a 30 s timeout.  A /stop during that upload is never seen: the
+        library returns the text and the service types it.  No un-cancel by
+        anyone is required -- the window is the whole upload.
+
+  B2 -- the audit's schedule: the cancel IS pending, but a later worker's
+        `state._cancel_event.clear()` takes the wire down before the library
+        reads it, so the library reports success and the service types it.
+        Modelled here with a rendezvous so the interleaving is exact rather
+        than hoped for; the un-cancel itself is the real svc.speak() path.
+
+Both end the same way, and it is the one that matters most for a voice-first
+user: text appears at the cursor after they asked for silence.
+
+exit 0 = nothing reached the cursor after stop; exit 1 = it did.
+"""
+import sys
+import threading
+import time
+
+import harness
+
+SECRET = "this sentence must never reach the cursor"
+
+
+def scenario_b1():
+    """Cancel lands while the library is past its last cancellation check."""
+    mod, _events, inj = harness.load()
+    svc = harness.make_service(mod)
+    svc._stt_mode = "fixed"
+
+    upload_started = threading.Event()
+
+    def fake_stt(mode=None, **kw):
+        # phase 1 -- recorder running; cancel_active() terminates it and the
+        # library then checks is_cancelled() once.
+        deadline = time.monotonic() + 0.4
+        while time.monotonic() < deadline:
+            if mod.state._cancel_event.is_set():
+                return {"text": "", "cancelled": True}
+            time.sleep(0.01)
+        if mod.state._cancel_event.is_set():
+            return {"text": "", "cancelled": True}
+        # phase 2 -- the Azure POST.  Nothing between here and the return
+        # looks at the wire again (stt.py:680-700).
+        upload_started.set()
+        time.sleep(5.0)
+        return {"text": SECRET}
+
+    mod.stt_dispatch = fake_stt
+
+    assert svc.start_listening() == "ok"
+    assert upload_started.wait(5.0), "setup: upload phase never reached"
+
+    t_stop = time.monotonic()
+    svc.stop()                       # the user says "stop"
+    print(f"    stop() returned after {time.monotonic() - t_stop:.1f}s "
+          f"(state={svc.current_state})")
+
+    harness.wait_for(lambda: inj.all_text(), 8.0)
+    time.sleep(0.5)
+    late = [(txt, ts - t_stop) for txt, ts in inj.all_text() if ts > t_stop]
+    return late, svc.current_state
+
+
+def scenario_b2():
+    """A later worker's clear() un-cancels a still-running STT worker."""
+    mod, _events, inj = harness.load()
+    svc = harness.make_service(mod)
+    svc._stt_mode = "fixed"
+
+    about_to_check = threading.Event()
+    may_check = threading.Event()
+
+    def fake_stt(mode=None, **kw):
+        # phase 1 -- recorder; cancel_active() kills it promptly.
+        while not mod.state._cancel_event.is_set():
+            time.sleep(0.01)
+        # The library is now between "recorder exited" and its single
+        # is_cancelled() call.  Hold there while the un-cancel happens.
+        about_to_check.set()
+        may_check.wait(10.0)
+        if mod.state._cancel_event.is_set():
+            return {"text": "", "cancelled": True}
+        upload = time.monotonic()
+        time.sleep(0.5)
+        del upload
+        return {"text": SECRET}
+
+    mod.stt_dispatch = fake_stt
+
+    assert svc.start_listening() == "ok"
+    time.sleep(0.2)
+
+    t_stop = time.monotonic()
+    svc.stop()                       # sets the wire; join times out at 3 s
+    print(f"    stop() returned after {time.monotonic() - t_stop:.1f}s "
+          f"(state={svc.current_state})")
+    assert about_to_check.wait(5.0), "setup: library never reached its check"
+
+    # The real un-cancel: any subsequent speech worker clears the global wire
+    # on entry (gnome-speaks-service.py, _speak_worker).
+    svc.speak("unrelated agent chatter")
+    harness.wait_for(lambda: not mod.state._cancel_event.is_set(), 3.0)
+    print(f"    after a later speak() the wire is "
+          f"{'STILL SET' if mod.state._cancel_event.is_set() else 'CLEARED'}")
+    may_check.set()
+
+    harness.wait_for(lambda: inj.all_text(), 8.0)
+    time.sleep(0.5)
+    late = [(txt, ts - t_stop) for txt, ts in inj.all_text() if ts > t_stop]
+    mod.state.cancel_active()
+    return late, None
+
+
+def main():
+    print(f"service under test: {harness.SVC_PATH}")
+    failures = 0
+    for name, fn, desc in (
+            ("B1", scenario_b1, "cancel arrives after the library's last check"),
+            ("B2", scenario_b2, "a later worker's clear() un-cancels the STT worker")):
+        print(f"\n  {name}: {desc}")
+        late, state_after = fn()
+        if late:
+            failures += 1
+            for txt, dt in late:
+                print(f"    FAIL: {txt!r} reached the cursor {dt:.1f}s AFTER stop()")
+        else:
+            print("    OK: nothing reached the cursor after stop()")
+        if state_after is not None and state_after not in ("idle",):
+            print(f"    note: service left in state {state_after!r} after stop()")
+
+    print()
+    if failures:
+        print(f"FAIL: {failures}/2 schedules typed a transcript after stop.")
+        return 1
+    print("PASS: a stopped STT operation never reaches the cursor.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/cancel-tokens/repro_c_streaming_after_stop.py
+++ b/tests/repros/cancel-tokens/repro_c_streaming_after_stop.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Issue #21, streaming path: /stop still types the transcript collected so far.
+
+Streaming is the DEFAULT STT mode (stt_mode=auto picks it whenever
+websocket-client and webrtcvad are present), so this is the path JP's
+dictation actually takes.
+
+_streaming_stt_worker has ONE stop signal, self._stop_event, and two callers
+set it for opposite reasons:
+
+  * stop_listening()  -- "end the utterance, KEEP the text"  (the dictation
+    hotkey; the docstring says so).  The transcript must be typed.
+  * stop()            -- the panic stop: D-Bus Stop, POST /stop, "cast stop",
+    and every user-speech preemption.  The transcript must be ABANDONED.
+
+The worker cannot tell them apart.  After the receive loop exits, control
+falls straight through to
+
+        user_text = " ".join(phrases).strip()
+        ...
+        self._set_state("processing")
+        ...
+        get_injector().commit(user_text)
+
+with no cancellation check anywhere in between.  So a panic stop types
+whatever Azure had already returned -- no race, no hang, no un-cancel needed.
+(state.cancel_active() does raise the global wire, but nothing on this path
+reads it, which is the same missing-authority defect as consequence (b).)
+
+C1 -- stop():          nothing may reach the cursor.
+C2 -- stop_listening(): the transcript MUST still reach the cursor.
+      C2 is the regression guard: the fix must not break dictation.
+
+exit 0 = both hold; exit 1 = at least one is violated.
+"""
+import sys
+import threading
+import time
+
+import harness
+
+PHRASE = "the quick brown fox"
+
+
+class FakeStdout:
+    def __init__(self, frame_bytes):
+        self._frame = b"\x00" * frame_bytes
+
+    def read(self, n):
+        time.sleep(0.005)
+        return self._frame
+
+
+class FakeProc:
+    """Stands in for the pw-record/arecord subprocess."""
+
+    def __init__(self, frame_bytes):
+        self.stdout = FakeStdout(frame_bytes)
+        self.terminated = False
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.terminated = True
+
+    def poll(self):
+        return 0 if self.terminated else None
+
+    def wait(self, timeout=None):
+        return 0
+
+
+class FakeWS:
+    """Stands in for the Azure streaming WebSocket."""
+
+    def __init__(self):
+        self.closed = threading.Event()
+
+    def settimeout(self, t):
+        pass
+
+    def send(self, payload, opcode=None):
+        if self.closed.is_set():
+            raise RuntimeError("ws closed")
+
+    def recv(self):
+        if self.closed.is_set():
+            raise RuntimeError("ws closed")
+        time.sleep(0.05)
+        return "MSG"
+
+
+def run(stop_kind):
+    mod, _events, inj = harness.load()
+
+    frame_bytes = mod.FRAME_BYTES
+    proc = FakeProc(frame_bytes)
+    ws = FakeWS()
+    phrase_seen = threading.Event()
+
+    mod.HAS_WS = True
+    mod.HAS_VAD = False            # skip webrtcvad; energy gate is stubbed below
+    mod._take_prewarmed_rec = lambda *a, **k: proc
+    mod._get_stt_ws = lambda *a, **k: (ws, True)
+    mod._init_stt_ws_session = lambda *a, **k: None
+    mod._make_ws_audio_msg = lambda *a, **k: b""
+    mod.calibrate_noise = lambda p: (1000.0, [])
+    mod.rms_energy = lambda chunk: 5000.0
+    mod.is_speech_energy = lambda chunk, vad, thr: True
+    mod._rest_stt_fallback = lambda *a, **k: ""
+
+    def fake_parse(msg, phrases, partial_holder, end_word_event, end_word,
+                   _log, raw_partial_holder=None, use_lexical=False):
+        if not phrase_seen.is_set():
+            phrases.append(PHRASE)
+            partial_holder[0] = PHRASE
+            if raw_partial_holder is not None:
+                raw_partial_holder[0] = PHRASE
+            phrase_seen.set()
+        return "hypothesis"        # keep the receive loop running
+
+    mod._parse_ws_msg = fake_parse
+
+    svc = harness.make_service(mod)
+    svc._stt_mode = "streaming"
+    # Route the transcript through the single final commit rather than the
+    # live-typing path, so "did it reach the cursor" is one unambiguous fact.
+    inj.available = lambda: False
+
+    assert svc.start_listening() == "ok", "setup: start_listening refused"
+    assert phrase_seen.wait(5.0), "setup: no phrase was ever recognised"
+    time.sleep(0.1)
+
+    t_stop = time.monotonic()
+    if stop_kind == "stop":
+        svc.stop()
+    else:
+        svc.stop_listening()
+    ws.closed.set()
+
+    harness.wait_for(lambda: inj.all_text(), 4.0)
+    time.sleep(0.3)
+    # The streaming worker has four exits; none of them may leak its token.
+    leaked = getattr(svc, "_cancels", None) and svc._cancels.live()
+    if leaked:
+        print(f"    FAIL: leaked cancel token(s) {[repr(t) for t in leaked]}")
+    return ([(txt, ts - t_stop) for txt, ts in inj.all_text()],
+            svc.current_state, bool(leaked))
+
+
+def main():
+    print(f"service under test: {harness.SVC_PATH}")
+    failures = 0
+
+    print("\n  C1: stop() -- the panic stop; the transcript must be abandoned")
+    typed, st, leaked = run("stop")
+    failures += int(leaked)
+    if typed:
+        failures += 1
+        for txt, dt in typed:
+            print(f"    FAIL: {txt!r} typed {dt:+.1f}s relative to stop()")
+    else:
+        print("    OK: nothing reached the cursor")
+    print(f"    (state after: {st!r})")
+
+    print("\n  C2: stop_listening() -- the dictation hotkey; text must be KEPT")
+    typed, st, leaked = run("stop_listening")
+    failures += int(leaked)
+    if not typed:
+        failures += 1
+        print("    FAIL: dictation lost its transcript (regression)")
+    else:
+        for txt, dt in typed:
+            print(f"    OK: {txt!r} typed {dt:+.1f}s relative to stop_listening()")
+    print(f"    (state after: {st!r})")
+
+    print()
+    if failures:
+        print(f"FAIL: {failures}/2 -- stop() and stop_listening() are not "
+              f"distinguishable to the streaming worker.")
+        return 1
+    print("PASS: stop() abandons the transcript, stop_listening() keeps it.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/cancel-tokens/repro_d_mic_disconnect.py
+++ b/tests/repros/cancel-tokens/repro_d_mic_disconnect.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Issue #57: a dead recorder is invisible -- no Error signal, loop mode spins.
+
+The recorder (pw-record on a USB mic that is unplugged) returns EOF from
+stdout immediately.  Expected: exactly one Error signal, the cycle loop exits
+after one cycle, the service is idle.  Bug: no Error, and with
+continuous_dictation=True the cycle loop treats the EOF as "no speech" and
+re-enters listening -- forever, badge stuck on "listening".
+
+exit 0 = clean, exit 1 = bug present.
+"""
+import sys
+import threading
+import time
+
+import harness
+
+WINDOW = 6.0   # a spin produces several cycles in this window (~2s each)
+
+
+class DeadStdout:
+    def __init__(self, proc):
+        self._proc = proc
+
+    def read(self, n):
+        self._proc.exited = True     # pw-record exits right after its EOF
+        return b""
+
+
+class DeadProc:
+    """pw-record whose device vanished mid-session: stdout EOF, then exit.
+
+    poll() reports alive until the first read so the prewarm liveness check
+    passes -- this is the mic yanked while the session is live, not a stale
+    prewarm (that case is covered by the same check and must not open a
+    real recorder from inside the repro).
+    """
+
+    def __init__(self):
+        self.exited = False
+        self.stdout = DeadStdout(self)
+
+    def poll(self):
+        return 1 if self.exited else None
+
+    def terminate(self):
+        pass
+
+    def kill(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 1
+
+
+class FakeWS:
+    def __init__(self, timeout_exc):
+        self._exc = timeout_exc
+
+    def settimeout(self, t):
+        pass
+
+    def send(self, payload, opcode=None):
+        pass
+
+    def recv(self):
+        time.sleep(0.05)
+        raise self._exc()
+
+
+def main():
+    mod, _events, inj = harness.load()
+    print(f"service under test: {harness.SVC_PATH}")
+
+    cycles = [0]
+    errors = []
+
+    mod.HAS_WS = True
+    mod.HAS_VAD = False
+    mod.CONFIG["continuous_dictation"] = True
+    mod._take_prewarmed_rec = lambda *a, **k: DeadProc()
+    mod._get_stt_ws = lambda *a, **k: (FakeWS(mod.websocket.WebSocketTimeoutException), True)
+    mod._make_ws_audio_msg = lambda *a, **k: b""
+    mod._rest_stt_fallback = lambda *a, **k: ""
+    mod._parse_ws_msg = lambda *a, **k: None
+    # the real calibrate_noise is left in place: (500.0, []) on a dead pipe
+
+    def count_cycle(*a, **k):
+        cycles[0] += 1
+    mod._init_stt_ws_session = count_cycle
+
+    # No GLib main loop in the harness: run idle callbacks inline so the
+    # Error signal (marshalled via idle_add) is observable.
+    mod.GLib.idle_add = lambda fn, *a, **k: fn(*a, **k)
+
+    svc = harness.make_service(mod)
+    svc._stt_mode = "streaming"
+    svc._reload_config_flags = lambda: None   # keep continuous_dictation=True
+    svc._emit_error = lambda msg: errors.append(msg) or False
+
+    assert svc.start_listening() == "ok", "setup: start_listening refused"
+    idle_at = [None]
+    t0 = time.monotonic()
+    if harness.wait_for(lambda: svc.current_state == "idle", WINDOW):
+        idle_at[0] = time.monotonic() - t0
+    else:
+        time.sleep(0.2)
+    state_seen = svc.current_state
+    svc.stop()
+    time.sleep(0.3)
+
+    failures = 0
+    print(f"  cycles run in {WINDOW:.0f}s window: {cycles[0]}")
+    print(f"  Error signals: {errors}")
+    print(f"  state after window: {state_seen!r}"
+          + (f" (idle after {idle_at[0]:.1f}s)" if idle_at[0] is not None else ""))
+    if cycles[0] > 1:
+        failures += 1
+        print("    FAIL: loop mode spun on a dead recorder")
+    if len(errors) != 1 or "icrophone" not in errors[0]:
+        failures += 1
+        print("    FAIL: expected exactly one microphone Error signal")
+    if idle_at[0] is None or idle_at[0] > 4.0:
+        failures += 1
+        print("    FAIL: service did not return to idle promptly")
+    if inj.all_text():
+        failures += 1
+        print(f"    FAIL: text reached the cursor: {inj.all_text()}")
+    leaked = svc._cancels.live()
+    if leaked:
+        failures += 1
+        print(f"    FAIL: leaked cancel token(s) {leaked}")
+    print()
+    if failures:
+        print(f"FAIL: {failures} -- a dead recorder is invisible / spins")
+        return 1
+    print("PASS: dead recorder -> one Error, one cycle, idle")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/cancel-tokens/verify_cancel_invariants.py
+++ b/tests/repros/cancel-tokens/verify_cancel_invariants.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Invariants the cancel-token layer must hold (issue #21).
+
+  I1  Every issued token is retired.  A leaked token is not cosmetic: it stays
+      in the live set forever, so cancel_all() keeps "cancelling" a dead
+      operation and begin() logs a stale warning on every later utterance.
+  I2  When nothing is running, the global wire is DOWN.  A stale cancel left
+      raised is what makes the next operation die on arrival.
+  I3  Exactly one terminal outcome per queue item id (the #19 contract), with
+      cancel/skip/stop mixed in.
+  I4  A skip lands on the item it named, and that item alone.
+
+Exercises the queue, /skip, /stop, user preemption and batch STT together --
+the paths that share the one wire.
+
+Reports SKIP on a build without the registry (pre-#21), so the suite can be
+pointed at origin/main without a false failure.
+"""
+import sys
+import time
+
+import harness
+
+
+def main():
+    print(f"service under test: {harness.SVC_PATH}")
+    mod, _events, inj = harness.load(fake_tts_seconds=0.4)
+    svc = harness.make_service(mod)
+
+    if not hasattr(svc, "_cancels"):
+        print("SKIP: this build has no cancel registry (pre-#21).")
+        return 0
+
+    failures = []
+
+    def check(ok, label):
+        print(f"  {'ok  ' if ok else 'FAIL'} {label}")
+        if not ok:
+            failures.append(label)
+
+    # --- a burst of queue items, one of them skipped by id -----------------
+    ids = [svc.enqueue_speech(f"Q{n} queued item", source="agent")[0]
+           for n in range(6)]
+    harness.wait_for(lambda: svc._queue_current is not None, 5.0)
+    playing = svc._queue_current.id
+    skipped = svc.skip_current(playing)
+    check(skipped == playing, f"skip_current({playing}) hit the playing item")
+
+    # I4 is checked here, in isolation: the panic stop below legitimately
+    # interrupts whatever is playing by then, which would mask a cascade.
+    harness.wait_for(lambda: harness.outcome_of(svc, playing) is not None, 5.0)
+    after_skip = {r["id"]: r["outcome"] for r in list(svc._queue_recent)}
+    check(after_skip.get(playing) == "interrupted",
+          f"I4 the skipped item is 'interrupted' (got {after_skip.get(playing)!r})")
+    check(set(after_skip) == {playing},
+          f"I4 the skip touched that item and no other ({after_skip})")
+    check(svc.skip_current(999999) is None, "skip_current(wrong id) is a no-op")
+
+    # --- user speech preempts the rest, then a panic stop ------------------
+    time.sleep(0.3)
+    svc.speak("USER preempting speech")
+    time.sleep(0.3)
+    svc.stop()
+
+    # --- a batch STT session that is stopped while "uploading" -------------
+    svc._stt_mode = "fixed"
+
+    def slow_stt(mode=None, **kw):
+        time.sleep(1.0)
+        return {"text": "late transcript"}
+
+    mod.stt_dispatch = slow_stt
+    svc.start_listening()
+    time.sleep(0.2)
+    svc.stop()
+
+    # --- let everything wind down ------------------------------------------
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        if not svc._cancels.live() and svc._queue_current is None:
+            break
+        time.sleep(0.05)
+    time.sleep(0.5)
+
+    live = svc._cancels.live()
+    check(not live, f"I1 no leaked tokens (live={[repr(t) for t in live]})")
+    check(not mod.state._cancel_event.is_set(),
+          "I2 the global wire is down once nothing is running")
+
+    outcomes = [(r["id"], r["outcome"]) for r in list(svc._queue_recent)]
+    seen = {}
+    dupes = []
+    for item_id, outcome in outcomes:
+        if item_id in seen:
+            dupes.append(item_id)
+        seen[item_id] = outcome
+    check(not dupes, f"I3 one terminal outcome per id (dupes={dupes})")
+    check(all(i in seen for i in ids),
+          "I3 every enqueued id reached a terminal outcome")
+    check(all(o in ("canceled", "done", "interrupted") for o in seen.values()),
+          f"I3 every outcome is from the terminal vocabulary ({seen})")
+    check(not [t for t, _ts in inj.all_text()],
+          "no STT transcript reached the cursor across the whole run")
+
+    print(f"\noutcomes: {outcomes}")
+    if failures:
+        print(f"FAIL: {len(failures)} invariant(s) violated.")
+        return 1
+    print("RESULT: CANCEL INVARIANTS HOLD")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/chronicle-perf/harness.py
+++ b/tests/repros/chronicle-perf/harness.py
@@ -1,0 +1,305 @@
+"""Shared harness: import gnome-speaks-service.py with every dangerous seam stubbed.
+
+No audio, no network, no mic, no D-Bus, no port 7710, no writes outside /tmp.
+"""
+import atexit
+import contextlib
+import glob
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import time
+
+# ---------------------------------------------------------------------------
+# ISOLATION -- read this before changing any path or CONFIG line below.
+#
+# Two external inputs used to decide these repros' verdicts, and both produced
+# results that read as product regressions:
+#
+# 1. JP's LIVE ~/.config/speech-to-cli/config.json.  state.load_config() reads
+#    it at import, so CONFIG started as ~47 live desktop keys (terminal_mode
+#    and wake_word are True on this machine right now).  Worse,
+#    _reload_config_flags() RE-READS that file mid-run and overwrites CONFIG
+#    for every key in _SYNC_FLAGS, so a pin applied after load() is silently
+#    clobbered unless the repro also stubs that method; and _save_config_flag()
+#    WRITES it.  _isolate_config() below cuts all three wires.
+#
+# 2. Another agent running these same suites.  Every scratch path used to be a
+#    fixed absolute directory, so two processes shared one chronicle file.
+#    MEASURED: two concurrent runs of verify_chronicle_contract.py both fail
+#    with 'equivalence [...]' mismatches; each alone passes.  Hence SCRATCH is
+#    keyed by PID and removed at exit.
+#
+# CONCURRENCY, precisely (an earlier note here overstated this):
+#   * verify_ibus_injector.py rmtree()s a FIXED runtime dir at import, so two
+#     concurrent runs OF IT destroy each other's breadcrumb -- that is the
+#     mechanism behind the one '[9] GetGlobalEngine raises' flake observed on
+#     2026-09-06, not an interaction with verify_wake_gate.py.  Now per-PID.
+#   * UNVERIFIED, flagged: the in-repo verify_wake_gate.py imports
+#     ibus_injector WITHOUT redirecting XDG_RUNTIME_DIR, so anything in it that
+#     reaches acquire() would write JP's REAL prior-engine breadcrumb -- which
+#     is also what verify_ibus_injector's check [12] asserts must not exist.
+# ---------------------------------------------------------------------------
+
+# ENV CONTRACT (unified 2026-09-06): GS_SVC_PATH is the ONE input -- the
+# service.py file under test. The worktree dir is DERIVED from its dirname,
+# so sibling modules (spellbook, injector, ibus_injector) always come from
+# the same tree as the service. GS_WT overrides the dir only if you really
+# mean to mix trees. Defaults to the main checkout; the old defaults pointed
+# at ~/Projects/gnome-speaks-wt/<name>/ worktrees that no longer exist, so a
+# bare run died with FileNotFoundError instead of testing anything.
+# Repo-relative by construction: this file lives at
+# tests/repros/<suite>/<file>.py, so four dirnames reach the repo root. #59:
+# the old defaults were absolute paths into ~/Projects/gnome-speaks-wt/<name>/
+# worktrees that no longer existed, so a bare run died with FileNotFoundError
+# instead of testing anything.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+# Scratch lives in the repo's gitignored tmp/, keyed by PID. Never a fixed
+# shared path: two agents running a suite at once used to corrupt each other
+# and it read exactly like a service regression.
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+SVC_PATH = os.environ.get("GS_SVC_PATH", SVC_DEFAULT)
+WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
+
+# get(), never setdefault(): setdefault EXPORTS the path, so any child python
+# this suite spawns would inherit the PARENT's dir and its atexit would delete
+# the still-running parent's scratch out from under it.
+_PINNED = os.environ.get("GS_REPRO_SCRATCH")
+SCRATCH = _PINNED or os.path.join(SCRATCH_ROOT, f"chronicle-repros-{os.getpid()}")
+STATE_DIR = os.path.join(SCRATCH, "state")
+os.environ["XDG_STATE_HOME"] = STATE_DIR        # BEFORE the module computes
+                                                # CHRONICLE_PATH from it
+if _PINNED is None:
+    # Only ever reset and remove a directory THIS process created. A dir the
+    # caller pinned belongs to the caller.
+    shutil.rmtree(SCRATCH, ignore_errors=True)  # a verdict must never depend
+    atexit.register(shutil.rmtree, SCRATCH, True)   # on who ran here before
+os.makedirs(STATE_DIR, exist_ok=True)
+
+
+def _sweep_stale_scratch():
+    """Remove scratch dirs whose owning process is gone.
+
+    atexit does NOT run when `timeout` SIGTERMs a run, which is exactly how
+    these are usually killed -- so the PID-keyed dirs accumulate. Only a dir
+    whose PID no longer exists is touched, so a live sibling run is never
+    swept out from under itself.
+    """
+    import re
+    for d in glob.glob(os.path.join(os.path.dirname(SCRATCH), "*-repros-*")):
+        m = re.search(r"-repros-(\d+)$", d)
+        if not m or d == SCRATCH:
+            continue
+        try:
+            os.kill(int(m.group(1)), 0)      # signal 0: liveness probe only
+        except ProcessLookupError:
+            shutil.rmtree(d, ignore_errors=True)
+        except PermissionError:
+            pass                              # someone else's live process
+        except Exception:
+            pass
+
+
+_sweep_stale_scratch()
+os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+
+
+
+# Every key below is pinned because a repro's verdict depends on it. Nothing
+# here may be read from JP's live config -- see the ISOLATION note above.
+CONFIG_PINS = {
+    "key": "test-key",              # speak() bails out early without one
+    "wake_word": False,             # the wake watcher must never open the mic
+    "wake_word_model": "",
+    "wake_word_secure_gate": False, # #55: gates live_typing for the session
+    "continuous_dictation": False,  # is_loop -- picks the whole cycle shape
+    "conversation_mode": False,
+    "dictation_mode": True,
+    "terminal_mode": False,         # use_lexical: rewrites text before asserts
+    "skip_final_paste": False,      # picks finalize() vs paste() in step 9
+    "injection_method": "ydotool",
+    "read_notifications": False,
+    "llm_thinking": False,
+    "spiel_provider": False,        # a second D-Bus name on the session bus
+    "debug": False,                 # else every run appends to /tmp/speech-debug.log
+    "live_subtitles": False,
+    "phrase_list": [],
+    "wyoming_host": "",             # no LAN fallback from a test
+    "chronicle": True,
+}
+
+
+
+REAL_STATE = os.path.join(os.path.expanduser("~/.local/state"), "gnome-speaks")
+
+
+
+@contextlib.contextmanager
+def config_scope(mod, **overrides):
+    """Run ONE scenario with its own CONFIG flags, restored afterwards.
+
+    Every load() in a process hands back the SAME dict -- `from state import
+    CONFIG` binds one shared object across the service, audio, stt, speech_tts
+    and wyoming -- so two scenarios in one process silently clobber each
+    other's flags, and the second one's verdict describes the first one's
+    configuration. Snapshot/restore rather than forking, so the repro stays
+    debuggable in one process:
+
+        with harness.config_scope(mod, continuous_dictation=True):
+            ...                      # loop-mode scenario
+        # flags are back to the pinned baseline here
+    
+
+    Three traps a scenario can hit that produce a GREEN run while measuring the
+    WRONG code path -- all three found by lucid-pin-lifecycle, and all three
+    cost an hour each to rediscover:
+
+    1. `_reload_config_flags()` restores conversation_mode=False at
+       start_listening(), so a conversation-mode scenario silently takes the
+       DICTATION path (send_backspaces + paste), the reply path never runs, and
+       the repro still prints a paste and looks like it passed. The CONFIG_PATH
+       redirect in _isolate_config() closes this -- the reload re-reads OUR
+       file and re-applies OUR pins -- but only for flags that are IN
+       CONFIG_PINS. Put a scenario's flags there or in config_scope(), never in
+       a bare CONFIG[...] assignment after load().
+    2. In SINGLE-SHOT, turn_end sets _stop_event and
+       _stream_conversation_worker aborts on it before stream_chat is ever
+       called. Any reply-path scenario needs loop mode, and should assert
+       stream_chat was actually invoked so it cannot pass while testing
+       something else.
+    3. Production calls _conversation_worker SYNCHRONOUSLY from inside
+       _streaming_stt_cycle, so the cycle's `finally` -- and its injector
+       release -- runs after the reply. A scenario that starts the worker on
+       its OWN thread has no such release and will report a stranded backend
+       that production does not have.
+    """
+    saved = dict(mod.CONFIG)
+    mod.CONFIG.update(overrides)
+    try:
+        yield mod.CONFIG
+    finally:
+        mod.CONFIG.clear()
+        mod.CONFIG.update(saved)
+
+
+def assert_isolated(mod):
+    """Prove the module under test cannot reach JP's live state, BEFORE any
+    scenario runs.
+
+    CHRONICLE_PATH is computed at MODULE IMPORT from $XDG_STATE_HOME, so this
+    only holds if the env var was set before exec_module -- which is easy to
+    break by moving an import. The chronicle archive and the rotated
+    generations are derived from CHRONICLE_PATH at call time, so pinning it
+    pins them too. Raises rather than warns: a repro that has quietly attached
+    itself to the real ledger must not be allowed to report a verdict.
+    """
+    root = os.path.realpath(SCRATCH)
+    checks = {
+        "CHRONICLE_PATH": getattr(mod, "CHRONICLE_PATH", None),
+        "CONFIG_PATH": getattr(mod, "CONFIG_PATH", None),
+        "XDG_STATE_HOME": os.environ.get("XDG_STATE_HOME"),
+    }
+    for name, value in checks.items():
+        if value is None:
+            raise AssertionError(f"{name} is unset -- cannot prove isolation")
+        real = os.path.realpath(value)
+        if not (real == root or real.startswith(root + os.sep)):
+            raise AssertionError(
+                f"{name}={value!r} resolves OUTSIDE the isolated scratch "
+                f"{SCRATCH!r} -- refusing to run")
+        if os.path.realpath(REAL_STATE) in (real, os.path.dirname(real)):
+            raise AssertionError(f"{name} points at JP's live state dir")
+    return True
+
+
+def _isolate_config(mod):
+    """Rebuild CONFIG from the service's OWN defaults plus CONFIG_PINS.
+
+    CONFIG is mutated IN PLACE: `from state import CONFIG` means audio, stt,
+    speech_tts and wyoming all hold the same dict object, so rebinding
+    mod.CONFIG would isolate the service module and miss every other one.
+    CONFIG_PATH is repointed at a file holding exactly the same values, so
+    _reload_config_flags() re-reading it is a no-op and _save_config_flag()
+    can never touch JP's real file.
+    """
+    real_defaults = mod.state.DEFAULTS_PATH
+    try:
+        mod.state.DEFAULTS_PATH = os.path.join(SCRATCH, "absent-config.json")
+        baseline = mod.state.load_config()
+    finally:
+        mod.state.DEFAULTS_PATH = real_defaults
+    baseline.update(CONFIG_PINS)
+    path = os.path.join(SCRATCH, "config.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(baseline, f)
+    mod.CONFIG_PATH = path
+    mod.CONFIG.clear()
+    mod.CONFIG.update(baseline)
+    return baseline
+
+
+def load(fake_tts_seconds=1.0):
+    sys.path.insert(0, os.path.dirname(SVC_PATH))  # sibling spellbook.py
+    spec = importlib.util.spec_from_file_location("gsvc_under_test", SVC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["gsvc_under_test"] = mod
+    spec.loader.exec_module(mod)  # main() is __main__-guarded; nothing starts
+
+    _isolate_config(mod)   # BEFORE anything reads CONFIG
+    assert_isolated(mod)   # and prove it, before any scenario
+
+    # --- neutralize every side effect before any instance exists ---
+    mod._schedule_warmup = lambda *a, **k: None
+    mod._refresh_audio_detection = lambda *a, **k: None
+    mod._prewarm_recorder = lambda *a, **k: None
+    mod.type_at_cursor = lambda *a, **k: None
+    mod.clipboard_write = lambda *a, **k: True
+
+    events = []          # (kind, tag, monotonic)
+    t0 = time.monotonic()
+
+    def fake_tts(text, **kw):
+        tag = text.split()[0]
+        events.append(("start", tag, time.monotonic() - t0))
+        deadline = time.monotonic() + fake_tts_seconds
+        while time.monotonic() < deadline:
+            if mod.state._cancel_event.is_set():
+                events.append(("cancel", tag, time.monotonic() - t0))
+                return {"spoken": False, "cancelled": True}
+            time.sleep(0.01)
+        events.append(("end", tag, time.monotonic() - t0))
+        return {"spoken": True}
+
+    mod.speech_tts.tts = fake_tts
+    return mod, events
+
+
+def make_service(mod):
+    svc = mod.GnomeSpeaksService()
+    svc._audio_detected = True
+    svc.play_sound = lambda *a, **k: True
+    return svc
+
+
+def spans(events):
+    """Collapse the event log into {tag: (start, end)} playback spans."""
+    out = {}
+    for kind, tag, ts in events:
+        if kind == "start":
+            out.setdefault(tag, [ts, None])
+        else:
+            if tag in out:
+                out[tag][1] = ts
+    return {k: tuple(v) for k, v in out.items()}
+
+
+def overlap(a, b):
+    (a0, a1), (b0, b1) = a, b
+    a1 = a1 if a1 is not None else 1e9
+    b1 = b1 if b1 is not None else 1e9
+    return max(0.0, min(a1, b1) - max(a0, b0))

--- a/tests/repros/chronicle-perf/repro_chronicle_stall.py
+++ b/tests/repros/chronicle-perf/repro_chronicle_stall.py
@@ -1,0 +1,154 @@
+"""Issue #22 repro: GetChronicle scans the whole ledger ON the GLib main loop.
+
+Three measurements, all against a synthetic ledger (never the real one — the
+harness redirects XDG_STATE_HOME to /tmp):
+
+  1. main-loop stall — a 20ms heartbeat runs on a real GLib main loop while
+     DBusHandler.handle_method_call("GetChronicle") is dispatched exactly as
+     GDBus dispatches it. The worst heartbeat gap IS the stall: for that long
+     the service emits no SubtitleUpdate, no AudioLevel, no StateChanged.
+  2. scan cost — _chronicle_read(limit=12), the badge/submenu call.
+  3. append starvation — how long _chronicle_append blocks behind a reader
+     that holds _chronicle_lock for a whole-file scan. That is the speech
+     path waiting on the UI.
+
+Ledger sizing comes from the real one: 369 entries / 142 KB = ~385 B/entry,
+growing ~74 entries/day, so a year of use is ~27k entries / ~10 MB.
+"""
+import json
+import os
+import statistics
+import sys
+import threading
+import time
+
+# No sys.path insert into a world-writable /tmp dir: those dirs held no
+# harness.py (the line was already a no-op), but a stale copy left there
+# would silently shadow this suite's own. See harness.py's ISOLATION note.
+import harness
+
+ENTRIES = int(os.environ.get("LEDGER_ENTRIES", "40000"))
+
+mod, _events = harness.load(0.05)
+from gi.repository import GLib  # noqa: E402
+
+
+def build_ledger(path, n):
+    """Synthetic ledger with realistic entry shape (~385 B/line). No real text."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    filler = ("the queue held while the mic was open and the narrator waited "
+              "for its turn to speak ")
+    with open(path, "w", encoding="utf-8") as f:
+        for i in range(n):
+            body = f"synthetic entry {i} " + filler * 3
+            f.write(json.dumps({
+                "kind": "spoken" if i % 2 else "you",
+                "text": body[:340],
+                "ts": "2026-08-17T12:00:00-0700",
+                "voice": "en-US-BrianNeural",
+                "source": "agent-x",
+                "id": 1755400000000 + i,
+            }, ensure_ascii=False) + "\n")
+    return os.path.getsize(path)
+
+
+size = build_ledger(mod.CHRONICLE_PATH, ENTRIES)
+print(f"ledger: {ENTRIES} entries, {size / 1e6:.1f} MB "
+      f"({size / ENTRIES:.0f} B/entry) at {mod.CHRONICLE_PATH}")
+
+svc = harness.make_service(mod)
+handler = mod.DBusHandler(svc)
+
+
+class FakeInvocation:
+    """Stands in for Gio.DBusMethodInvocation."""
+
+    def __init__(self):
+        self.done = threading.Event()
+        self.error = None
+
+    def return_value(self, variant):
+        self.payload = variant
+        self.done.set()
+
+    def return_dbus_error(self, name, msg):
+        self.error = (name, msg)
+        self.done.set()
+
+
+# --- 1. main-loop stall ----------------------------------------------------
+loop = GLib.MainLoop()
+svc._main_loop = loop
+beats = []
+
+
+def heartbeat():
+    beats.append(time.monotonic())
+    return True
+
+
+GLib.timeout_add(20, heartbeat)
+inv = FakeInvocation()
+
+
+def fire():
+    # Exactly how GDBus dispatches an incoming call: on the main loop.
+    handler.handle_method_call(None, None, mod.OBJECT_PATH, mod.INTERFACE_NAME,
+                              "GetChronicle", GLib.Variant("(i)", (12,)), inv)
+    return False
+
+
+def finish():
+    if inv.done.wait(timeout=25):
+        GLib.idle_add(loop.quit)
+    return False
+
+
+GLib.timeout_add(500, fire)
+threading.Thread(target=finish, daemon=True).start()
+GLib.timeout_add(24000, lambda: (loop.quit(), False)[-1])
+loop.run()
+
+gaps = [round((b - a) * 1000, 1) for a, b in zip(beats, beats[1:])]
+stall = max(gaps) if gaps else 0.0
+entries = json.loads(inv.payload.unpack()[0]) if inv.error is None else []
+print(f"1. main-loop stall: worst heartbeat gap {stall:.1f} ms "
+      f"(median {statistics.median(gaps):.1f} ms over {len(gaps)} beats)")
+print(f"   GetChronicle returned {len(entries)} entries, "
+      f"oldest-first={bool(entries) and entries[0]['id'] < entries[-1]['id']}")
+
+# --- 2. scan cost ----------------------------------------------------------
+t = time.monotonic()
+got = mod._chronicle_read(limit=12)
+scan_ms = (time.monotonic() - t) * 1000
+print(f"2. _chronicle_read(limit=12): {scan_ms:.1f} ms for {len(got)} entries")
+
+t = time.monotonic()
+found = mod._chronicle_find(1755400000000 + ENTRIES - 3)
+find_ms = (time.monotonic() - t) * 1000
+print(f"2b. _chronicle_find(recent id): {find_ms:.1f} ms, hit={found is not None}")
+
+# --- 3. append starvation --------------------------------------------------
+blocked = []
+go = threading.Event()
+
+
+def reader():
+    go.set()
+    for _ in range(3):
+        mod._chronicle_read(limit=12)
+
+
+r = threading.Thread(target=reader)
+r.start()
+go.wait()
+time.sleep(0.002)  # let the reader take the lock
+t = time.monotonic()
+mod._chronicle_append("spoken", "a line the speech path needs to record")
+blocked.append((time.monotonic() - t) * 1000)
+r.join()
+print(f"3. append blocked behind a reader: {blocked[0]:.1f} ms")
+
+verdict = stall > 50 or scan_ms > 50 or blocked[0] > 50
+print("\nRESULT:", "SLOW (issue #22 reproduced)" if verdict else "FAST")
+sys.exit(1 if verdict else 0)

--- a/tests/repros/chronicle-perf/verify_archive.py
+++ b/tests/repros/chronicle-perf/verify_archive.py
@@ -1,0 +1,153 @@
+"""Archive rotation verification: no line ever lost, no id ever duplicated.
+
+Forces many rotations with a tiny cap, then checks the promises the
+chronicle-archive branch makes:
+  1. NO LOSS      — union(hot + archive) ids == every id ever appended
+  2. NO DUPES     — a full include_archive read returns each id once
+  3. BOUNDED HOT  — the recent list (no q) never reads the archive
+  4. DEEP FIND    — _chronicle_find reaches an id rotated into the archive
+  5. CLOCK STEP   — ids stay unique/ascending across a backwards clock step,
+                    seeded from the archive even if hot files are cleared
+Run with GS_SVC_PATH pointing at the branch under test.
+"""
+import json
+import os
+import shutil
+import sys
+import time
+
+# Default to the main checkout, not a worktree that no longer exists.
+# Repo-relative by construction: this file lives at
+# tests/repros/<suite>/<file>.py, so four dirnames reach the repo root. #59:
+# the old defaults were absolute paths into ~/Projects/gnome-speaks-wt/<name>/
+# worktrees that no longer existed, so a bare run died with FileNotFoundError
+# instead of testing anything.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+# Scratch lives in the repo's gitignored tmp/, keyed by PID. Never a fixed
+# shared path: two agents running a suite at once used to corrupt each other
+# and it read exactly like a service regression.
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+os.environ.setdefault(
+    "GS_SVC_PATH",
+    SVC_DEFAULT)
+os.environ["GNOME_SPEAKS_CHRONICLE_MAX_BYTES"] = "20000"  # ~50 entries/gen
+
+import harness  # noqa: E402  (sets XDG_STATE_HOME; we point it somewhere fresh)
+
+# Was "/tmp/audit-repro/archive-state" -- the CHRONICLE suite writing into
+# the AUDIT suite's directory, colliding even with one agent running.
+STATE_DIR = os.path.join(harness.SCRATCH, "archive-state")
+shutil.rmtree(STATE_DIR, ignore_errors=True)
+os.environ["XDG_STATE_HOME"] = STATE_DIR
+os.makedirs(STATE_DIR, exist_ok=True)
+
+svc, _events = harness.load()
+
+FAIL = 0
+
+
+def check(name, ok, detail=""):
+    global FAIL
+    print(("  ok   " if ok else "  FAIL ") + name + (f"  ({detail})" if detail else ""))
+    if not ok:
+        FAIL += 1
+
+
+def settle():
+    """Wait out any in-flight background rotation."""
+    deadline = time.time() + 10
+    while svc._chronicle_archiving.is_set() and time.time() < deadline:
+        time.sleep(0.02)
+    assert not svc._chronicle_archiving.is_set(), "rotation never settled"
+
+
+def read_ids(path):
+    ids = []
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                ids.append(json.loads(line)["id"])
+    except FileNotFoundError:
+        pass
+    return ids
+
+
+# -- 1+2: append enough padded entries to force several rotations ----------
+appended = []
+for i in range(300):
+    svc._chronicle_append("you" if i % 3 else "spoken",
+                          f"line {i:04d} " + "x" * 300)
+    if i % 25 == 0:
+        settle()
+settle()
+
+hot_ids = []
+for p in svc._chronicle_files():
+    hot_ids += read_ids(p)
+archive_ids = read_ids(svc._chronicle_archive_path())
+
+all_read = svc._chronicle_read(limit=100000, q="line", include_archive=True)
+union = set(hot_ids) | set(archive_ids)
+
+check("archive exists and holds rotated history", len(archive_ids) > 0,
+      f"{len(archive_ids)} archived, {len(hot_ids)} hot")
+check("no loss: hot+archive covers all 300 appends", len(union) == 300,
+      f"union={len(union)}")
+check("no dupes in full include_archive read",
+      len(all_read) == len({e['id'] for e in all_read}) == 300,
+      f"read {len(all_read)}")
+
+# -- 3: recent list must stay a bounded hot read ----------------------------
+recent = svc._chronicle_read(limit=100000)
+recent_ids = {e["id"] for e in recent}
+check("recent list never reaches the archive",
+      recent_ids.isdisjoint(set(archive_ids) - set(hot_ids)),
+      f"recent={len(recent)}")
+
+# -- 4: find falls through to the archive -----------------------------------
+oldest_id = min(union)
+in_archive_only = oldest_id in set(archive_ids) and oldest_id not in set(hot_ids)
+found = svc._chronicle_find(oldest_id)
+check("oldest id lives only in the archive (test is meaningful)",
+      in_archive_only)
+check("_chronicle_find reaches an archived id",
+      found is not None and found["id"] == oldest_id)
+
+# -- 5: backwards clock step + hot wipe: ids seeded from the archive --------
+real_time = time.time
+try:
+    time.time = lambda: real_time() - 3 * 86400  # 3-day backwards step
+    before = svc._chronicle_last_id
+    svc._chronicle_append("you", "clock step entry")
+    check("backwards clock still mints a fresh ascending id",
+          svc._chronicle_last_id > before)
+finally:
+    time.time = real_time
+
+settle()
+for p in svc._chronicle_files():
+    try:
+        os.unlink(p)
+    except FileNotFoundError:
+        pass
+svc._chronicle_id_seeded = False
+svc._chronicle_last_id = 0
+try:
+    time.time = lambda: real_time() - 3 * 86400
+    svc._chronicle_append("you", "post-wipe entry")
+    top_archive = max(read_ids(svc._chronicle_archive_path()))
+    check("id seeding falls through to the archive after a hot wipe",
+          svc._chronicle_last_id > top_archive,
+          f"minted {svc._chronicle_last_id} > archive max {top_archive}")
+finally:
+    time.time = real_time
+
+print()
+print("RESULT: " + ("ARCHIVE CONTRACT HOLDS" if FAIL == 0 else f"{FAIL} FAILURES"))
+sys.exit(1 if FAIL else 0)

--- a/tests/repros/chronicle-perf/verify_chronicle_contract.py
+++ b/tests/repros/chronicle-perf/verify_chronicle_contract.py
@@ -1,0 +1,219 @@
+"""Contract tests for the tail-read + rotation rewrite (issue #22).
+
+The reverse reader is the risky part, so it is checked against an oracle: the
+ORIGINAL full-scan algorithm, run over the same file. Every case must agree
+exactly. Block size is forced small so every straddle boundary is exercised.
+"""
+import json
+import os
+import random
+import shutil
+import sys
+import threading
+import time
+
+# No sys.path insert into a world-writable /tmp dir: those dirs held no
+# harness.py (the line was already a no-op), but a stale copy left there
+# would silently shadow this suite's own. See harness.py's ISOLATION note.
+import harness
+
+mod, _events = harness.load(0.05)
+DIR = os.path.join(harness.SCRATCH, "contract")
+shutil.rmtree(DIR, ignore_errors=True)
+os.makedirs(DIR, exist_ok=True)
+mod.CHRONICLE_PATH = os.path.join(DIR, "chronicle.jsonl")
+fails = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {'ok  ' if ok else 'FAIL'} {name}{'' if ok else '  <- ' + detail}")
+    if not ok:
+        fails.append(name)
+
+
+def oracle_read(path, limit=20, q=None, kind=None):
+    """The pre-#22 implementation, verbatim in spirit: forward whole-file scan."""
+    from collections import deque
+    entries = deque(maxlen=max(1, min(int(limit or 20), 500)))
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if kind and entry.get("kind") != kind:
+                    continue
+                if q and q.lower() not in entry.get("text", "").lower():
+                    continue
+                entries.append(entry)
+    except FileNotFoundError:
+        pass
+    return list(entries)
+
+
+def write_lines(path, lines):
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("".join(lines))
+
+
+def entry_line(i, kind="you", text=None, extra=None):
+    e = {"kind": kind, "text": text if text is not None else f"line {i} hello",
+         "ts": "2026-08-17T12:00:00-0700", "id": 1000 + i}
+    if extra:
+        e.update(extra)
+    return json.dumps(e, ensure_ascii=False) + "\n"
+
+
+# ---------------------------------------------------------------- equivalence
+P = mod.CHRONICLE_PATH
+cases = {
+    "empty file": [],
+    "one line": [entry_line(0)],
+    "no trailing newline": [entry_line(0), entry_line(1).rstrip("\n")],
+    "blank lines interleaved": [entry_line(0), "\n", entry_line(1), "\n"],
+    "invalid json line": [entry_line(0), "{not json\n", entry_line(1)],
+    "unicode": [entry_line(0, text="ünïcødé — 漢字 🜛 boundary"),
+                entry_line(1, text="ünïcødé — 漢字 🜛 boundary")],
+    "one huge entry (200 KB)": [entry_line(0, text="X" * 200000), entry_line(1)],
+    "40 lines": [entry_line(i, kind=("spoken" if i % 3 else "you"),
+                            text=f"line {i} " + "pad " * (i % 7))
+                 for i in range(40)],
+}
+for name, lines in cases.items():
+    write_lines(P, lines)
+    for block in (1, 7, 64, 4096):
+        mod._CHRONICLE_BLOCK = block
+        for limit, q, kind in [(20, None, None), (1, None, None),
+                               (500, None, None), (5, "line", None),
+                               (20, None, "spoken"), (20, "PAD", None),
+                               (20, "nomatch-zzz", None), (3, None, "you")]:
+            got = mod._chronicle_read(limit=limit, q=q, kind=kind)
+            want = oracle_read(P, limit=limit, q=q, kind=kind)
+            if got != want:
+                check(f"equivalence [{name}] block={block} "
+                      f"limit={limit} q={q} kind={kind}",
+                      False, f"got {len(got)} want {len(want)}")
+                break
+        else:
+            continue
+        break
+    else:
+        check(f"equivalence [{name}] (4 block sizes x 8 queries)", True)
+mod._CHRONICLE_BLOCK = 65536
+
+# missing file must be empty, not an exception
+os.remove(P)
+check("missing file -> []", mod._chronicle_read(limit=5) == [])
+check("missing file -> find None", mod._chronicle_find(1234) is None)
+
+# ------------------------------------------------------------------- find
+write_lines(P, [entry_line(i) for i in range(30)])
+check("find first entry", (mod._chronicle_find(1000) or {}).get("text") == "line 0 hello")
+check("find last entry", (mod._chronicle_find(1029) or {}).get("text") == "line 29 hello")
+check("find absent id", mod._chronicle_find(999999) is None)
+check("find with string id coerces", (mod._chronicle_find("1005") or {}).get("id") == 1005)
+check("find with junk id -> None", mod._chronicle_find("abc") is None)
+check("find with None -> None", mod._chronicle_find(None) is None)
+
+# ---------------------------------------------------------------- rotation
+shutil.rmtree(DIR, ignore_errors=True)
+os.makedirs(DIR, exist_ok=True)
+mod._CHRONICLE_MAX_BYTES = 8192
+mod._chronicle_last_id = 0
+mod._chronicle_id_seeded = False
+mod.CONFIG["chronicle"] = True
+ids = []
+for i in range(200):
+    mod._chronicle_append("spoken", f"rotating entry {i} " + "pad " * 20,
+                          voice="en-US-BrianNeural", source="test")
+# Rotation runs on a background thread now (perf/chronicle-archive):
+# wait for it to settle, and the just-rotated active file may not exist
+# until the next append recreates it.
+if hasattr(mod, "_chronicle_archiving"):
+    _deadline = time.time() + 10
+    while mod._chronicle_archiving.is_set() and time.time() < _deadline:
+        time.sleep(0.02)
+rotated = P + ".1"
+check("rotation happened", os.path.exists(rotated))
+_active = os.path.getsize(P) if os.path.exists(P) else 0
+check("active file under cap after rotation",
+      _active < mod._CHRONICLE_MAX_BYTES * 2, f"{_active} bytes")
+spanning = mod._chronicle_read(limit=200)
+# A fully-rotated active file doesn't exist until the next append: 0 lines.
+_active_lines = len(list(open(P))) if os.path.exists(P) else 0
+check("read spans both generations",
+      len(spanning) > _active_lines,
+      f"read {len(spanning)}, active file has {_active_lines}")
+all_ids = [e["id"] for e in spanning]
+check("ids ascending across rotation", all_ids == sorted(all_ids))
+check("no duplicate ids", len(set(all_ids)) == len(all_ids))
+oldest_in_rotated = json.loads(open(rotated).readline())
+check("respeak can still find an entry in the rotated file",
+      (mod._chronicle_find(oldest_in_rotated["id"]) or {}).get("id")
+      == oldest_in_rotated["id"])
+check("read is oldest-first", spanning[0]["id"] < spanning[-1]["id"])
+
+# -------------------------------------------------- id seeding across restart
+newest_before = mod._chronicle_read(limit=1)[0]["id"]
+mod._chronicle_last_id = 0            # simulate a fresh process
+mod._chronicle_id_seeded = False
+real_time = time.time
+try:
+    time.time = lambda: real_time() - 86400 * 3   # clock stepped back 3 days
+    mod._chronicle_append("you", "after a backwards clock step")
+finally:
+    time.time = real_time
+after = mod._chronicle_read(limit=1)[0]
+check("id still ascends after a backwards clock step",
+      after["id"] > newest_before, f"{after['id']} vs {newest_before}")
+check("no duplicate id minted", mod._chronicle_find(newest_before)["id"] == newest_before)
+
+# ------------------------------------------------------------- concurrency
+shutil.rmtree(DIR, ignore_errors=True)
+os.makedirs(DIR, exist_ok=True)
+mod._chronicle_last_id = 0
+mod._chronicle_id_seeded = False
+mod._CHRONICLE_MAX_BYTES = 16384
+errors = []
+stop = threading.Event()
+
+
+def appender(n):
+    try:
+        for i in range(120):
+            mod._chronicle_append("spoken", f"t{n} entry {i} " + "pad " * 10)
+    except Exception as exc:
+        errors.append(f"append: {exc!r}")
+
+
+def reader():
+    try:
+        while not stop.is_set():
+            mod._chronicle_read(limit=12)
+            mod._chronicle_read(limit=5, kind="spoken")
+            mod._chronicle_find(random.randint(1, 10**13))
+    except Exception as exc:
+        errors.append(f"read: {exc!r}")
+
+
+ts = [threading.Thread(target=appender, args=(n,)) for n in range(4)]
+rs = [threading.Thread(target=reader, daemon=True) for _ in range(3)]
+for t in rs + ts:
+    t.start()
+for t in ts:
+    t.join()
+stop.set()
+time.sleep(0.3)
+check("no exceptions under 4 appenders x 3 readers + rotation", not errors,
+      "; ".join(errors[:3]))
+lines = []
+for p in mod._chronicle_files():
+    if os.path.exists(p):
+        lines += [json.loads(x) for x in open(p) if x.strip()]
+cids = sorted(e["id"] for e in lines)
+check("no duplicate ids under concurrency", len(set(cids)) == len(cids))
+check("every line is valid json", len(lines) > 0)
+
+print("\nRESULT:", "CONTRACT HOLDS" if not fails else f"FAILURES: {fails}")
+sys.exit(1 if fails else 0)

--- a/tests/repros/chronicle-perf/verify_endpoints.py
+++ b/tests/repros/chronicle-perf/verify_endpoints.py
@@ -1,0 +1,237 @@
+"""End-to-end: the two callers that ride along with the tail-read.
+
+  - GET /chronicle over real HTTP (bound on port 0, an ephemeral port —
+    never 7710, the live service owns that)
+  - Respeak through DBusHandler.handle_method_call, which now goes to the
+    thread pool: the reply must still arrive with the right value, and an id
+    that has already rotated into chronicle.jsonl.1 must still be found and
+    enqueued for playback.
+"""
+import http.client
+import http.server
+import json
+import os
+import shutil
+import sys
+import threading
+import time
+
+# No sys.path insert into a world-writable /tmp dir: those dirs held no
+# harness.py (the line was already a no-op), but a stale copy left there
+# would silently shadow this suite's own. See harness.py's ISOLATION note.
+import harness
+
+mod, events = harness.load(0.05)
+from gi.repository import GLib  # noqa: E402
+
+DIR = os.path.join(harness.SCRATCH, "endpoints")
+shutil.rmtree(DIR, ignore_errors=True)
+os.makedirs(DIR, exist_ok=True)
+mod.CHRONICLE_PATH = os.path.join(DIR, "chronicle.jsonl")
+mod._CHRONICLE_MAX_BYTES = 8192
+mod._chronicle_last_id = 0
+mod._chronicle_id_seeded = False
+fails = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {'ok  ' if ok else 'FAIL'} {name}{'' if ok else '  <- ' + detail}")
+    if not ok:
+        fails.append(name)
+
+
+svc = harness.make_service(mod)
+for i in range(120):                      # forces at least one rotation
+    mod._chronicle_append("spoken" if i % 2 else "you",
+                          f"endpoint entry {i} " + "pad " * 20,
+                          voice="en-US-BrianNeural", source="test")
+
+
+def settle(timeout=10.0):
+    """Wait out the background chronicle-rotate thread.
+
+    _chronicle_rotate_locked() is DETECTION ONLY: it sets _chronicle_archiving
+    and hands the archive+rename to a daemon thread (perf/chronicle-archive,
+    PR #27). Asserting on the rotated file straight after the append loop
+    races that thread, and the rename moves chronicle.jsonl aside without
+    recreating it -- which is where the FileNotFoundError at the active-file
+    read came from. Both were flaky on main long before anything read this
+    file (measured: 1/12 green). Wait for the documented boundary instead.
+    """
+    deadline = time.monotonic() + timeout
+    while mod._chronicle_archiving.is_set() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not mod._chronicle_archiving.is_set(), "rotation did not finish"
+
+
+settle()
+# Rotation renames the active generation away and does NOT recreate it -- the
+# next append does. Restore a non-empty active generation so the "spans BOTH
+# generations" checks below test what they mean to test.
+for i in range(120, 130):
+    mod._chronicle_append("spoken" if i % 2 else "you",
+                          f"endpoint entry {i} " + "pad " * 20,
+                          voice="en-US-BrianNeural", source="test")
+settle()
+
+TOTAL_APPENDED = 130   # 120 in the setup loop + 10 restoring the active file
+
+rotated = mod.CHRONICLE_PATH + ".1"
+check("rotated during setup", os.path.exists(rotated))
+
+# ------------------------------------------------------------------ HTTP
+mod.SpeechHTTPHandler.service = svc
+srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), mod.SpeechHTTPHandler)
+port = srv.server_address[1]
+assert port != 7710
+threading.Thread(target=srv.serve_forever, daemon=True).start()
+
+
+def get(path):
+    c = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+    c.request("GET", path)
+    r = c.getresponse()
+    body = json.loads(r.read())
+    c.close()
+    return r.status, body
+
+
+def post(path, payload):
+    c = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+    body = json.dumps(payload).encode()
+    c.request("POST", path, body=body,
+              headers={"Content-Type": "application/json"})
+    r = c.getresponse()
+    out = json.loads(r.read())
+    c.close()
+    return r.status, out
+
+
+st, body = get("/chronicle?limit=12")
+check("GET /chronicle 200", st == 200, str(st))
+check("GET /chronicle returns 12", body.get("count") == 12, str(body.get("count")))
+ids = [e["id"] for e in body["entries"]]
+check("GET /chronicle oldest-first", ids == sorted(ids))
+check("GET /chronicle reports enabled", body.get("enabled") is True)
+
+st, body = get("/chronicle?limit=5&kind=you")
+check("GET /chronicle?kind=you filters",
+      st == 200 and all(e["kind"] == "you" for e in body["entries"])
+      and body["count"] == 5, json.dumps(body)[:120])
+
+def _nlines(path):
+    """Line count, treating an absent generation as empty.
+
+    Rotation renames a generation away; whether a given file exists at this
+    instant depends on how many async rotations fired, which is not something
+    this test gets to pin down.
+    """
+    try:
+        with open(path) as fh:
+            return len([1 for x in fh if x.strip()])
+    except FileNotFoundError:
+        return 0
+
+
+active_lines = _nlines(mod.CHRONICLE_PATH)
+rotated_lines = _nlines(rotated)
+st, body = get("/chronicle?limit=500&q=endpoint%20entry")
+check("GET /chronicle?q= draws matches from BOTH generations",
+      st == 200 and body["count"] > active_lines,
+      f"count={body.get('count')} active={active_lines} rotated={rotated_lines}")
+# The real contract of perf/chronicle-archive: rotation LOSES NOTHING. Every
+# line ever appended is still reachable through a q search, whichever
+# generation (or the cold archive) it has since drifted into. The old form of
+# this check compared against active+rotated only, which silently assumed
+# exactly one rotation had fired -- it is a race, not an invariant, and it was
+# the residual flake here after the rotate-thread wait went in.
+check("GET /chronicle?q= reaches every retained line",
+      body["count"] == TOTAL_APPENDED,
+      f"count={body.get('count')} vs {TOTAL_APPENDED} appended "
+      f"(active={active_lines} rotated={rotated_lines})")
+# The cold archive (perf/chronicle-archive) flips rotation's old cost:
+# a q search reaches the archive, so rotated-out entries are FOUND and the
+# response says the deep walk happened.
+st, body = get("/chronicle?limit=500&q=endpoint%20entry%203%20")
+check("GET /chronicle?q= reaches rotated-out entries via the archive",
+      st == 200 and body["count"] >= 1 and body.get("archive") is True,
+      json.dumps(body)[:120])
+
+st, body = get("/chronicle?kind=bogus")
+check("GET /chronicle rejects a bad kind", st == 400, str(st))
+
+# a respeak of an id living in the ROTATED generation
+oldest = json.loads(open(rotated).readline())
+before = svc._tts_queue.qsize()
+st, body = post("/respeak", {"id": oldest["id"]})
+check("POST /respeak finds a rotated id", st == 200
+      and body.get("respeaking", {}).get("id") == oldest["id"],
+      f"{st} {json.dumps(body)[:120]}")
+check("POST /respeak enqueued playback", svc._tts_queue.qsize() > before
+      or svc._queue_current is not None)
+st, body = post("/respeak", {"id": 1})
+check("POST /respeak unknown id -> 404", st == 404, str(st))
+srv.shutdown()
+
+# ------------------------------------------------------- D-Bus (async now)
+handler = mod.DBusHandler(svc)
+loop = GLib.MainLoop()
+svc._main_loop = loop
+
+
+class FakeInvocation:
+    def __init__(self):
+        self.done = threading.Event()
+        self.payload = None
+        self.error = None
+
+    def return_value(self, variant):
+        self.payload = variant
+        self.done.set()
+
+    def return_dbus_error(self, name, msg):
+        self.error = (name, msg)
+        self.done.set()
+
+
+def dispatch(method, variant):
+    inv = FakeInvocation()
+    GLib.idle_add(lambda: (handler.handle_method_call(
+        None, None, mod.OBJECT_PATH, mod.INTERFACE_NAME, method, variant, inv),
+        False)[-1])
+    t = threading.Thread(target=lambda: (inv.done.wait(15),
+                                         GLib.idle_add(loop.quit)), daemon=True)
+    t.start()
+    GLib.timeout_add(16000, lambda: (loop.quit(), False)[-1])
+    loop.run()
+    return inv
+
+
+inv = dispatch("GetChronicle", GLib.Variant("(i)", (12,)))
+entries = json.loads(inv.payload.unpack()[0]) if inv.payload else []
+check("D-Bus GetChronicle still replies", inv.error is None and len(entries) == 12,
+      str(inv.error or len(entries)))
+check("D-Bus GetChronicle oldest-first",
+      [e["id"] for e in entries] == sorted(e["id"] for e in entries))
+
+inv = dispatch("GetChronicle", GLib.Variant("(i)", (0,)))   # 0 -> default 20
+entries = json.loads(inv.payload.unpack()[0]) if inv.payload else []
+check("D-Bus GetChronicle(0) defaults to 20", len(entries) == 20, str(len(entries)))
+
+inv = dispatch("Respeak", GLib.Variant("(x)", (oldest["id"],)))
+check("D-Bus Respeak(rotated id) -> True",
+      inv.payload is not None and inv.payload.unpack()[0] is True,
+      str(inv.error or (inv.payload and inv.payload.unpack())))
+
+inv = dispatch("Respeak", GLib.Variant("(x)", (1,)))
+check("D-Bus Respeak(unknown) -> False",
+      inv.payload is not None and inv.payload.unpack()[0] is False,
+      str(inv.error))
+
+inv = dispatch("Respeak", GLib.Variant("(x)", (0,)))   # 0 -> last spoken line
+check("D-Bus Respeak(0) replays the last spoken line",
+      inv.payload is not None and inv.payload.unpack()[0] is True,
+      str(inv.error))
+
+print("\nRESULT:", "ENDPOINTS OK" if not fails else f"FAILURES: {fails}")
+sys.exit(1 if fails else 0)

--- a/tests/repros/dead-recorder/fakes.py
+++ b/tests/repros/dead-recorder/fakes.py
@@ -1,0 +1,103 @@
+"""Shared fakes for the dead-recorder repros (issues #57 / #48).
+
+A recorder that dies is modelled with the SAME shape the real one has:
+pw-record keeps stdout open until it exits, so EOF and a non-None poll()
+arrive together.  poll() reports alive until the first read, which is the
+mic yanked while the session is live (a stale prewarm is a different case,
+covered by repro_h).
+"""
+import time
+
+
+class DeadStdout:
+    def __init__(self, proc):
+        self._proc = proc
+
+    def read(self, n):
+        self._proc.exited = True     # pw-record exits right after its EOF
+        return b""
+
+
+class DeadProc:
+    """pw-record whose device vanished mid-session: stdout EOF, then exit."""
+
+    def __init__(self, exited=False):
+        self.exited = exited
+        self.returncode = 1 if exited else None
+        self.stdout = DeadStdout(self)
+
+    def poll(self):
+        self.returncode = 1 if self.exited else None
+        return self.returncode
+
+    def terminate(self):
+        pass
+
+    def kill(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 1
+
+
+class LiveStdout:
+    """Silence at 16 kHz s16: enough for the sender to never hit EOF."""
+
+    def read(self, n):
+        time.sleep(0.01)
+        return b"\x00" * n
+
+
+class LiveProc:
+    """A recorder that is perfectly healthy — the negative control."""
+
+    def __init__(self):
+        self.returncode = None
+        self.stdout = LiveStdout()
+
+    def poll(self):
+        return None
+
+    def terminate(self):
+        pass
+
+    def kill(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 0
+
+
+class ScriptedWS:
+    """WebSocket that replays a script of messages, then times out forever.
+
+    delay models Azure answering AFTER the audio stream ends — which is the
+    whole ordering problem: the recorder is already gone by the time the
+    verdict arrives.
+    """
+
+    def __init__(self, timeout_exc, script=(), delay=0.15):
+        self._exc = timeout_exc
+        self._script = list(script)
+        self._delay = delay
+
+    def settimeout(self, t):
+        pass
+
+    def send(self, payload, opcode=None):
+        pass
+
+    def recv(self):
+        if self._script:
+            time.sleep(self._delay)
+            return self._script.pop(0)
+        time.sleep(0.05)
+        raise self._exc()
+
+
+class LoopingWS(ScriptedWS):
+    """Answers the same message forever — one utterance per cycle, quickly."""
+
+    def recv(self):
+        time.sleep(self._delay)
+        return self._script[0]

--- a/tests/repros/dead-recorder/harness.py
+++ b/tests/repros/dead-recorder/harness.py
@@ -1,0 +1,403 @@
+"""Shared harness for the cancel-token repros (issue #21).
+
+Same discipline as ../service-audit/harness.py: import the real
+gnome-speaks-service.py in-process with every dangerous seam stubbed.  No
+audio, no network, no mic, no D-Bus, no port 7710, no ~/.config writes, no
+service restart.
+
+Differences from the audit harness:
+  * scratch lives in the repo's gitignored tmp/, keyed by PID (never /tmp,
+    which is a RAM-backed tmpfs on this workstation)
+  * get_injector() is replaced by a RecordingInjector, so "did a transcript
+    reach the cursor?" is a fact we can assert on instead of a stub no-op
+  * the fake TTS honours the *global* wire (state._cancel_event) exactly like
+    speech_tts.tts does -- the whole point is that the wire is shared
+
+Run any repro with:
+    GS_SVC_PATH=<path to a gnome-speaks-service.py> python3 <script>
+exit 0 = clean, exit 1 = bug present.
+"""
+import atexit
+import contextlib
+import glob
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import time
+
+# ---------------------------------------------------------------------------
+# ISOLATION -- read this before changing any path or CONFIG line below.
+#
+# Two external inputs used to decide these repros' verdicts, and both produced
+# results that read as product regressions:
+#
+# 1. JP's LIVE ~/.config/speech-to-cli/config.json.  state.load_config() reads
+#    it at import, so CONFIG started as ~47 live desktop keys (terminal_mode
+#    and wake_word are True on this machine right now).  Worse,
+#    _reload_config_flags() RE-READS that file mid-run and overwrites CONFIG
+#    for every key in _SYNC_FLAGS, so a pin applied after load() is silently
+#    clobbered unless the repro also stubs that method; and _save_config_flag()
+#    WRITES it.  _isolate_config() below cuts all three wires.
+#
+# 2. Another agent running these same suites.  Every scratch path used to be a
+#    fixed absolute directory, so two processes shared one chronicle file.
+#    MEASURED: two concurrent runs of verify_chronicle_contract.py both fail
+#    with 'equivalence [...]' mismatches; each alone passes.  Hence SCRATCH is
+#    keyed by PID and removed at exit.
+#
+# CONCURRENCY, precisely (an earlier note here overstated this):
+#   * verify_ibus_injector.py rmtree()s a FIXED runtime dir at import, so two
+#     concurrent runs OF IT destroy each other's breadcrumb -- that is the
+#     mechanism behind the one '[9] GetGlobalEngine raises' flake observed on
+#     2026-09-06, not an interaction with verify_wake_gate.py.  Now per-PID.
+#   * UNVERIFIED, flagged: the in-repo verify_wake_gate.py imports
+#     ibus_injector WITHOUT redirecting XDG_RUNTIME_DIR, so anything in it that
+#     reaches acquire() would write JP's REAL prior-engine breadcrumb -- which
+#     is also what verify_ibus_injector's check [12] asserts must not exist.
+# ---------------------------------------------------------------------------
+
+# ENV CONTRACT (unified 2026-09-06): GS_SVC_PATH is the ONE input -- the
+# service.py file under test. The worktree dir is DERIVED from its dirname,
+# so sibling modules (spellbook, injector, ibus_injector) always come from
+# the same tree as the service. GS_WT overrides the dir only if you really
+# mean to mix trees. Defaults to the main checkout; the old defaults pointed
+# at ~/Projects/gnome-speaks-wt/<name>/ worktrees that no longer exist, so a
+# bare run died with FileNotFoundError instead of testing anything.
+# Repo-relative by construction: this file lives at
+# tests/repros/<suite>/<file>.py, so four dirnames reach the repo root. #59:
+# the old defaults were absolute paths into ~/Projects/gnome-speaks-wt/<name>/
+# worktrees that no longer existed, so a bare run died with FileNotFoundError
+# instead of testing anything.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+# Scratch lives in the repo's gitignored tmp/, keyed by PID. Never a fixed
+# shared path: two agents running a suite at once used to corrupt each other
+# and it read exactly like a service regression.
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+SVC_PATH = os.environ.get("GS_SVC_PATH", SVC_DEFAULT)
+WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
+
+# get(), never setdefault(): setdefault EXPORTS the path, so any child python
+# this suite spawns would inherit the PARENT's dir and its atexit would delete
+# the still-running parent's scratch out from under it.
+_PINNED = os.environ.get("GS_REPRO_SCRATCH")
+SCRATCH = _PINNED or os.path.join(SCRATCH_ROOT, f"deadrec-repros-{os.getpid()}")
+STATE_DIR = os.path.join(SCRATCH, "state")
+os.environ["XDG_STATE_HOME"] = STATE_DIR        # BEFORE the module computes
+                                                # CHRONICLE_PATH from it
+if _PINNED is None:
+    # Only ever reset and remove a directory THIS process created. A dir the
+    # caller pinned belongs to the caller.
+    shutil.rmtree(SCRATCH, ignore_errors=True)  # a verdict must never depend
+    atexit.register(shutil.rmtree, SCRATCH, True)   # on who ran here before
+os.makedirs(STATE_DIR, exist_ok=True)
+
+
+def _sweep_stale_scratch():
+    """Remove scratch dirs whose owning process is gone.
+
+    atexit does NOT run when `timeout` SIGTERMs a run, which is exactly how
+    these are usually killed -- so the PID-keyed dirs accumulate. Only a dir
+    whose PID no longer exists is touched, so a live sibling run is never
+    swept out from under itself.
+    """
+    import re
+    for d in glob.glob(os.path.join(os.path.dirname(SCRATCH), "*-repros-*")):
+        m = re.search(r"-repros-(\d+)$", d)
+        if not m or d == SCRATCH:
+            continue
+        try:
+            os.kill(int(m.group(1)), 0)      # signal 0: liveness probe only
+        except ProcessLookupError:
+            shutil.rmtree(d, ignore_errors=True)
+        except PermissionError:
+            pass                              # someone else's live process
+        except Exception:
+            pass
+
+
+_sweep_stale_scratch()
+os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+
+
+class RecordingInjector:
+    """Stands in for the ydotool/IBus backends; records instead of typing."""
+
+    name = "recording"
+
+    def __init__(self):
+        self.commits = []       # [(text, monotonic)]
+        self.pastes = []
+        self.typed = []
+        self.preedits = []
+        self.backspaces = 0
+        self.enters = 0
+
+    # -- lifecycle (no-ops) ------------------------------------------------
+    def prepare(self):
+        return True
+
+    def acquire(self):
+        return True
+
+    def end(self):
+        return True
+
+    def cancel(self):
+        return True
+
+    def recover(self):
+        return True
+
+    def available(self):
+        return True
+
+    def supports_preedit(self):
+        return False
+
+    # -- text paths --------------------------------------------------------
+    def commit(self, text):
+        self.commits.append((text, time.monotonic()))
+        return True
+
+    def finalize(self, text):
+        # The keep-live-text path (#45/#64): a key-event backend already typed
+        # it, a pre-edit backend commits here. Either way the text stuck, so
+        # the fake records it as delivered.
+        self.commits.append((text, time.monotonic()))
+        return True
+
+    def purpose_known(self):
+        return False
+
+    def type_text(self, text):
+        self.typed.append((text, time.monotonic()))
+        return True
+
+    def paste(self, text):
+        self.pastes.append((text, time.monotonic()))
+        return True
+
+    def set_preedit(self, text):
+        self.preedits.append((text, time.monotonic()))
+        return True
+
+    def replace_text(self, old_text, new_text):
+        self.commits.append((new_text, time.monotonic()))
+        return True
+
+    def send_backspaces(self, count):
+        self.backspaces += count
+        return True
+
+    def press_enter(self):
+        self.enters += 1
+        return True
+
+    # -- assertions --------------------------------------------------------
+    def all_text(self):
+        """Every way a transcript can reach the cursor, oldest first."""
+        return sorted(self.commits + self.pastes + self.typed, key=lambda p: p[1])
+
+
+
+# Every key below is pinned because a repro's verdict depends on it. Nothing
+# here may be read from JP's live config -- see the ISOLATION note above.
+CONFIG_PINS = {
+    "key": "test-key",              # speak() bails out early without one
+    "wake_word": False,             # the wake watcher must never open the mic
+    "wake_word_model": "",
+    "wake_word_secure_gate": False, # #55: gates live_typing for the session
+    "continuous_dictation": False,  # is_loop -- picks the whole cycle shape
+    "conversation_mode": False,
+    "dictation_mode": True,
+    "terminal_mode": False,         # use_lexical: rewrites text before asserts
+    "skip_final_paste": False,      # picks finalize() vs paste() in step 9
+    "injection_method": "ydotool",
+    "read_notifications": False,
+    "llm_thinking": False,
+    "spiel_provider": False,        # a second D-Bus name on the session bus
+    "debug": False,                 # else every run appends to /tmp/speech-debug.log
+    "live_subtitles": False,
+    "phrase_list": [],
+    "wyoming_host": "",             # no LAN fallback from a test
+    "chronicle": False,
+}
+
+
+
+REAL_STATE = os.path.join(os.path.expanduser("~/.local/state"), "gnome-speaks")
+
+
+
+@contextlib.contextmanager
+def config_scope(mod, **overrides):
+    """Run ONE scenario with its own CONFIG flags, restored afterwards.
+
+    Every load() in a process hands back the SAME dict -- `from state import
+    CONFIG` binds one shared object across the service, audio, stt, speech_tts
+    and wyoming -- so two scenarios in one process silently clobber each
+    other's flags, and the second one's verdict describes the first one's
+    configuration. Snapshot/restore rather than forking, so the repro stays
+    debuggable in one process:
+
+        with harness.config_scope(mod, continuous_dictation=True):
+            ...                      # loop-mode scenario
+        # flags are back to the pinned baseline here
+    
+
+    Three traps a scenario can hit that produce a GREEN run while measuring the
+    WRONG code path -- all three found by lucid-pin-lifecycle, and all three
+    cost an hour each to rediscover:
+
+    1. `_reload_config_flags()` restores conversation_mode=False at
+       start_listening(), so a conversation-mode scenario silently takes the
+       DICTATION path (send_backspaces + paste), the reply path never runs, and
+       the repro still prints a paste and looks like it passed. The CONFIG_PATH
+       redirect in _isolate_config() closes this -- the reload re-reads OUR
+       file and re-applies OUR pins -- but only for flags that are IN
+       CONFIG_PINS. Put a scenario's flags there or in config_scope(), never in
+       a bare CONFIG[...] assignment after load().
+    2. In SINGLE-SHOT, turn_end sets _stop_event and
+       _stream_conversation_worker aborts on it before stream_chat is ever
+       called. Any reply-path scenario needs loop mode, and should assert
+       stream_chat was actually invoked so it cannot pass while testing
+       something else.
+    3. Production calls _conversation_worker SYNCHRONOUSLY from inside
+       _streaming_stt_cycle, so the cycle's `finally` -- and its injector
+       release -- runs after the reply. A scenario that starts the worker on
+       its OWN thread has no such release and will report a stranded backend
+       that production does not have.
+    """
+    saved = dict(mod.CONFIG)
+    mod.CONFIG.update(overrides)
+    try:
+        yield mod.CONFIG
+    finally:
+        mod.CONFIG.clear()
+        mod.CONFIG.update(saved)
+
+
+def assert_isolated(mod):
+    """Prove the module under test cannot reach JP's live state, BEFORE any
+    scenario runs.
+
+    CHRONICLE_PATH is computed at MODULE IMPORT from $XDG_STATE_HOME, so this
+    only holds if the env var was set before exec_module -- which is easy to
+    break by moving an import. The chronicle archive and the rotated
+    generations are derived from CHRONICLE_PATH at call time, so pinning it
+    pins them too. Raises rather than warns: a repro that has quietly attached
+    itself to the real ledger must not be allowed to report a verdict.
+    """
+    root = os.path.realpath(SCRATCH)
+    checks = {
+        "CHRONICLE_PATH": getattr(mod, "CHRONICLE_PATH", None),
+        "CONFIG_PATH": getattr(mod, "CONFIG_PATH", None),
+        "XDG_STATE_HOME": os.environ.get("XDG_STATE_HOME"),
+    }
+    for name, value in checks.items():
+        if value is None:
+            raise AssertionError(f"{name} is unset -- cannot prove isolation")
+        real = os.path.realpath(value)
+        if not (real == root or real.startswith(root + os.sep)):
+            raise AssertionError(
+                f"{name}={value!r} resolves OUTSIDE the isolated scratch "
+                f"{SCRATCH!r} -- refusing to run")
+        if os.path.realpath(REAL_STATE) in (real, os.path.dirname(real)):
+            raise AssertionError(f"{name} points at JP's live state dir")
+    return True
+
+
+def _isolate_config(mod):
+    """Rebuild CONFIG from the service's OWN defaults plus CONFIG_PINS.
+
+    CONFIG is mutated IN PLACE: `from state import CONFIG` means audio, stt,
+    speech_tts and wyoming all hold the same dict object, so rebinding
+    mod.CONFIG would isolate the service module and miss every other one.
+    CONFIG_PATH is repointed at a file holding exactly the same values, so
+    _reload_config_flags() re-reading it is a no-op and _save_config_flag()
+    can never touch JP's real file.
+    """
+    real_defaults = mod.state.DEFAULTS_PATH
+    try:
+        mod.state.DEFAULTS_PATH = os.path.join(SCRATCH, "absent-config.json")
+        baseline = mod.state.load_config()
+    finally:
+        mod.state.DEFAULTS_PATH = real_defaults
+    baseline.update(CONFIG_PINS)
+    path = os.path.join(SCRATCH, "config.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(baseline, f)
+    mod.CONFIG_PATH = path
+    mod.CONFIG.clear()
+    mod.CONFIG.update(baseline)
+    return baseline
+
+
+def load(fake_tts_seconds=1.0):
+    """Import the module under test with the dangerous seams neutralized."""
+    sys.path.insert(0, os.path.dirname(SVC_PATH))  # sibling spellbook.py etc.
+    spec = importlib.util.spec_from_file_location("gsvc_under_test", SVC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["gsvc_under_test"] = mod
+    spec.loader.exec_module(mod)  # main() is __main__-guarded; nothing starts
+
+    _isolate_config(mod)   # BEFORE anything reads CONFIG
+    assert_isolated(mod)   # and prove it, before any scenario
+
+    # Pin the delivery path: this file is loaded from JP's real config.json,
+    # and skip_final_paste flips step 9 to finalize()-only. A repro that reads
+    # the live desktop's config is not a repro.
+    mod._schedule_warmup = lambda *a, **k: None
+    mod._refresh_audio_detection = lambda *a, **k: None
+    mod._prewarm_recorder = lambda *a, **k: None
+    mod.clipboard_write = lambda *a, **k: True
+
+    injector = RecordingInjector()
+    mod.get_injector = lambda: injector
+
+    events = []          # (kind, tag, monotonic)
+    t0 = time.monotonic()
+
+    def fake_tts(text, **kw):
+        tag = text.split()[0]
+        events.append(("start", tag, time.monotonic() - t0))
+        deadline = time.monotonic() + fake_tts_seconds
+        while time.monotonic() < deadline:
+            if mod.state._cancel_event.is_set():
+                events.append(("cancel", tag, time.monotonic() - t0))
+                return {"spoken": False, "cancelled": True}
+            time.sleep(0.01)
+        events.append(("end", tag, time.monotonic() - t0))
+        return {"spoken": True}
+
+    mod.speech_tts.tts = fake_tts
+    return mod, events, injector
+
+
+def make_service(mod):
+    svc = mod.GnomeSpeaksService()
+    svc._audio_detected = True
+    svc.play_sound = lambda *a, **k: True
+    return svc
+
+
+def outcome_of(svc, item_id):
+    """Terminal outcome recorded for a queue item id, or None."""
+    for rec in list(svc._queue_recent):
+        if rec.get("id") == item_id:
+            return rec.get("outcome")
+    return None
+
+
+def wait_for(pred, timeout=10.0, interval=0.01):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return True
+        time.sleep(interval)
+    return False

--- a/tests/repros/dead-recorder/repro_e_single_shot_turn_end.py
+++ b/tests/repros/dead-recorder/repro_e_single_shot_turn_end.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""#57 / reviewer finding 1: single-shot never reports the lost mic.
+
+The mic is yanked during a single-shot dictation.  The sender hits EOF, sends
+the end-of-audio marker, and Azure answers turn.end -- which in single-shot
+mode sets _stop_event.  Any dead-recorder verdict gated on `not _stopping()`
+is therefore defeated by the session's OWN natural end, and the user is told
+nothing at all.
+
+Expected: exactly one microphone Error, one cycle, idle, no restart.
+exit 0 = clean, exit 1 = bug present.
+"""
+import sys
+import time
+
+import fakes
+import harness
+
+WINDOW = 6.0
+
+
+def main():
+    mod, _events, inj = harness.load()
+    print(f"service under test: {harness.SVC_PATH}")
+
+    cycles = [0]
+    errors = []
+    restarts = []
+
+    mod.HAS_WS = True
+    mod.HAS_VAD = False
+    mod.CONFIG["continuous_dictation"] = False      # SINGLE SHOT
+    mod.CONFIG["conversation_mode"] = False
+    mod._take_prewarmed_rec = lambda *a, **k: fakes.DeadProc()
+    mod._get_stt_ws = lambda *a, **k: (
+        fakes.ScriptedWS(mod.websocket.WebSocketTimeoutException,
+                         script=[b"turn_end"], delay=0.2), True)
+    mod._make_ws_audio_msg = lambda *a, **k: b""
+    mod._rest_stt_fallback = lambda *a, **k: ""
+    mod._invalidate_stt_ws = lambda *a, **k: None
+
+    def fake_parse(msg, phrases, partial_holder, *a, **k):
+        return "turn_end" if msg == b"turn_end" else None
+    mod._parse_ws_msg = fake_parse
+
+    def count_cycle(*a, **k):
+        cycles[0] += 1
+    mod._init_stt_ws_session = count_cycle
+
+    mod.GLib.idle_add = lambda fn, *a, **k: fn(*a, **k)
+
+    svc = harness.make_service(mod)
+    svc._stt_mode = "streaming"
+    svc._reload_config_flags = lambda: None
+    svc._emit_error = lambda msg: errors.append(msg) or False
+    svc._try_cast = lambda text: False
+    _real_start = svc.start_listening
+    svc.start_listening = lambda *a, **k: (restarts.append(time.monotonic()),
+                                           _real_start(*a, **k))[-1]
+
+    assert svc.start_listening() == "ok", "setup: start_listening refused"
+    restarts.clear()                      # the priming call is not a restart
+    idle_at = [None]
+    t0 = time.monotonic()
+    if harness.wait_for(lambda: svc.current_state == "idle", WINDOW):
+        idle_at[0] = time.monotonic() - t0
+    time.sleep(0.4)                       # give a rogue restart room to show
+    state_seen = svc.current_state
+    svc.stop()
+    time.sleep(0.3)
+
+    failures = 0
+    print(f"  cycles: {cycles[0]}")
+    print(f"  Error signals: {errors}")
+    print(f"  restarts after the session: {len(restarts)}")
+    print(f"  state: {state_seen!r}"
+          + (f" (idle after {idle_at[0]:.1f}s)" if idle_at[0] is not None else ""))
+    if len([e for e in errors if "icrophone" in e]) != 1:
+        failures += 1
+        print("    FAIL: expected exactly one microphone Error signal")
+    if cycles[0] != 1:
+        failures += 1
+        print("    FAIL: single-shot should run exactly one cycle")
+    if idle_at[0] is None:
+        failures += 1
+        print("    FAIL: service did not return to idle")
+    if restarts:
+        failures += 1
+        print("    FAIL: restarted listening onto a dead recorder")
+    leaked = svc._cancels.live()
+    if leaked:
+        failures += 1
+        print(f"    FAIL: leaked cancel token(s) {leaked}")
+    print()
+    if failures:
+        print(f"FAIL: {failures} -- turn.end masks the lost microphone")
+        return 1
+    print("PASS: single-shot + turn.end still reports the lost microphone")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/dead-recorder/repro_f_text_survives_yank.py
+++ b/tests/repros/dead-recorder/repro_f_text_survives_yank.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""#57 / reviewer finding 2: the dead-recorder branch throws away the words.
+
+The user dictates "hello world"; Azure returns the phrase; THEN the mic is
+yanked.  A dead-recorder branch that fires before the transcript is assembled
+discards `phrases` and backspaces the live-typed partial, so speech that was
+already recognized never reaches the cursor.  Reporting the fault must be
+ADDITIONAL to delivering the text, never instead of it.
+
+Expected: "hello world" reaches the cursor AND exactly one microphone Error.
+exit 0 = clean, exit 1 = bug present.
+"""
+import sys
+import time
+
+import fakes
+import harness
+
+WINDOW = 6.0
+
+
+def main():
+    mod, _events, inj = harness.load()
+    print(f"service under test: {harness.SVC_PATH}")
+
+    cycles = [0]
+    errors = []
+
+    mod.HAS_WS = True
+    mod.HAS_VAD = False
+    mod.CONFIG["continuous_dictation"] = False
+    mod.CONFIG["conversation_mode"] = False
+    mod.CONFIG["dictation_mode"] = True
+    mod._take_prewarmed_rec = lambda *a, **k: fakes.DeadProc()
+    mod._get_stt_ws = lambda *a, **k: (
+        fakes.ScriptedWS(mod.websocket.WebSocketTimeoutException,
+                         script=[b"phrase"], delay=0.15), True)
+    mod._make_ws_audio_msg = lambda *a, **k: b""
+    mod._rest_stt_fallback = lambda *a, **k: ""
+    mod._invalidate_stt_ws = lambda *a, **k: None
+
+    served = []
+
+    def fake_parse(msg, phrases, partial_holder, *a, **k):
+        if msg == b"phrase" and not served:
+            served.append(True)
+            phrases.append("hello world")
+            partial_holder[0] = "hello world"
+            return "phrase"
+        return None
+    mod._parse_ws_msg = fake_parse
+
+    def count_cycle(*a, **k):
+        cycles[0] += 1
+    mod._init_stt_ws_session = count_cycle
+
+    mod.GLib.idle_add = lambda fn, *a, **k: fn(*a, **k)
+
+    svc = harness.make_service(mod)
+    svc._stt_mode = "streaming"
+    svc._reload_config_flags = lambda: None
+    svc._emit_error = lambda msg: errors.append(msg) or False
+    svc._try_cast = lambda text: False
+    svc._wake_gate_blocks = lambda: False
+
+    assert svc.start_listening() == "ok", "setup: start_listening refused"
+    harness.wait_for(lambda: svc.current_state == "idle", WINDOW)
+    time.sleep(0.3)
+    svc.stop()
+    time.sleep(0.3)
+
+    delivered = [t for t, _ts in inj.all_text()]
+    failures = 0
+    print(f"  cycles: {cycles[0]}")
+    print(f"  text delivered to the cursor: {delivered}")
+    print(f"  Error signals: {errors}")
+    print(f"  backspaces: {inj.backspaces}")
+    if not any("world" in t.lower() for t in delivered):
+        failures += 1
+        print("    FAIL: speech recognized before the yank was thrown away")
+    if len([e for e in errors if "icrophone" in e]) != 1:
+        failures += 1
+        print("    FAIL: expected exactly one microphone Error signal")
+    if svc.current_state != "idle":
+        failures += 1
+        print(f"    FAIL: state is {svc.current_state!r}, expected idle")
+    leaked = svc._cancels.live()
+    if leaked:
+        failures += 1
+        print(f"    FAIL: leaked cancel token(s) {leaked}")
+    print()
+    if failures:
+        print(f"FAIL: {failures} -- the dead recorder cost the user their words")
+        return 1
+    print("PASS: text delivered, then the lost microphone reported once")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/dead-recorder/repro_g_ws_init_unbound.py
+++ b/tests/repros/dead-recorder/repro_g_ws_init_unbound.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""#48 regression guard: the WS-init failure `break` must not hit an unbound local.
+
+The closed duplicate PR bound its dead-recorder flag INSIDE the cycle loop and
+read it after the loop.  The WS-session-init failure path breaks out of the
+loop before any per-cycle state exists, so that read raised UnboundLocalError
+inside the STT worker thread -- the session never reported anything and never
+went idle.  This pins the flag's binding site.
+
+Expected: exactly one "STT session init failed" Error, no microphone Error,
+idle, and NO exception escaping the worker thread.
+exit 0 = clean, exit 1 = bug present.
+"""
+import sys
+import threading
+import time
+
+import fakes
+import harness
+
+WINDOW = 6.0
+
+
+def main():
+    mod, _events, inj = harness.load()
+    print(f"service under test: {harness.SVC_PATH}")
+
+    errors = []
+    thread_excs = []
+
+    def hook(args):
+        thread_excs.append(f"{args.exc_type.__name__}: {args.exc_value}")
+    threading.excepthook = hook
+
+    mod.HAS_WS = True
+    mod.HAS_VAD = False
+    mod.CONFIG["continuous_dictation"] = False
+    mod._take_prewarmed_rec = lambda *a, **k: fakes.LiveProc()
+    mod._get_stt_ws = lambda *a, **k: (
+        fakes.ScriptedWS(mod.websocket.WebSocketTimeoutException), True)
+    mod._make_ws_audio_msg = lambda *a, **k: b""
+    mod._rest_stt_fallback = lambda *a, **k: ""
+    mod._invalidate_stt_ws = lambda *a, **k: None
+    mod._parse_ws_msg = lambda *a, **k: None
+
+    def boom(*a, **k):
+        raise RuntimeError("session init refused")
+    mod._init_stt_ws_session = boom
+
+    mod.GLib.idle_add = lambda fn, *a, **k: fn(*a, **k)
+
+    svc = harness.make_service(mod)
+    svc._stt_mode = "streaming"
+    svc._reload_config_flags = lambda: None
+    svc._emit_error = lambda msg: errors.append(msg) or False
+    svc._try_cast = lambda text: False
+
+    assert svc.start_listening() == "ok", "setup: start_listening refused"
+    reached_idle = harness.wait_for(lambda: svc.current_state == "idle", WINDOW)
+    time.sleep(0.3)
+    svc.stop()
+    time.sleep(0.3)
+
+    failures = 0
+    print(f"  Error signals: {errors}")
+    print(f"  exceptions escaping the worker thread: {thread_excs}")
+    print(f"  state: {svc.current_state!r}")
+    if thread_excs:
+        failures += 1
+        print("    FAIL: the WS-init break path raised out of the worker")
+    if len([e for e in errors if "session init failed" in e]) != 1:
+        failures += 1
+        print("    FAIL: expected exactly one session-init Error")
+    if any("icrophone" in e for e in errors):
+        failures += 1
+        print("    FAIL: a healthy recorder was reported as a lost microphone")
+    if not reached_idle:
+        failures += 1
+        print("    FAIL: service did not return to idle")
+    leaked = svc._cancels.live()
+    if leaked:
+        failures += 1
+        print(f"    FAIL: leaked cancel token(s) {leaked}")
+    print()
+    if failures:
+        print(f"FAIL: {failures} -- WS-init break path is broken")
+        return 1
+    print("PASS: WS-init failure reports once, no unbound locals")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/dead-recorder/repro_h_stale_prewarm.py
+++ b/tests/repros/dead-recorder/repro_h_stale_prewarm.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""#48: a prewarmed recorder that already exited must be discarded, not used.
+
+_prewarm_recorder() starts pw-record and hands it over on the next hotkey
+without ever polling it.  With an on-demand USB mic absent, pw-record exits
+immediately, so the session opens on a corpse and diagnoses the failure
+against a recorder that died minutes ago, in a different device state.
+
+Expected: the stale process is discarded and a fresh recorder is started.
+exit 0 = clean, exit 1 = bug present.
+"""
+import sys
+import time
+
+import fakes
+import harness
+
+WINDOW = 6.0
+
+
+def main():
+    mod, _events, inj = harness.load()
+    print(f"service under test: {harness.SVC_PATH}")
+
+    errors = []
+    spawned = []
+
+    stale = fakes.DeadProc(exited=True)      # poll() is non-None from the start
+    mod.HAS_WS = True
+    mod.HAS_VAD = False
+    mod.CONFIG["continuous_dictation"] = False
+    mod._take_prewarmed_rec = lambda *a, **k: stale
+    mod._get_stt_ws = lambda *a, **k: (
+        fakes.ScriptedWS(mod.websocket.WebSocketTimeoutException), True)
+    mod._make_ws_audio_msg = lambda *a, **k: b""
+    mod._rest_stt_fallback = lambda *a, **k: ""
+    mod._invalidate_stt_ws = lambda *a, **k: None
+    mod._parse_ws_msg = lambda *a, **k: None
+    mod._init_stt_ws_session = lambda *a, **k: None
+    mod._build_rec_cmd = lambda *a, **k: ["/bin/true"]
+
+    def fake_popen(cmd, **kw):
+        spawned.append(cmd)
+        return fakes.DeadProc()              # a fresh one, alive until read
+    mod.subprocess.Popen = fake_popen
+
+    mod.GLib.idle_add = lambda fn, *a, **k: fn(*a, **k)
+
+    svc = harness.make_service(mod)
+    svc._stt_mode = "streaming"
+    svc._reload_config_flags = lambda: None
+    svc._emit_error = lambda msg: errors.append(msg) or False
+    svc._try_cast = lambda text: False
+
+    assert svc.start_listening() == "ok", "setup: start_listening refused"
+    reached_idle = harness.wait_for(lambda: svc.current_state == "idle", WINDOW)
+    time.sleep(0.3)
+    svc.stop()
+    time.sleep(0.3)
+
+    failures = 0
+    print(f"  fresh recorders spawned: {len(spawned)}")
+    print(f"  Error signals: {errors}")
+    print(f"  state: {svc.current_state!r}")
+    if len(spawned) != 1:
+        failures += 1
+        print("    FAIL: a stale prewarmed recorder was used instead of a fresh one")
+    if not reached_idle:
+        failures += 1
+        print("    FAIL: service did not return to idle")
+    leaked = svc._cancels.live()
+    if leaked:
+        failures += 1
+        print(f"    FAIL: leaked cancel token(s) {leaked}")
+    print()
+    if failures:
+        print(f"FAIL: {failures} -- stale prewarm handed to the session")
+        return 1
+    print("PASS: stale prewarmed recorder discarded, fresh one started")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/dead-recorder/repro_i_healthy_loop.py
+++ b/tests/repros/dead-recorder/repro_i_healthy_loop.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""NEGATIVE CONTROL: a live recorder must never be reported as a lost one.
+
+Every other repro here asserts that a death IS seen.  This one asserts the
+opposite direction, because a liveness detector that fails toward a false
+positive would end a perfectly good loop session on the first quiet cycle and
+tell the user their microphone was unplugged.  Healthy recorder, loop mode,
+several cycles: no microphone Error, and the loop keeps looping.
+
+exit 0 = clean, exit 1 = the detector fires on a live mic.
+"""
+import sys
+import time
+
+import fakes
+import harness
+
+WINDOW = 4.0
+MIN_CYCLES = 3
+
+
+def main():
+    mod, _events, inj = harness.load()
+    print(f"service under test: {harness.SVC_PATH}")
+
+    cycles = [0]
+    errors = []
+
+    mod.HAS_WS = True
+    mod.HAS_VAD = False
+    mod.CONFIG["continuous_dictation"] = True       # LOOP
+    mod.CONFIG["conversation_mode"] = False
+    mod._take_prewarmed_rec = lambda *a, **k: fakes.LiveProc()
+    mod._get_stt_ws = lambda *a, **k: (
+        fakes.LoopingWS(mod.websocket.WebSocketTimeoutException,
+                        script=[b"turn_end"], delay=0.05), True)
+    mod._make_ws_audio_msg = lambda *a, **k: b""
+    mod._rest_stt_fallback = lambda *a, **k: ""
+    mod._invalidate_stt_ws = lambda *a, **k: None
+    mod._parse_ws_msg = lambda msg, *a, **k: "turn_end"
+
+    def count_cycle(*a, **k):
+        cycles[0] += 1
+    mod._init_stt_ws_session = count_cycle
+
+    mod.GLib.idle_add = lambda fn, *a, **k: fn(*a, **k)
+
+    svc = harness.make_service(mod)
+    svc._stt_mode = "streaming"
+    svc._reload_config_flags = lambda: None
+    svc._emit_error = lambda msg: errors.append(msg) or False
+    svc._try_cast = lambda text: False
+    svc._drain_speech_gap = lambda *a, **k: None
+
+    assert svc.start_listening() == "ok", "setup: start_listening refused"
+    time.sleep(WINDOW)
+    state_seen = svc.current_state
+    cycles_seen = cycles[0]
+    svc.stop()
+    time.sleep(0.5)
+
+    failures = 0
+    print(f"  cycles run in {WINDOW:.0f}s: {cycles_seen}")
+    print(f"  Error signals: {errors}")
+    print(f"  state during the run: {state_seen!r}")
+    if any("icrophone" in e for e in errors):
+        failures += 1
+        print("    FAIL: a live recorder was reported as a lost microphone")
+    if cycles_seen < MIN_CYCLES:
+        failures += 1
+        print(f"    FAIL: loop stalled ({cycles_seen} < {MIN_CYCLES} cycles)")
+    if state_seen != "listening":
+        failures += 1
+        print(f"    FAIL: state was {state_seen!r} mid-loop, expected 'listening'")
+    print()
+    if failures:
+        print(f"FAIL: {failures} -- the detector fires on a healthy recorder")
+        return 1
+    print("PASS: healthy loop keeps looping, nothing reported")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/dead-recorder/run_all.sh
+++ b/tests/repros/dead-recorder/run_all.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Run the dead-recorder repro suite against a given gnome-speaks-service.py.
+# usage: run_all.sh <path-to-service.py>
+#
+# BASELINE IS A PINNED SHA, NEVER A BRANCH. These repros were written to fail
+# before the #57/#48 fix and pass after it. That claim is only reproducible
+# against the commit the fix landed on top of:
+#
+#   GS_BASELINE_REF=e863b2c     # last commit BEFORE #72 merged (848b855)
+#   git archive $GS_BASELINE_REF | tar -x -C <dir> && ./run_all.sh <dir>/gnome-speaks-service.py
+#   expected there: e FAIL, f FAIL, h FAIL, g PASS, i PASS
+#
+# Against a moving ref this check goes vacuous the moment the fix merges: it
+# starts comparing the fix to itself and passes forever. Verified 2026-09-06.
+set -u
+# Default to the service in THIS checkout: tests/repros/<suite>/ -> repo root,
+# so a bare run tests the tree you are standing in.
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+SVC="${1:-$REPO/gnome-speaks-service.py}"
+cd "$(dirname "$0")" || exit 2
+rc=0
+for r in repro_e_single_shot_turn_end.py repro_f_text_survives_yank.py \
+         repro_g_ws_init_unbound.py repro_h_stale_prewarm.py \
+         repro_i_healthy_loop.py; do
+  out=$(GS_SVC_PATH="$SVC" timeout 120 python3 "$r" 2>/dev/null)
+  st=$?
+  verdict=$(printf '%s\n' "$out" | grep -E '^(PASS|FAIL):' | tail -1)
+  [ $st -ne 0 ] && rc=1
+  printf '%-38s rc=%s  %s\n' "$r" "$st" "$verdict"
+done
+exit $rc

--- a/tests/repros/injector-seam/verify_ibus_injector.py
+++ b/tests/repros/injector-seam/verify_ibus_injector.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""Verify the IBus injection backend against a MOCK bus.
+
+Deliberately never touches the live session: no IBus.Bus() is constructed, no
+SetGlobalEngine is issued, and XDG_RUNTIME_DIR is redirected so the real
+prior-engine breadcrumb is never read or written. The only sanctioned live
+touch in this project is the Phase 0 probe, and this is not it.
+
+Covers the safety properties that make the backend shippable:
+  * the prior engine is persisted BEFORE the swap, cleared only after restore
+  * password/PIN fields are refused at acquire AND re-checked on every commit
+  * restore is idempotent (restore-once) and survives being called from
+    error paths
+  * the watchdog force-restores a session that outlives its bound
+  * a crash breadcrumb is replayed by restore_prior_engine()
+  * press_enter never becomes a text commit
+  * commit coalescing joins whitespace without doubling it
+"""
+import atexit
+import importlib.util
+import os
+import shutil
+import sys
+import time
+
+# ENV CONTRACT (unified 2026-09-06): GS_SVC_PATH is the ONE input -- the
+# service.py file under test. The worktree dir is DERIVED from its dirname,
+# so ibus_injector.py, which is what this file actually imports always come from
+# the same tree as the service. GS_WT overrides the dir only if you really
+# mean to mix trees. Defaults to the main checkout; the old defaults pointed
+# at ~/Projects/gnome-speaks-wt/<name>/ worktrees that no longer exist, so a
+# bare run died with FileNotFoundError instead of testing anything.
+# This file used to read GS_WT ONLY and ignore GS_SVC_PATH, so a caller
+# following the suite-wide contract silently tested the WRONG tree --
+# PYTHONPATH appeared to work only by accident of a bogus sys.path entry.
+# Repo-relative by construction: this file lives at
+# tests/repros/<suite>/<file>.py, so four dirnames reach the repo root. #59:
+# the old defaults were absolute paths into ~/Projects/gnome-speaks-wt/<name>/
+# worktrees that no longer existed, so a bare run died with FileNotFoundError
+# instead of testing anything.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+# Scratch lives in the repo's gitignored tmp/, keyed by PID. Never a fixed
+# shared path: two agents running a suite at once used to corrupt each other
+# and it read exactly like a service regression.
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+SVC_PATH = os.environ.get("GS_SVC_PATH", SVC_DEFAULT)
+WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
+# Per-PID: this dir is rmtree()d at import, so a FIXED path meant two
+# agents running this file at once destroyed each other's breadcrumb.
+RUNTIME = os.path.join(SCRATCH_ROOT, f"morpheus-ibus-tests-{os.getpid()}", "runtime")
+shutil.rmtree(RUNTIME, ignore_errors=True)
+os.makedirs(RUNTIME, exist_ok=True)
+os.environ["XDG_RUNTIME_DIR"] = RUNTIME          # never the real breadcrumb
+atexit.register(shutil.rmtree, os.path.dirname(RUNTIME), True)
+sys.path.insert(0, WT)
+
+import ibus_injector as ib  # noqa: E402
+from ibus_injector import IbusInjector, _Coalescer  # noqa: E402
+
+FAILS = []
+
+
+def capture_log():
+    """Attach a buffer to the backend's logger; returns (buffer, detach)."""
+    import io
+    import logging
+    buf = io.StringIO()
+    h = logging.StreamHandler(buf)
+    h.setLevel(logging.DEBUG)
+    ib.log.addHandler(h)
+    return buf, lambda: ib.log.removeHandler(h)
+
+
+def check(label, cond, detail=""):
+    if cond:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}  <- {detail}")
+        FAILS.append(label)
+
+
+class FakeEngineDesc:
+    def __init__(self, name):
+        self._name = name
+
+    def get_name(self):
+        return self._name
+
+
+class FakeBus:
+    """Records engine swaps. Never speaks to a real daemon."""
+
+    def __init__(self, prior="xkb:us::eng", accept=True, raise_on_get=False):
+        self.current = prior
+        self.accept = accept
+        self.raise_on_get = raise_on_get
+        self.swaps = []
+
+    def is_connected(self):
+        return True
+
+    def get_global_engine(self):
+        if self.raise_on_get:
+            # What GNOME actually does: GetGlobalEngine fails outright
+            # ("No global engine") because the shell owns input sources.
+            raise RuntimeError("No global engine")
+        return FakeEngineDesc(self.current) if self.current else None
+
+    def set_global_engine(self, name):
+        self.swaps.append(name)
+        if not self.accept:
+            return False
+        self.current = name
+        return True
+
+
+class FakeEngine:
+    """Stands in for the object the daemon would drive."""
+
+    def __init__(self, purpose=0, preedit_capable=True):
+        self.purpose = purpose
+        self.focused = True
+        self.commits = []
+        self.preedits = []
+        self.cleared = 0
+        self._preedit_capable = preedit_capable
+
+    def is_secure(self):
+        return self.purpose in ib._SECURE_PURPOSES
+
+    def set_preedit(self, text):
+        if not text:
+            self.clear_preedit()
+            return
+        if not self._preedit_capable:
+            return
+        self.preedits.append(text)
+
+    def clear_preedit(self):
+        self.cleared += 1
+
+    def commit(self, text):
+        self.commits.append(text)
+        return True
+
+
+class FakeFallback:
+    name = "ydotool"
+
+    def __init__(self):
+        self.enters = 0
+        self.recovers = 0
+        self.prepared = 0
+
+    def prepare(self):
+        self.prepared += 1
+
+    def press_enter(self):
+        self.enters += 1
+        return True
+
+    def recover(self):
+        self.recovers += 1
+
+
+def wired(prior="xkb:us::eng", purpose=0, accept=True, preedit_capable=True,
+          raise_on_get=False):
+    """An IbusInjector pre-wired to fakes, bypassing real registration."""
+    inj = IbusInjector(fallback=FakeFallback())
+    inj._bus = FakeBus(prior, accept=accept, raise_on_get=raise_on_get)
+    inj._engine = FakeEngine(purpose, preedit_capable=preedit_capable)
+    inj._registered = True
+    return inj
+
+
+def flush_now(inj):
+    """Force the coalescer out without waiting on its timer."""
+    inj._cancel_timers()
+    inj._flush(allowed=True)
+
+
+def main():
+    print(f"backend under test: {WT}/ibus_injector.py")
+    print(f"XDG_RUNTIME_DIR redirected to {RUNTIME}\n")
+
+    # ---- identity / the keymap bug we must not copy ----------------------
+    print("[1] identity")
+    check("engine layout is 'default', never 'us'", ib.ENGINE_LAYOUT == "default",
+          ib.ENGINE_LAYOUT)
+    check("component name is ours", ib.COMPONENT_NAME.endswith("GnomeSpeaks"))
+    check("secure purposes are PASSWORD/PIN", ib._SECURE_PURPOSES == (8, 9))
+    if ib.HAS_IBUS:
+        eng_cls = ib.SpeaksEngine
+        check("do_process_key_event returns False (keys pass through)",
+              eng_cls.do_process_key_event(object(), 0, 0, 0) is False)
+        check("engine implements both focus spellings",
+              all(hasattr(eng_cls, m) for m in
+                  ("do_focus_in", "do_focus_in_id", "do_focus_out", "do_focus_out_id")))
+        check("engine implements do_set_content_type",
+              hasattr(eng_cls, "do_set_content_type"))
+    else:
+        print("  --   IBus bindings absent; engine-class checks skipped")
+
+    # ---- coalescing ------------------------------------------------------
+    print("\n[2] commit coalescing")
+    c = _Coalescer()
+    c.push("This is")
+    c.push("not working")
+    check("stripped segments get a separator", c.pending == "This is not working", c.pending)
+    c2 = _Coalescer()
+    c2.push("hello")
+    c2.push(" world")
+    check("natural leading space is not doubled", c2.pending == "hello world", c2.pending)
+    c3 = _Coalescer()
+    c3.push("a")
+    c3.committed_any = True
+    check("later flush is spaced from earlier commit", c3.take() == " a", repr(c3.take()))
+    c4 = _Coalescer()
+    c4.push("secret")
+    check("take(allowed=False) DISCARDS", c4.take(allowed=False) == "", "leaked")
+    check("...and leaves nothing buffered", c4.pending == "")
+
+    # ---- acquire ordering: persist BEFORE swap ---------------------------
+    print("\n[3] acquire persists the way back BEFORE swapping")
+    inj = wired()
+    ok = inj.acquire()
+    check("acquire() succeeded", ok is True)
+    check("swapped to our engine", inj._bus.swaps == [ib.ENGINE_NAME], inj._bus.swaps)
+    check("breadcrumb written", ib.read_prior_engine() == "xkb:us::eng",
+          ib.read_prior_engine())
+    check("watchdog armed", inj._watchdog is not None)
+    inj.end()
+    check("end() restored the prior engine",
+          inj._bus.swaps == [ib.ENGINE_NAME, "xkb:us::eng"], inj._bus.swaps)
+    check("breadcrumb cleared after clean restore", ib.read_prior_engine() is None)
+    check("watchdog disarmed", inj._watchdog is None)
+
+    # write-before-swap ordering, proven by refusing the swap
+    inj = wired(accept=False)
+    ok = inj.acquire()
+    check("acquire() returns False when the swap is refused", ok is False)
+    check("refused swap leaves no stale breadcrumb", ib.read_prior_engine() is None,
+          ib.read_prior_engine())
+    check("refused swap leaves us inactive", inj._active is False)
+
+    # ---- secure fields ---------------------------------------------------
+    print("\n[4] password/PIN refusal")
+    for purpose, label in ((8, "PASSWORD"), (9, "PIN")):
+        inj = wired(purpose=purpose)
+        ok = inj.acquire()
+        check(f"acquire() refuses a {label} field", ok is False)
+        check(f"{label}: engine restored on refusal",
+              inj._bus.swaps[-1] == "xkb:us::eng", inj._bus.swaps)
+        check(f"{label}: breadcrumb cleared", ib.read_prior_engine() is None)
+        check(f"{label}: nothing was committed", inj._engine.commits == [])
+
+    # late content-type: ordinary field at acquire, secure by commit time
+    inj = wired(purpose=0)
+    inj.acquire()
+    inj._engine.purpose = 8
+    got = inj.commit("hunter2")
+    flush_now(inj)
+    check("mid-session focus into a password field refuses the commit", got is False)
+    check("...and commits nothing", inj._engine.commits == [], inj._engine.commits)
+    check("...and hands the input method back",
+          inj._bus.swaps[-1] == "xkb:us::eng", inj._bus.swaps)
+
+    # ---- restore-once / idempotency --------------------------------------
+    print("\n[5] restore is idempotent")
+    inj = wired()
+    inj.acquire()
+    inj.end()
+    inj.end()
+    inj.cancel()
+    check("repeated end()/cancel() restore exactly once",
+          inj._bus.swaps.count("xkb:us::eng") == 1, inj._bus.swaps)
+    inj = wired()
+    inj.cancel()
+    check("cancel() before acquire() is a no-op", inj._bus.swaps == [], inj._bus.swaps)
+
+    # no prior engine at all (nothing to go back to)
+    inj = wired(prior=None)
+    inj.acquire()
+    inj.end()
+    check("no prior engine: nothing is written",
+          ib.read_prior_engine() is None)
+
+    # ---- watchdog --------------------------------------------------------
+    print("\n[6] watchdog bounds the session")
+    saved = ib.SESSION_MAX_SECONDS
+    ib.SESSION_MAX_SECONDS = 0.15
+    try:
+        inj = wired()
+        inj.acquire()
+        deadline = time.monotonic() + 3.0
+        while inj._active and time.monotonic() < deadline:
+            time.sleep(0.02)
+        check("a session that outlives its bound is force-restored",
+              inj._active is False)
+        check("...and the engine went back",
+              inj._bus.swaps[-1] == "xkb:us::eng", inj._bus.swaps)
+        check("...and the breadcrumb was cleared", ib.read_prior_engine() is None)
+    finally:
+        ib.SESSION_MAX_SECONDS = saved
+
+    # ---- crash recovery --------------------------------------------------
+    print("\n[7] crash recovery replays the breadcrumb")
+
+    class FakeIBusModule:
+        def __init__(self, bus):
+            self._bus = bus
+            self.inited = 0
+
+        def init(self):
+            self.inited += 1
+
+        def Bus(self):
+            return self._bus
+
+    real_ibus, real_has = ib.IBus, ib.HAS_IBUS
+    try:
+        bus = FakeBus(prior="gnome-speaks-stt")   # crash left OURS installed
+        ib.IBus = FakeIBusModule(bus)
+        ib.HAS_IBUS = True
+        ib.write_prior_engine("xkb:us::eng")
+        did = ib.restore_prior_engine("test")
+        check("stranded engine is restored at startup", did is True)
+        check("...to the recorded engine", bus.swaps == ["xkb:us::eng"], bus.swaps)
+        check("...and the breadcrumb is consumed", ib.read_prior_engine() is None)
+
+        check("no breadcrumb -> no action and no error",
+              ib.restore_prior_engine("test") is False)
+
+        bus2 = FakeBus(prior="xkb:us::eng")
+        ib.IBus = FakeIBusModule(bus2)
+        ib.write_prior_engine("xkb:us::eng")
+        did = ib.restore_prior_engine("test")
+        check("already-correct engine: no redundant swap", bus2.swaps == [], bus2.swaps)
+        check("...stale breadcrumb still cleared", ib.read_prior_engine() is None)
+    finally:
+        ib.IBus, ib.HAS_IBUS = real_ibus, real_has
+
+    # ---- the seam contract under IBus ------------------------------------
+    print("\n[8] seam methods map correctly onto IBus")
+    inj = wired()
+    check("supports_preedit() is True", inj.supports_preedit() is True)
+
+    inj = wired()
+    inj.acquire()
+    inj.replace_text("hello wor", "hello world")
+    check("replace_text() becomes a preedit replacement",
+          inj._engine.preedits == ["hello world"], inj._engine.preedits)
+    check("...and commits nothing yet", inj._engine.commits == [])
+    inj.send_backspaces(9)
+    check("send_backspaces() clears the preedit instead of typing keys",
+          inj._engine.cleared >= 1)
+
+    inj = wired()
+    inj.acquire()
+    inj.paste("a block of text")
+    flush_now(inj)
+    check("paste() becomes a commit, not a clipboard round-trip",
+          inj._engine.commits == ["a block of text"], inj._engine.commits)
+
+    inj = wired()
+    inj.acquire()
+    inj.commit("one")
+    inj.commit("two")
+    flush_now(inj)
+    check("back-to-back finals coalesce into ONE commit",
+          inj._engine.commits == ["one two"], inj._engine.commits)
+
+    inj = wired()
+    got = inj.press_enter()
+    check("press_enter() delegates to the key-event backend",
+          inj._fallback.enters == 1, inj._fallback.enters)
+    check("press_enter() never commits text", inj._engine.commits == [])
+    check("press_enter() does not acquire an IBus session", inj._active is False)
+
+    inj = wired(preedit_capable=False)
+    inj.acquire()
+    inj.set_preedit("partial")
+    check("client without preedit capability drops partials silently",
+          inj._engine.preedits == [], inj._engine.preedits)
+
+    inj = wired()
+    inj.acquire()
+    inj.end()
+    inj._fallback.recovers = 0
+    inj.recover()
+    check("recover() also clears the fallback's state", inj._fallback.recovers == 1)
+
+    # ---- no global engine: the GNOME case that stranded a real session ---
+    # Live gate finding: on GNOME the shell manages input sources and
+    # GetGlobalEngine commonly fails with "No global engine". Recording None
+    # there left the session stranded on gnome-speaks-stt after one cycle.
+    print("\n[9] no global engine -> derive a restore target")
+    real_derive = ib.derive_restore_target
+    try:
+        ib.derive_restore_target = lambda bus=None: "xkb:us::eng"
+
+        for label, kwargs in (("GetGlobalEngine returns None", dict(prior=None)),
+                              ("GetGlobalEngine raises", dict(prior=None,
+                                                              raise_on_get=True))):
+            inj = wired(**kwargs)
+            ok = inj.acquire()
+            check(f"{label}: acquire() still succeeds", ok is True)
+            check(f"{label}: derived target recorded as the breadcrumb",
+                  ib.read_prior_engine() == "xkb:us::eng", ib.read_prior_engine())
+            inj.end()
+            check(f"{label}: engine restored to the derived target",
+                  inj._bus.swaps == [ib.ENGINE_NAME, "xkb:us::eng"], inj._bus.swaps)
+            check(f"{label}: breadcrumb cleared", ib.read_prior_engine() is None)
+
+        # late derivation: acquire found nothing, restore must still act
+        inj = wired(prior=None)
+        ib.derive_restore_target = lambda bus=None: None
+        inj.acquire()
+        check("acquire with no derivable target still proceeds", inj._active is True)
+        ib.derive_restore_target = lambda bus=None: "xkb:us::eng"
+        inj.end()
+        check("restore derives LATE rather than standing down",
+              inj._bus.swaps[-1] == "xkb:us::eng", inj._bus.swaps)
+
+        # nothing derivable at all: must WARN, never finish quietly
+        inj = wired(prior=None)
+        ib.derive_restore_target = lambda bus=None: None
+        buf, detach = capture_log()
+        try:
+            inj.acquire()
+            inj.end()
+        finally:
+            detach()
+        text = buf.getvalue()
+        check("undecidable restore target logs a WARNING",
+              "no restore target" in text.lower(), repr(text[-200:]))
+        check("...and does not claim a restore it did not do",
+              inj._bus.swaps == [ib.ENGINE_NAME], inj._bus.swaps)
+    finally:
+        ib.derive_restore_target = real_derive
+
+    # ---- stranded with no breadcrumb -------------------------------------
+    print("\n[10] stranded session is rescued without a breadcrumb")
+    real_ibus, real_has = ib.IBus, ib.HAS_IBUS
+    real_derive = ib.derive_restore_target
+    try:
+        class FakeIBusModule2:
+            def __init__(self, bus):
+                self._bus = bus
+
+            def init(self):
+                pass
+
+            def Bus(self):
+                return self._bus
+
+        bus = FakeBus(prior=ib.ENGINE_NAME)     # we are the installed engine
+        ib.IBus = FakeIBusModule2(bus)
+        ib.HAS_IBUS = True
+        ib.derive_restore_target = lambda b=None: "xkb:us::eng"
+        ib.clear_prior_engine()                 # no breadcrumb at all
+        did = ib.restore_prior_engine("test")
+        check("stranded-on-ours is detected with no breadcrumb", did is True)
+        check("...and the derived source is restored",
+              bus.swaps[-1] == "xkb:us::eng", bus.swaps)
+
+        bus2 = FakeBus(prior="xkb:us::eng")     # NOT ours: nothing to do
+        ib.IBus = FakeIBusModule2(bus2)
+        check("a session not on our engine is left alone",
+              ib.restore_prior_engine("test") is False)
+        check("...with no swap issued", bus2.swaps == [], bus2.swaps)
+    finally:
+        ib.IBus, ib.HAS_IBUS = real_ibus, real_has
+        ib.derive_restore_target = real_derive
+
+    # ---- derivation itself ------------------------------------------------
+    print("\n[11] derivation reads GNOME's own input-sources")
+
+    class FakeSettings:
+        def __init__(self, mru, sources):
+            self._v = {"mru-sources": mru, "sources": sources}
+
+        def get_value(self, key):
+            class V:
+                def __init__(self, val):
+                    self._val = val
+
+                def unpack(self):
+                    return self._val
+            return V(self._v[key])
+
+    class FakeGio:
+        settings = None
+
+        @staticmethod
+        def _new(schema):
+            return FakeGio.settings
+
+    class EngList:
+        def __init__(self, names):
+            self.names = names
+
+        def list_engines(self):
+            return [FakeEngineDesc(n) for n in self.names]
+
+    real_gio = getattr(ib, "Gio", None)
+    try:
+        class GioShim:
+            class Settings:
+                @staticmethod
+                def new(schema):
+                    return FakeGio.settings
+        ib.Gio = GioShim
+        engines = EngList(["xkb:us::eng", "xkb:us:dvorak:eng",
+                           "xkb:de:neo:deu", "xkb:de:neo:eng"])
+
+        FakeGio.settings = FakeSettings([], [("xkb", "us")])
+        check("sources[0] xkb -> the daemon's real engine name",
+              ib.derive_restore_target(engines) == "xkb:us::eng")
+
+        FakeGio.settings = FakeSettings([("xkb", "us+dvorak")], [("xkb", "us")])
+        check("mru-sources wins over sources",
+              ib.derive_restore_target(engines) == "xkb:us:dvorak:eng")
+
+        FakeGio.settings = FakeSettings([], [("ibus", "anthy")])
+        check("an ibus source is already an engine name",
+              ib.derive_restore_target(engines) == "anthy")
+
+        FakeGio.settings = FakeSettings([], [])
+        check("no configured sources -> None (caller warns)",
+              ib.derive_restore_target(engines) is None)
+    finally:
+        if real_gio is not None:
+            ib.Gio = real_gio
+
+    # ---- we never touched the live session -------------------------------
+    print("\n[12] live session untouched")
+    check("no real prior-engine file outside the redirected runtime dir",
+          ib.prior_engine_path().startswith(RUNTIME), ib.prior_engine_path())
+
+    print()
+    if FAILS:
+        print(f"FAILED: {len(FAILS)}")
+        for f in FAILS:
+            print(f"  - {f}")
+        return 1
+    print("ALL IBUS BACKEND CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/injector-seam/verify_injector_seam.py
+++ b/tests/repros/injector-seam/verify_injector_seam.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Verify the Phase-1 Injector seam in gnome-speaks-service.py.
+
+Contract under test:
+  1. get_injector() yields a YdotoolInjector by default, and is a singleton.
+  2. Every seam method delegates to the original module-level function,
+     with the arguments and return value passed through untouched.
+  3. injection_method: ibus / auto / garbage all fall back to ydotool;
+     ibus and garbage log a warning.
+  4. available() tracks _TYPING_TOOL; supports_preedit() is False.
+  5. No call site outside the seam names a ydotool function (static scan).
+
+Touches nothing real: every ydotool/clipboard function is replaced by a spy
+before it can be called.  No port 7710, no service restart, no uinput.
+"""
+import atexit
+import importlib.util
+import io
+import logging
+import os
+import re
+import shutil
+import sys
+
+# ENV CONTRACT (unified 2026-09-06): GS_SVC_PATH is the ONE input -- the
+# service.py file under test. The worktree dir is DERIVED from its dirname,
+# so sibling modules (spellbook, injector, ibus_injector) always come from
+# the same tree as the service. GS_WT overrides the dir only if you really
+# mean to mix trees. Defaults to the main checkout; the old defaults pointed
+# at ~/Projects/gnome-speaks-wt/<name>/ worktrees that no longer exist, so a
+# bare run died with FileNotFoundError instead of testing anything.
+# Repo-relative by construction: this file lives at
+# tests/repros/<suite>/<file>.py, so four dirnames reach the repo root. #59:
+# the old defaults were absolute paths into ~/Projects/gnome-speaks-wt/<name>/
+# worktrees that no longer existed, so a bare run died with FileNotFoundError
+# instead of testing anything.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+# Scratch lives in the repo's gitignored tmp/, keyed by PID. Never a fixed
+# shared path: two agents running a suite at once used to corrupt each other
+# and it read exactly like a service regression.
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+SVC_PATH = os.environ.get("GS_SVC_PATH", SVC_DEFAULT)
+WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
+
+# disk-backed scratch, never the /tmp tmpfs
+_STATE = os.path.join(SCRATCH_ROOT, f"morpheus-injector-seam-{os.getpid()}", "state")
+os.makedirs(_STATE, exist_ok=True)
+atexit.register(shutil.rmtree, os.path.dirname(_STATE), True)
+os.environ["XDG_STATE_HOME"] = _STATE
+os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+
+FAILS = []
+
+
+def check(label, cond, detail=""):
+    if cond:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label} {detail}")
+        FAILS.append(label)
+
+
+def load():
+    sys.path.insert(0, os.path.dirname(SVC_PATH))  # sibling spellbook.py
+    spec = importlib.util.spec_from_file_location("gsvc_seam", SVC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["gsvc_seam"] = mod
+    spec.loader.exec_module(mod)  # main() is __main__-guarded; nothing starts
+    # CONFIG arrives holding JP's LIVE ~/.config/speech-to-cli/config.json
+    # (~47 keys; terminal_mode and wake_word are True on this machine). Pin
+    # every key this file's verdicts can see, in place -- `from state import
+    # CONFIG` means audio/stt/speech_tts share the same dict object. Point
+    # CONFIG_PATH somewhere we own too: _reload_config_flags() re-reads it
+    # mid-run and _save_config_flag() writes it.
+    mod.CONFIG.update({
+        "key": "test-key", "wake_word": False, "wake_word_model": "",
+        "wake_word_secure_gate": False, "chronicle": False,
+        "continuous_dictation": False, "conversation_mode": False,
+        "dictation_mode": True, "terminal_mode": False,
+        "skip_final_paste": False, "read_notifications": False,
+        "spiel_provider": False, "debug": False, "wyoming_host": "",
+    })
+    mod.CONFIG.pop("injection_method", None)   # each test sets it explicitly
+    os.makedirs(_STATE, exist_ok=True)
+    mod.CONFIG_PATH = os.path.join(_STATE, "config.json")
+    return mod
+
+
+def fresh(mod, method=None):
+    """Rebuild the singleton, optionally under a given injection_method."""
+    if method is None:
+        mod.CONFIG.pop("injection_method", None)
+    else:
+        mod.CONFIG["injection_method"] = method
+    mod._injector = None
+    return mod.get_injector()
+
+
+class Spy:
+    def __init__(self, ret=None):
+        self.calls = []
+        self.ret = ret
+
+    def __call__(self, *a, **kw):
+        self.calls.append((a, kw))
+        return self.ret
+
+
+def _raises(obj, meth, *args):
+    try:
+        getattr(obj, meth)(*args)
+        return False
+    except NotImplementedError:
+        return True
+
+
+def capture_log(mod):
+    """Attach a buffer to the service logger; returns (buffer, detach)."""
+    buf = io.StringIO()
+    h = logging.StreamHandler(buf)
+    h.setLevel(logging.DEBUG)
+    mod.log.addHandler(h)
+    return buf, lambda: mod.log.removeHandler(h)
+
+
+def main():
+    print(f"service under test: {SVC_PATH}")
+    mod = load()
+
+    # ---- 1. default selection + singleton -------------------------------
+    print("\n[1] default backend selection")
+    inj = fresh(mod)
+    check("default is YdotoolInjector", type(inj) is mod.YdotoolInjector, type(inj))
+    check("YdotoolInjector is an Injector", isinstance(inj, mod.Injector))
+    check("name == 'ydotool'", inj.name == "ydotool", inj.name)
+    check("get_injector() is a singleton", mod.get_injector() is inj)
+    check("explicit 'ydotool' selects it too",
+          type(fresh(mod, "ydotool")) is mod.YdotoolInjector)
+
+    # ---- 2. delegation --------------------------------------------------
+    print("\n[2] seam methods delegate to the original implementations")
+    inj = fresh(mod)
+    cases = [
+        # (module function, seam method, args, spy return, expected return)
+        ("type_at_cursor",     "commit",          ("hello",),      True,  True),
+        ("_type_raw",          "type_text",       (" ",),          None,  None),
+        ("_send_backspaces",   "send_backspaces", (7,),            None,  None),
+        ("replace_typed_text", "replace_text",    ("old", "new"),  None,  None),
+        ("_clipboard_paste",   "paste",           ("pasted",),     True,  True),
+        ("_reset_ydotoold",    "recover",         (),              None,  None),
+    ]
+    for fn_name, meth_name, args, spy_ret, want in cases:
+        original = getattr(mod, fn_name)
+        spy = Spy(spy_ret)
+        setattr(mod, fn_name, spy)
+        try:
+            got = getattr(inj, meth_name)(*args)
+        finally:
+            setattr(mod, fn_name, original)
+        check(f"{meth_name}() -> {fn_name}(): called once",
+              len(spy.calls) == 1, spy.calls)
+        check(f"{meth_name}() -> {fn_name}(): args passed through",
+              spy.calls and spy.calls[0] == (args, {}), spy.calls)
+        check(f"{meth_name}() -> {fn_name}(): return passed through",
+              got == want, repr(got))
+        check(f"{fn_name} restored after patch",
+              getattr(mod, fn_name) is original)
+
+    # prepare() == detect + reset, in that order
+    order = []
+    o_detect, o_reset = mod._detect_typing_tool, mod._reset_ydotoold
+    mod._detect_typing_tool = lambda: order.append("detect")
+    mod._reset_ydotoold = lambda: order.append("reset")
+    try:
+        inj.prepare()
+    finally:
+        mod._detect_typing_tool, mod._reset_ydotoold = o_detect, o_reset
+    check("prepare() -> _detect_typing_tool() then _reset_ydotoold()",
+          order == ["detect", "reset"], order)
+
+    # ---- 3. backend selection -------------------------------------------
+    # NOTE: a real IbusInjector.available() registers a component with the
+    # live ibus daemon. Tests must never do that, so IbusInjector is stubbed
+    # for every case below -- selection logic is what is under test here, and
+    # the backend itself has its own mock-bus suite.
+    print("\n[3] backend selection and fallback")
+    real_ibus_cls = mod.IbusInjector
+
+    class StubIbus(mod.Injector):
+        name = "ibus"
+        reachable = True
+
+        def __init__(self, fallback=None):
+            self.fallback = fallback
+
+        def available(self):
+            return StubIbus.reachable
+
+    try:
+        # (a) no IBus backend importable at all -> everything falls to ydotool
+        mod.IbusInjector = None
+        for method, want_warn in [("ibus", True), ("auto", False), ("uinput", True),
+                                  ("YDOTOOL", False), ("", False), (None, False)]:
+            buf, detach = capture_log(mod)
+            try:
+                got = fresh(mod, method)
+            finally:
+                detach()
+            text = buf.getvalue()
+            label = repr(method)
+            check(f"{label} falls back to YdotoolInjector",
+                  type(got) is mod.YdotoolInjector, type(got))
+            if want_warn:
+                check(f"{label} logs a warning",
+                      "could not be imported" in text or "Unknown injection_method" in text,
+                      repr(text))
+            else:
+                check(f"{label} logs no warning",
+                      "Unknown injection_method" not in text
+                      and "could not be imported" not in text, repr(text))
+        check("'  YdoTool ' is case/space normalized",
+              type(fresh(mod, "  YdoTool ")) is mod.YdotoolInjector)
+
+        # (b) IBus present and reachable -> ibus/auto select it, ydotool does not
+        mod.IbusInjector = StubIbus
+        StubIbus.reachable = True
+        check("'ibus' selects the IBus backend when reachable",
+              type(fresh(mod, "ibus")) is StubIbus, type(fresh(mod, "ibus")))
+        check("'auto' prefers IBus when reachable",
+              type(fresh(mod, "auto")) is StubIbus)
+        check("'ydotool' still means ydotool even when IBus is reachable",
+              type(fresh(mod, "ydotool")) is mod.YdotoolInjector)
+        check("default (unset) is ydotool even when IBus is reachable",
+              type(fresh(mod)) is mod.YdotoolInjector)
+        sel = fresh(mod, "ibus")
+        check("IBus backend is given a ydotool fallback for keystrokes",
+              type(sel.fallback) is mod.YdotoolInjector, sel.fallback)
+
+        # (c) IBus present but unreachable -> both fall back, never to nothing
+        StubIbus.reachable = False
+        for method in ("ibus", "auto"):
+            buf, detach = capture_log(mod)
+            try:
+                got = fresh(mod, method)
+            finally:
+                detach()
+            check(f"{method!r} falls back when IBus is unreachable",
+                  type(got) is mod.YdotoolInjector, type(got))
+            check(f"{method!r} says why", "unavailable" in buf.getvalue(),
+                  repr(buf.getvalue()))
+    finally:
+        mod.IbusInjector = real_ibus_cls
+        mod._injector = None
+
+    # ---- 3b. the escape hatch: config edit alone switches back -----------
+    print("\n[3b] config-only escape hatch")
+    mod.IbusInjector = StubIbus
+    StubIbus.reachable = True
+    try:
+        first = fresh(mod, "ibus")
+        check("started on the IBus backend", type(first) is StubIbus)
+        mod.CONFIG["injection_method"] = "ydotool"   # a bare config edit
+        second = mod.get_injector()                  # no restart, no reset
+        check("editing injection_method alone switches back to ydotool",
+              type(second) is mod.YdotoolInjector, type(second))
+        check("...without needing the singleton to be cleared by hand",
+              second is not first)
+    finally:
+        mod.IbusInjector = real_ibus_cls
+        mod._injector = None
+        mod.CONFIG.pop("injection_method", None)
+
+    # ---- 4. capability probes -------------------------------------------
+    print("\n[4] capability probes")
+    inj = fresh(mod)
+    check("supports_preedit() is False (phase 1)", inj.supports_preedit() is False)
+    saved = mod._TYPING_TOOL
+    try:
+        for tool, want in [("ydotool", True), ("xdotool", True),
+                           ("clipboard", False), (None, False)]:
+            mod._TYPING_TOOL = tool
+            check(f"available() is {want} for _TYPING_TOOL={tool!r}",
+                  inj.available() is want, inj.available())
+    finally:
+        mod._TYPING_TOOL = saved
+    base = mod.Injector()
+    check("base Injector.available() is False", base.available() is False)
+    check("base Injector.supports_preedit() is False", base.supports_preedit() is False)
+    for meth, args in [("commit", ("x",)), ("type_text", ("x",)),
+                       ("send_backspaces", (1,)), ("replace_text", ("a", "b")),
+                       ("paste", ("x",))]:
+        try:
+            getattr(base, meth)(*args)
+            check(f"base Injector.{meth}() raises NotImplementedError", False, "no raise")
+        except NotImplementedError:
+            check(f"base Injector.{meth}() raises NotImplementedError", True)
+
+    # ---- 4b. the two-category rule ---------------------------------------
+    # TEXT (commit/type_text/...) and KEYS (press_enter) must never be merged:
+    # commit_text("\n") inserts a newline character, so a shell never runs the
+    # command. This check exists to fail loudly if a future sweep folds them.
+    print("\n[4b] text path and key path stay distinct")
+    y = mod.YdotoolInjector()
+    check("press_enter is its own method, not an alias of type_text",
+          mod.Injector.press_enter is not mod.Injector.type_text)
+    check("YdotoolInjector keeps them distinct",
+          type(y).press_enter is not type(y).type_text)
+    check("base Injector.press_enter() raises NotImplementedError",
+          _raises(mod.Injector(), "press_enter"))
+    check("the seam exposes no generic 'type_raw' any more",
+          not hasattr(mod.Injector, "type_raw"))
+
+    # ---- 5. static scan: nothing bypasses the seam -----------------------
+    print("\n[5] static scan — no injection call outside the seam")
+    src = open(SVC_PATH, encoding="utf-8").read().split("\n")
+    guarded = re.compile(
+        r"\b(type_at_cursor|_type_raw|_send_backspaces|replace_typed_text"
+        r"|_clipboard_paste|_reset_ydotoold|_detect_typing_tool|_TYPING_TOOL)\b")
+    # the implementation block + the YdotoolInjector body legitimately name them
+    impl_start = next(i for i, l in enumerate(src) if l.startswith("_TYPING_TOOL = None"))
+    seam_start = next(i for i, l in enumerate(src)
+                      if l.startswith("class YdotoolInjector("))
+    seam_end = next(i for i, l in enumerate(src) if l.startswith("_INJECTION_METHODS"))
+    strays = [(i + 1, l.strip()) for i, l in enumerate(src)
+              if guarded.search(l) and not (impl_start <= i < seam_start or
+                                            seam_start <= i < seam_end)]
+    check("no stray direct injection calls", not strays, strays)
+
+    # Restore-on-start must be SYNCHRONOUS and must run before the background
+    # typing-init thread: a crash leaves NO input method, so recovery cannot
+    # sit behind a daemon thread that may be scheduled arbitrarily late.
+    joined = "\n".join(src)
+    i_restore = joined.find('restore_prior_engine("service start")')
+    i_thread = joined.find("threading.Thread(target=_init_typing")
+    check("restore-on-start is present", i_restore != -1)
+    check("restore-on-start runs BEFORE the _init_typing thread starts",
+          i_restore != -1 and i_thread != -1 and i_restore < i_thread,
+          f"restore@{i_restore} thread@{i_thread}")
+    check("restore-on-start is not buried inside prepare()",
+          "def prepare" not in joined[max(0, i_restore - 400):i_restore])
+    print(f"       (impl block lines {impl_start+1}-{seam_start}, "
+          f"seam lines {seam_start+1}-{seam_end})")
+
+    # ---- 6. the typing-engine spell -------------------------------------
+    # "cast typing engine" must (a) always leave IBus -- including from
+    # "auto", which may already be on IBus -- and (b) describe the backend
+    # get_injector() actually built, never the config string it just wrote:
+    # an "ibus" request falls back to ydotool when IBus is unreachable, and
+    # that is precisely the state where a key CAN stick (#56).
+    # _save_config_flag() writes CONFIG_PATH, so point it at a temp file.
+    print("\n[6] typing-engine spell (injection_toggle)")
+    import json
+    import shutil
+    import tempfile
+
+    class Svc:  # just the two methods the op needs, bound to a bare object
+        _save_config_flag = mod.GnomeSpeaksService._save_config_flag
+        _spell_ctx_dbus = mod.GnomeSpeaksService._spell_ctx_dbus
+
+    svc = Svc()
+    real_path = mod.CONFIG_PATH
+    real_home = os.path.expanduser("~/.config/speech-to-cli/config.json")
+    home_before = open(real_home, "rb").read() if os.path.exists(real_home) else None
+    tmpdir = tempfile.mkdtemp(dir=_STATE)
+    mod.CONFIG_PATH = os.path.join(tmpdir, "config.json")
+
+    def toggle(start):
+        if start is None:
+            mod.CONFIG.pop("injection_method", None)
+        else:
+            mod.CONFIG["injection_method"] = start
+        mod._injector = None
+        mod._injector_method = None
+        reply = svc._spell_ctx_dbus("injection_toggle")
+        return reply or "", mod.CONFIG.get("injection_method"), mod.get_injector()
+
+    def on_disk():
+        with open(mod.CONFIG_PATH) as f:
+            return json.load(f).get("injection_method")
+
+    try:
+        mod.IbusInjector = StubIbus
+
+        StubIbus.reachable = True
+        reply, cfg, inj = toggle("ydotool")
+        check("ydotool -> ibus: config now 'ibus'", cfg == "ibus", cfg)
+        check("ydotool -> ibus: written to CONFIG_PATH", on_disk() == "ibus", on_disk())
+        check("ydotool -> ibus: backend is IBus", type(inj) is StubIbus, type(inj))
+        check("ydotool -> ibus: reply says input method",
+              "input method" in reply and "no key can stick" in reply, repr(reply))
+
+        reply, cfg, inj = toggle("ibus")
+        check("ibus -> ydotool: config now 'ydotool'", cfg == "ydotool", cfg)
+        check("ibus -> ydotool: backend is ydotool",
+              type(inj) is mod.YdotoolInjector, type(inj))
+        check("ibus -> ydotool: reply says virtual keyboard",
+              "virtual keyboard" in reply and "no key can stick" not in reply, repr(reply))
+
+        reply, cfg, inj = toggle("auto")
+        check("auto -> ydotool (escape hatch works from auto)", cfg == "ydotool", cfg)
+        check("auto -> ydotool: backend is ydotool",
+              type(inj) is mod.YdotoolInjector, type(inj))
+        check("auto -> ydotool: reply says virtual keyboard",
+              "virtual keyboard" in reply and "input method" not in reply, repr(reply))
+
+        reply, cfg, inj = toggle(None)
+        check("unset -> ibus", cfg == "ibus" and type(inj) is StubIbus, (cfg, type(inj)))
+        reply, cfg, inj = toggle("uinput")
+        check("unknown value (== ydotool) -> ibus", cfg == "ibus", cfg)
+
+        StubIbus.reachable = False
+        reply, cfg, inj = toggle("ydotool")
+        check("ibus unreachable: config still records the 'ibus' request", cfg == "ibus", cfg)
+        check("ibus unreachable: backend fell back to ydotool",
+              type(inj) is mod.YdotoolInjector, type(inj))
+        check("ibus unreachable: reply does NOT claim 'no key can stick'",
+              "no key can stick" not in reply, repr(reply))
+        check("ibus unreachable: reply says so",
+              "unreachable" in reply and "virtual keyboard" in reply, repr(reply))
+
+        mod.IbusInjector = None
+        reply, cfg, inj = toggle("ydotool")
+        check("no IBus backend at all: reply does NOT claim 'no key can stick'",
+              "no key can stick" not in reply and "virtual keyboard" in reply, repr(reply))
+
+        home_after = open(real_home, "rb").read() if os.path.exists(real_home) else None
+        check("the real ~/.config/speech-to-cli/config.json was not touched",
+              home_after == home_before)
+    finally:
+        mod.IbusInjector = real_ibus_cls
+        mod._injector = None
+        mod._injector_method = None
+        mod.CONFIG_PATH = real_path
+        mod.CONFIG.pop("injection_method", None)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    print()
+    if FAILS:
+        print(f"FAILED: {len(FAILS)}")
+        for f in FAILS:
+            print(f"  - {f}")
+        return 1
+    print("ALL SEAM CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/offline-handoff/fake_rec.py
+++ b/tests/repros/offline-handoff/fake_rec.py
@@ -1,0 +1,50 @@
+"""Synthetic recorder: 30 ms / 16 kHz / s16le frames emitted at REAL TIME.
+
+Models pw-record honestly: content is a function of WALL-CLOCK capture time,
+so when the pipe fills and this writer blocks, the audio of that interval is
+genuinely gone -- exactly what a real mic recorder does.
+
+sample[0] carries the capture frame index (small magnitude, ~45 rms, well
+under the 300 floor) so a consumer can reconstruct the capture timeline and
+detect dropouts.
+"""
+import math
+import os
+import struct
+import sys
+import time
+
+FRAME_BYTES = 960
+FRAME_SAMPLES = 480
+FRAME_S = 0.030
+SPEECH_MS = int(os.environ.get("FAKE_REC_SPEECH_MS", "4000"))
+# Simulates the USB mic being yanked: pw-record exits, stdout hits EOF.
+EXIT_MS = int(os.environ.get("FAKE_REC_EXIT_MS", "0"))
+
+_speech = []
+for i in range(FRAME_SAMPLES):
+    t = i / 16000.0
+    v = (6000 * math.sin(2 * math.pi * 130 * t)
+         + 3000 * math.sin(2 * math.pi * 260 * t)
+         + 1500 * math.sin(2 * math.pi * 520 * t)
+         + 900 * math.sin(2 * math.pi * 1300 * t))
+    _speech.append(int(max(-32000, min(32000, v))))
+_silence = [0] * FRAME_SAMPLES
+
+out = sys.stdout.buffer
+t0 = time.monotonic()
+n = 0
+while True:
+    target = t0 + n * FRAME_S
+    now = time.monotonic()
+    if now < target:
+        time.sleep(target - now)
+    elapsed = time.monotonic() - t0
+    if EXIT_MS and elapsed * 1000 >= EXIT_MS:
+        sys.exit(0)
+    idx = int(elapsed / FRAME_S)            # capture index, NOT write index
+    body = _speech if elapsed * 1000 < SPEECH_MS else _silence
+    frame = [min(idx, 32000)] + body[1:]
+    out.write(struct.pack('<480h', *frame))
+    out.flush()
+    n += 1

--- a/tests/repros/offline-handoff/repro_offline_handoff.py
+++ b/tests/repros/offline-handoff/repro_offline_handoff.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""Repros for PR #70 / issue #49 — the streaming-STT -> Wyoming handoff.
+
+Four cases, all driven through the REAL _streaming_stt_cycle with a REAL
+subprocess recorder on a REAL pipe (so pipe back-pressure is measured, not
+modelled) and the REAL speech-to-cli _rest_stt_fallback / breaker:
+
+  A  stop_listening() already requested when the WS connect gives up
+     -> the whole utterance recorded so far must still reach the recognizer
+  B  speech spoken during a long (10 s-class) failed connect
+     -> must reach the recognizer with no dropout
+  C  breaker open (Azure marked down) -> next press must not touch the WS
+  D  Azure healthy -> the WS still receives the complete frame stream
+
+Every case asserts on the CAPTURE TIMELINE recovered from the audio itself:
+fake_rec.py stamps sample[0] of each frame with its capture index, so a gap
+in the delivered indices is proof that audio was lost, not an inference.
+
+Usage:  GS_SVC_PATH=<service.py> python3 repro_offline_handoff.py [A B C D]
+
+ENV CONTRACT: GS_SVC_PATH is the only input -- the service.py under test. The
+worktree dir is derived from its dirname by the shared harness, so sibling
+modules always come from the same tree.
+
+BASELINE IS A PINNED SHA, NEVER A BRANCH. Against a moving ref this suite goes
+vacuous the moment its fix merges -- it starts comparing the fix to itself and
+passes forever:
+
+    GS_BASELINE_REF=79594dd     # last commit BEFORE #70 merged (as 7eaeb02)
+    git archive $GS_BASELINE_REF | tar -x -C <dir>
+    GS_SVC_PATH=<dir>/gnome-speaks-service.py python3 repro_offline_handoff.py
+
+Case I additionally needs #72 (merged as 848b855), so against 79594dd it fails
+for two independent reasons -- the missing Wyoming handoff AND the swallowed
+dead recorder. Verified 2026-09-06.
+
+STATE: owned entirely by the shared harness, which pins $XDG_STATE_HOME to a
+per-PID scratch dir BEFORE importing the service (CHRONICLE_PATH is computed at
+module import from it) and asserts the module's paths resolve inside it. This
+file must NOT set XDG_STATE_HOME itself: a fixed path here is shared between
+concurrent agents, and that is what made the chronicle suite read another
+process's writes as a service regression.
+"""
+import os
+import struct
+import sys
+import threading
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AUDIT = os.path.join(os.path.dirname(HERE), "service-audit")
+sys.path.insert(0, AUDIT)
+sys.path.insert(0, HERE)
+
+# XDG_STATE_HOME is deliberately NOT set here -- see STATE in the docstring.
+os.environ["SPEECH_FORCE_OFFLINE"] = "1"     # breaker forced: Wyoming direct
+
+import harness  # noqa: E402
+
+FRAME_BYTES = 960
+FRAME_MS = 30
+
+
+# --------------------------------------------------------------------------
+# instrumentation
+# --------------------------------------------------------------------------
+
+def capture_indices(pcm):
+    """Recover the capture-frame index stamped in sample[0] of each frame."""
+    out = []
+    for off in range(0, len(pcm) - FRAME_BYTES + 1, FRAME_BYTES):
+        out.append(struct.unpack_from('<h', pcm, off)[0])
+    return out
+
+
+def gaps(idx):
+    """[(after, before)] for every discontinuity > 1 in the capture timeline."""
+    return [(a, b) for a, b in zip(idx, idx[1:]) if b - a > 1]
+
+
+class FakeWS:
+    """Enough of websocket.WebSocket for _init_stt_ws_session/_parse_ws_msg."""
+
+    def __init__(self, script=()):
+        self.audio = bytearray()
+        self._inbox = list(script)
+        self._lock = threading.Lock()
+        self.closed = False
+
+    def send(self, data, opcode=None):
+        if isinstance(data, (bytes, bytearray)):
+            body = bytes(data)
+            hlen = struct.unpack_from('>H', body, 0)[0]
+            payload = body[2 + hlen:]
+            if payload[:4] == b"RIFF":
+                return                      # the WAV header stt.py prepends
+            with self._lock:
+                self.audio.extend(payload)
+
+    def recv(self):
+        import websocket
+        with self._lock:
+            if self._inbox:
+                return self._inbox.pop(0)
+        raise websocket.WebSocketTimeoutException("no message")
+
+    def settimeout(self, _t):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+def phrase_msg(text):
+    return ('Path: speech.phrase\r\nX-RequestId: x\r\n\r\n'
+            '{"RecognitionStatus":"Success","DisplayText":"%s",'
+            '"NBest":[{"Display":"%s"}]}' % (text, text))
+
+
+def build(speech_ms=4000, exit_ms=0):
+    """Load the service with every dangerous seam replaced, recorder = fake_rec."""
+    mod, _ = harness.load()
+    svc = harness.make_service(mod)
+
+    rec_env = dict(os.environ, FAKE_REC_SPEECH_MS=str(speech_ms),
+                   FAKE_REC_EXIT_MS=str(exit_ms))
+    mod._build_rec_cmd = lambda *a, **k: [sys.executable, "-u",
+                                          os.path.join(HERE, "fake_rec.py")]
+    mod._take_prewarmed_rec = lambda *a, **k: None
+    mod._invalidate_stt_ws = lambda *a, **k: None
+    mod.subprocess_env = rec_env
+
+    # Popen without the env kwarg would lose FAKE_REC_SPEECH_MS.
+    real_popen = mod.subprocess.Popen
+
+    def popen(cmd, **kw):
+        kw.setdefault("env", rec_env)
+        return real_popen(cmd, **kw)
+    mod.subprocess.Popen = popen
+
+    # Never type anything, never speak, never touch the real injector.
+    typed = []
+    class _Inj:
+        def available(self): return False
+        def supports_preedit(self): return False
+        def commit(self, text): typed.append(text)
+        def finalize(self, text): typed.append(text)
+        def replace_text(self, *a): pass
+        def send_backspaces(self, *a): pass
+        def type_text(self, *a): pass
+        def paste(self, text): typed.append(text)
+        def end(self): pass
+    mod.get_injector = lambda: _Inj()
+
+    # GLib.idle_add only QUEUES; with no main loop nothing runs, so record
+    # the calls instead of executing them (same as the real service here).
+    idle_calls = []
+    real_idle_add = mod.GLib.idle_add
+
+    def rec_idle_add(fn, *args, **kw):
+        idle_calls.append((getattr(fn, "__name__", str(fn)), args))
+        return 0
+    mod.GLib.idle_add = rec_idle_add
+    svc._idle_calls = idle_calls
+    svc._errors = [] 
+    svc._save_config_flag = lambda *a, **k: None    # never touch config.json
+    # Harnesses share ONE CONFIG dict and _reload_config_flags() re-reads JP's
+    # LIVE config into it -- a scenario that calls start_listening() would
+    # otherwise measure his desktop, not this code. Pin it per scenario.
+    svc._reload_config_flags = lambda *a, **k: None
+    svc._try_cast = lambda *a, **k: False
+    svc._wake_gate_blocks = lambda *a, **k: False
+    svc._idle_after_stt = lambda *a, **k: svc._set_state("idle")
+
+    # The recognizer seam: capture exactly what bytes reach offline STT.
+    seen = {"pcm": b"", "calls": 0}
+
+    def fake_transcribe(host, port, pcm, **kw):
+        seen["calls"] += 1
+        seen["pcm"] = bytes(pcm)
+        return "offline transcript"
+    mod.wyoming_mod.transcribe = fake_transcribe
+    import stt as stt_mod
+    stt_mod.wyoming.transcribe = fake_transcribe
+
+    def _no_azure(*a, **k):                          # hard guard: no WAN calls
+        raise AssertionError("repro tried to reach Azure REST")
+    stt_mod.get_http_session = _no_azure
+
+    mod.CONFIG["wyoming_host"] = "wyoming.invalid"   # in-process only
+    mod.CONFIG["dictation_mode"] = True
+    mod.state._cached_noise_threshold = None         # deterministic calibration
+    return mod, svc, seen, typed
+
+
+def run_cycle(mod, svc, timeout=40):
+    tok = svc._cancels.issue("stt-stream")
+    t = threading.Thread(target=svc._streaming_stt_cycle, args=(tok,), daemon=True)
+    t.start()
+    return tok, t
+
+
+def result(name, ok, detail):
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}: {detail}")
+    return ok
+
+
+# --------------------------------------------------------------------------
+# A — stop already requested when the connect gives up
+# --------------------------------------------------------------------------
+
+def case_a():
+    """stop_listening() during a pending connect must NOT discard the words.
+
+    A stop request means 'finish this utterance', not 'throw it away'; only
+    stop() (which cancels the token) discards.
+    """
+    mod, svc, seen, typed = build(speech_ms=4000)
+    CONNECT_S, STOP_AT_S = 1.6, 1.0
+
+    def slow_fail():
+        time.sleep(CONNECT_S)
+        raise OSError("simulated Azure unreachable")
+    mod._get_stt_ws = slow_fail
+
+    t_start = time.monotonic()
+    tok, th = run_cycle(mod, svc)
+    time.sleep(STOP_AT_S)
+    svc._stop_event.set()                 # hotkey: end the utterance, KEEP text
+    th.join(timeout=30)
+
+    idx = capture_indices(seen["pcm"])
+    expect = int(CONNECT_S * 1000 / FRAME_MS)
+    ok = (seen["calls"] == 1 and len(idx) >= expect * 0.8
+          and not gaps(idx) and typed == ["offline transcript"])
+    return result(
+        "A stop-pending-at-handoff",
+        ok,
+        f"{len(seen['pcm'])} B / {len(idx)} frames reached the recognizer "
+        f"(expected >= {int(expect * 0.8)} = {CONNECT_S:.1f}s of capture); "
+        f"gaps={gaps(idx)}; typed={typed}; elapsed={time.monotonic()-t_start:.1f}s")
+
+
+# --------------------------------------------------------------------------
+# B — speech during a long failed connect
+# --------------------------------------------------------------------------
+
+def case_b():
+    """A 10 s connect timeout must not cost the words spoken during it.
+
+    The pipe holds 65536 B = 2.048 s; anything the recorder produced after
+    that is lost unless something drains the pipe while the connect is
+    pending.
+    """
+    mod, svc, seen, typed = build(speech_ms=4000)
+    CONNECT_S = 6.0
+
+    def slow_fail():
+        time.sleep(CONNECT_S)
+        raise OSError("simulated Azure unreachable")
+    mod._get_stt_ws = slow_fail
+
+    tok, th = run_cycle(mod, svc)
+    time.sleep(CONNECT_S + 0.2)
+    svc._stop_event.set()                 # end the utterance right at handoff
+    th.join(timeout=30)
+
+    idx = capture_indices(seen["pcm"])
+    pipe_frames = 65536 // FRAME_BYTES    # 68 — what the pipe alone can hold
+    expect = int(CONNECT_S * 1000 / FRAME_MS)
+    ok = (len(idx) >= expect * 0.8 and not gaps(idx))
+    return result(
+        "B speech-during-failed-connect",
+        ok,
+        f"{len(idx)} frames delivered (pipe alone holds {pipe_frames}; "
+        f"the utterance is {expect}); gaps={gaps(idx)}; "
+        f"span={idx[0] if idx else '-'}..{idx[-1] if idx else '-'}")
+
+
+# --------------------------------------------------------------------------
+# C — breaker open: the next press must not wait on the WS
+# --------------------------------------------------------------------------
+
+def case_c():
+    """Breaker semantics: once Azure is marked down, the NEXT press pays no
+    connect timeout -- it is routed straight to the offline batch path.
+
+    SPEECH_FORCE_OFFLINE is removed here so the only thing that can route the
+    session offline is mark_azure_down() + a configured Wyoming host.
+    """
+    forced = os.environ.pop("SPEECH_FORCE_OFFLINE", None)
+    try:
+        return _case_c_body()
+    finally:
+        if forced is not None:
+            os.environ["SPEECH_FORCE_OFFLINE"] = forced
+        mod_reset = None
+
+
+def _case_c_body():
+    mod, svc, seen, typed = build(speech_ms=500)
+    calls = {"ws": 0}
+
+    def counted():
+        calls["ws"] += 1
+        time.sleep(10.0)
+        raise OSError("simulated Azure unreachable")
+    mod._get_stt_ws = counted
+    mod.stt_dispatch = lambda **kw: {"text": "batch offline transcript"}
+    mod.wyoming_mod.mark_azure_up()
+    assert not mod.wyoming_mod.skip_azure(), "breaker must start closed"
+    mod.wyoming_mod.mark_azure_down()
+    assert mod.wyoming_mod.skip_azure(), "mark_azure_down must trip skip_azure"
+
+    svc._set_state("idle")
+    t0 = time.monotonic()
+    r = svc.start_listening()
+    if getattr(svc, "_stt_thread", None):
+        svc._stt_thread.join(timeout=10)
+    elapsed = time.monotonic() - t0
+
+    ok = (r == "ok" and calls["ws"] == 0 and elapsed < 2.0
+          and typed == ["batch offline transcript"])
+    return result(
+        "C breaker-open-skips-ws",
+        ok,
+        f"start_listening={r}; _get_stt_ws calls={calls['ws']} (must be 0); "
+        f"elapsed={elapsed:.2f}s; typed={typed}")
+
+
+# --------------------------------------------------------------------------
+# D — Azure healthy: the WS still gets the whole stream
+# --------------------------------------------------------------------------
+
+def case_d():
+    mod, svc, seen, typed = build(speech_ms=1500)
+    ws = FakeWS(script=[phrase_msg("hello from azure")])
+    mod._get_stt_ws = lambda: (ws, True)
+
+    tok, th = run_cycle(mod, svc)
+    time.sleep(2.5)
+    svc._stop_event.set()
+    th.join(timeout=30)
+
+    idx = capture_indices(bytes(ws.audio))
+    ok = (len(idx) >= 60 and not gaps(idx) and seen["calls"] == 0
+          and typed == ["hello from azure"])
+    return result(
+        "D azure-healthy-unchanged",
+        ok,
+        f"{len(idx)} frames reached the WS; gaps={gaps(idx)}; "
+        f"offline recognizer calls={seen['calls']} (must be 0); typed={typed}")
+
+
+# --------------------------------------------------------------------------
+# E — the other ordering: stop arrives DURING the offline capture
+# --------------------------------------------------------------------------
+
+def case_e():
+    """stop_listening() after the handoff ends the capture and keeps the text.
+
+    Same invariant as A, opposite ordering: here stopping() goes true while
+    the offline VAD capture is already running.
+    """
+    mod, svc, seen, typed = build(speech_ms=4000)
+    CONNECT_S, STOP_AT_S = 1.0, 2.6
+
+    def slow_fail():
+        time.sleep(CONNECT_S)
+        raise OSError("simulated Azure unreachable")
+    mod._get_stt_ws = slow_fail
+
+    tok, th = run_cycle(mod, svc)
+    time.sleep(STOP_AT_S)
+    svc._stop_event.set()                 # hotkey mid-capture: KEEP the text
+    th.join(timeout=30)
+
+    idx = capture_indices(seen["pcm"])
+    expect = int(STOP_AT_S * 1000 / FRAME_MS)
+    ok = (len(idx) >= expect * 0.8 and not gaps(idx)
+          and typed == ["offline transcript"])
+    return result(
+        "E stop-during-offline-capture",
+        ok,
+        f"{len(idx)} frames delivered (utterance so far is {expect}); "
+        f"gaps={gaps(idx)}; typed={typed}")
+
+
+# --------------------------------------------------------------------------
+# F — stop() still means ABANDON
+# --------------------------------------------------------------------------
+
+def case_f():
+    """The counterpart invariant: a cancelled token discards the transcript.
+
+    Nothing above may be bought by typing text the user asked to abandon.
+    """
+    mod, svc, seen, typed = build(speech_ms=4000)
+
+    def slow_fail():
+        time.sleep(1.0)
+        raise OSError("simulated Azure unreachable")
+    mod._get_stt_ws = slow_fail
+
+    tok, th = run_cycle(mod, svc)
+    time.sleep(1.8)
+    svc._cancels.cancel_all()             # stop(): ABANDON the utterance
+    svc._stop_event.set()
+    th.join(timeout=30)
+
+    ok = (typed == [])
+    return result(
+        "F stop-abandons-transcript",
+        ok,
+        f"typed={typed} (must be empty); recognizer calls={seen['calls']}")
+
+
+# --------------------------------------------------------------------------
+# G — no Wyoming host: the 4-attempt WS budget is unchanged
+# --------------------------------------------------------------------------
+
+def case_g():
+    """Without an offline recognizer there is nowhere better to go, so the
+    original retry budget stays. Guards the one-strike rule from leaking
+    into installs that have no Wyoming server."""
+    forced = os.environ.pop("SPEECH_FORCE_OFFLINE", None)
+    try:
+        mod, svc, seen, typed = build(speech_ms=500)
+        mod.CONFIG["wyoming_host"] = ""          # in-process only
+        calls = {"ws": 0}
+
+        def counted():
+            calls["ws"] += 1
+            raise OSError("simulated Azure unreachable")
+        mod._get_stt_ws = counted
+        import stt as stt_mod
+        real_fallback = stt_mod._rest_stt_fallback
+        stt_mod._rest_stt_fallback = lambda *a, **k: ""
+        mod._rest_stt_fallback = lambda *a, **k: ""
+        try:
+            tok, th = run_cycle(mod, svc)
+            time.sleep(1.0)
+            svc._stop_event.set()
+            th.join(timeout=30)
+        finally:
+            stt_mod._rest_stt_fallback = real_fallback
+
+        ok = calls["ws"] == 4
+        return result("G no-wyoming-keeps-4-attempts", ok,
+                      f"_get_stt_ws attempts={calls['ws']} (must be 4)")
+    finally:
+        if forced is not None:
+            os.environ["SPEECH_FORCE_OFFLINE"] = forced
+
+
+# --------------------------------------------------------------------------
+# H — a recovered utterance must not also raise "STT WebSocket failed"
+# --------------------------------------------------------------------------
+
+def case_h():
+    """The user sees ONE outcome, not a contradiction.
+
+    Recovered offline -> no error notification (the log carries it).
+    Recovered nothing -> the connect failure IS the outcome, so it is raised.
+    """
+    mod, svc, seen, typed = build(speech_ms=1500)
+
+    def fail():
+        time.sleep(0.8)
+        raise OSError("simulated Azure unreachable")
+    mod._get_stt_ws = fail
+
+    tok, th = run_cycle(mod, svc)
+    time.sleep(1.2)
+    svc._stop_event.set()
+    th.join(timeout=30)
+    recovered_errors = [a[0] for n, a in svc._idle_calls if n == "_emit_error"]
+
+    # Same session, but the offline recognizer returns nothing.
+    mod2, svc2, seen2, typed2 = build(speech_ms=1500)
+    mod2._get_stt_ws = fail
+    import stt as stt_mod
+    stt_mod.wyoming.transcribe = lambda *a, **k: ""
+    mod2.wyoming_mod.transcribe = lambda *a, **k: ""
+    tok2, th2 = run_cycle(mod2, svc2)
+    time.sleep(1.2)
+    svc2._stop_event.set()
+    th2.join(timeout=30)
+    silent_errors = [a[0] for n, a in svc2._idle_calls if n == "_emit_error"]
+
+    ok = (typed == ["offline transcript"] and recovered_errors == []
+          and typed2 == [] and len(silent_errors) == 1
+          and "WebSocket failed" in silent_errors[0])
+    return result(
+        "H no-false-error-when-recovered", ok,
+        f"recovered: typed={typed} errors={recovered_errors}; "
+        f"unrecovered: typed={typed2} errors={silent_errors}")
+
+
+# --------------------------------------------------------------------------
+# I — mic yanked AND Azure down: the words survive, ONE actionable toast
+# --------------------------------------------------------------------------
+
+def case_i():
+    """The compound failure. #57/#48 says a lost mic is reported once and in
+    addition to the words; #49 adds an exit that never used to deliver words
+    at all. The lost mic outranks "STT WebSocket failed" -- it is the
+    actionable one, and two toasts bury it."""
+    mod, svc, seen, typed = build(speech_ms=4000, exit_ms=600)
+
+    def slow_fail():
+        time.sleep(1.0)
+        raise OSError("simulated Azure unreachable")
+    mod._get_stt_ws = slow_fail
+
+    tok, th = run_cycle(mod, svc)
+    th.join(timeout=30)
+
+    errors = [a[0] for n, a in svc._idle_calls if n == "_emit_error"]
+    idx = capture_indices(seen["pcm"])
+    ok = (typed == ["offline transcript"] and len(idx) >= 15
+          and len(errors) == 1 and "Microphone disconnected" in errors[0])
+    return result(
+        "I mic-yanked-and-azure-down", ok,
+        f"{len(idx)} frames recovered from the dead recorder; typed={typed}; "
+        f"errors={errors} (want exactly one, the microphone one)")
+
+
+CASES = {"A": case_a, "B": case_b, "C": case_c, "D": case_d,
+         "E": case_e, "F": case_f, "G": case_g, "H": case_h, "I": case_i}
+
+if __name__ == "__main__":
+    import logging
+    logging.disable(logging.CRITICAL)
+    want = [a.upper() for a in sys.argv[1:]] or list(CASES)
+    ok = True
+    for name in want:
+        try:
+            ok &= bool(CASES[name]())
+        except Exception as exc:
+            import traceback
+            traceback.print_exc()
+            ok = False
+            print(f"[FAIL] {name}: raised {exc!r}")
+    print("\nALL GREEN" if ok else "\nRED")
+    sys.exit(0 if ok else 1)

--- a/tests/repros/pin-lifecycle/repro_compound_pin_x_deadmic.py
+++ b/tests/repros/pin-lifecycle/repro_compound_pin_x_deadmic.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""COMPOSITION: the injector pin (#46) x the latched dead-recorder verdict (#57/#72).
+
+Neither suite can see this case on its own. lucid-dead-recorder never swaps the
+engine, so it only ever exercises one backend; lucid-pin-lifecycle never kills
+the recorder, so it never reaches the latched-verdict exit. The interesting
+question lives exactly where they overlap:
+
+    the mic is yanked mid-utterance, AFTER a "cast typing engine" swap
+
+Three guarantees have to survive together:
+
+  X1  #46: the words go to the backend that TYPED the live partial (the pin),
+      not to whatever get_injector() returns after the swap.
+  X2  #57: the dead mic is still reported -- exactly once, and IN ADDITION to
+      the text, never instead of it.
+  X3  #46 lifecycle: the pinned backend is released, and released AFTER it
+      delivered.  The release lives in the post-loop `finally`; the dead-mic
+      report is emitted after that `finally`.  If the release were ever hoisted
+      above the delivery, or swapped for cancel() (which DISCARDS rather than
+      flushes), the user would lose the words the report is promising it kept.
+
+exit 0 = all three hold, exit 1 = at least one is violated.
+"""
+import logging
+import atexit
+import shutil
+import os
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "..", "dead-recorder"))
+import fakes      # noqa: E402
+import harness    # noqa: E402
+
+logging.disable(logging.INFO)
+
+# Repo-relative by construction: this file lives at
+# tests/repros/<suite>/<file>.py, so four dirnames reach the repo root. #59:
+# the old defaults were absolute paths into ~/Projects/gnome-speaks-wt/<name>/
+# worktrees that no longer existed, so a bare run died with FileNotFoundError
+# instead of testing anything.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+# Scratch lives in the repo's gitignored tmp/, keyed by PID. Never a fixed
+# shared path: two agents running a suite at once used to corrupt each other
+# and it read exactly like a service regression.
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+# Clean up on exit, but ONLY a directory this process chose. repro_pin_lifecycle
+# forks a child per scenario with GS_REPRO_SCRATCH pointing INTO its own
+# scratch, so a child that cleaned up a caller-pinned path would delete the
+# still-running parent's tree out from under it -- the same reason the shared
+# harnesses read this variable with get() and never setdefault().
+_OWNED = "GS_REPRO_SCRATCH" not in os.environ
+SCRATCH = os.environ.get("GS_REPRO_SCRATCH") or os.path.join(SCRATCH_ROOT, f"pin-x-deadmic-{os.getpid()}")
+os.makedirs(SCRATCH, exist_ok=True)
+if _OWNED:
+    atexit.register(shutil.rmtree, SCRATCH, True)
+
+WINDOW = 8.0
+PHRASE = "the words the report promises it kept"
+
+
+class Backend:
+    """Records what reached the cursor and how the session was closed."""
+
+    def __init__(self, name):
+        self.name = name
+        self.ops = []        # [(op, text, monotonic)]
+        self.lifecycle = []
+
+    def prepare(self): return True
+    def acquire(self): self.lifecycle.append(("acquire", time.monotonic())); return True
+    def end(self): self.lifecycle.append(("end", time.monotonic())); return True
+    def cancel(self): self.lifecycle.append(("cancel", time.monotonic())); return True
+    def recover(self): return True
+    def available(self): return True
+    def purpose_known(self): return False
+    def supports_preedit(self): return False
+
+    def _op(self, op, text=""):
+        self.ops.append((op, text, time.monotonic())); return True
+
+    def commit(self, t): return self._op("commit", t)
+    def type_text(self, t): return self._op("type_text", t)
+    def paste(self, t): return self._op("paste", t)
+    def finalize(self, t): return self._op("finalize", t)
+    def set_preedit(self, t): return self._op("set_preedit", t)
+    def replace_text(self, o, nw): return self._op("replace_text", nw)
+    def send_backspaces(self, n): return self._op("send_backspaces", "")
+    def press_enter(self): return self._op("press_enter")
+
+    DELIVERY = ("commit", "paste", "finalize", "type_text")
+
+    def delivered_text(self):
+        return [t for op, t, _ in self.ops if op in self.DELIVERY and t]
+
+    def deliveries_at(self):
+        return [ts for op, _, ts in self.ops if op in self.DELIVERY]
+
+    def ends(self):
+        return [ts for op, ts in self.lifecycle if op == "end"]
+
+
+def main():
+    mod, _events, _rec = harness.load()
+    print(f"service under test: {harness.SVC_PATH}")
+
+    A, B = Backend("ydotool"), Backend("ibus")
+    registry = {"ydotool": A, "ibus": B}
+    cur = {"obj": A, "method": "ydotool"}
+    lock = threading.Lock()
+
+    def get_injector():
+        m = str(mod.CONFIG.get("injection_method") or "ydotool").lower()
+        with lock:
+            if m != cur["method"]:
+                cur["obj"].cancel()          # all the real rebuild does
+                cur["obj"] = registry.get(m, A)
+                cur["method"] = m
+            return cur["obj"]
+    mod.get_injector = get_injector
+
+    # Pin every flag the verdict rests on.
+    mod.CONFIG["injection_method"] = "ydotool"
+    mod.CONFIG["dictation_mode"] = True
+    mod.CONFIG["conversation_mode"] = False
+    mod.CONFIG["continuous_dictation"] = True     # loop: the mic-yank case JP hits
+    mod.CONFIG["skip_final_paste"] = False
+    mod.CONFIG["wake_word_secure_gate"] = False
+
+    errors = []
+    mod.GLib.idle_add = lambda fn, *a, **k: fn(*a, **k)
+
+    # A recorder that stays alive until we yank it, then behaves like pw-record:
+    # EOF and a non-None poll() arrive together.
+    class Yankable:
+        def __init__(self):
+            self.dead = threading.Event()
+            self.exited = False
+            outer = self
+
+            class Out:
+                def read(self, n):
+                    if outer.dead.is_set():
+                        outer.exited = True
+                        return b""
+                    time.sleep(0.01)
+                    return b"\x00" * n
+            self.stdout = Out()
+
+        def poll(self): return 1 if self.exited else None
+        def terminate(self): pass
+        def kill(self): pass
+        def wait(self, timeout=None): return 1
+
+    proc = Yankable()
+
+    class WS:
+        def settimeout(self, t): pass
+        def send(self, p, opcode=None): pass
+        def recv(self):
+            time.sleep(0.02)
+            return "MSG"
+
+    mod.HAS_WS = True
+    mod.HAS_VAD = False
+    mod._take_prewarmed_rec = lambda *a, **k: proc
+    mod._get_stt_ws = lambda *a, **k: (WS(), True)
+    mod._init_stt_ws_session = lambda *a, **k: None
+    mod._make_ws_audio_msg = lambda *a, **k: b""
+    mod.calibrate_noise = lambda p: (1000.0, [])
+    mod.rms_energy = lambda c: 5000.0
+    mod.is_speech_energy = lambda c, v, t: True
+    mod._rest_stt_fallback = lambda *a, **k: ""
+    mod._invalidate_stt_ws = lambda *a, **k: None
+
+    swapped = threading.Event()
+    step = {"n": 0}
+    served = []
+
+    def fake_parse(msg, phrases, partial_holder, end_word_event, end_word,
+                   _log, raw_partial_holder=None, use_lexical=False):
+        step["n"] += 1
+        if step["n"] == 1:
+            partial_holder[0] = PHRASE
+            if raw_partial_holder is not None:
+                raw_partial_holder[0] = PHRASE
+            return "hypothesis"
+        if step["n"] == 2:
+            # The live partial is really on screen through the PINNED backend.
+            harness.wait_for(lambda: bool(A.ops), 3.0)
+            # ... now the user casts the engine swap ...
+            box["svc"]._spell_ctx_dbus("injection_toggle")
+            swapped.set()
+            return "hypothesis"
+        # ... and THEN the USB mic is yanked.
+        # Append ONCE: the post-sender drain loop parses again after the
+        # receive loop breaks, and a second append would double the transcript
+        # (`user_text = " ".join(phrases)`) and read as "text was mangled".
+        if not served:
+            served.append(True)
+            phrases.append(PHRASE)
+            partial_holder[0] = PHRASE
+            proc.dead.set()
+            return "turn_end"
+        return None
+
+    mod._parse_ws_msg = fake_parse
+
+    box = {}
+    svc = harness.make_service(mod)
+    box["svc"] = svc
+    svc._stt_mode = "streaming"
+    svc._emit_error = lambda m: errors.append(m)
+
+    assert svc.start_listening() == "ok", "setup: start_listening refused"
+    assert swapped.wait(WINDOW), "setup: the engine swap never fired"
+    harness.wait_for(lambda: svc.current_state == "idle", WINDOW)
+    time.sleep(0.5)
+
+    print(f"  A(ydotool) ops={[o for o, _, _ in A.ops]} "
+          f"lifecycle={[o for o, _ in A.lifecycle]}")
+    print(f"  B(ibus)    ops={[o for o, _, _ in B.ops]} "
+          f"lifecycle={[o for o, _ in B.lifecycle]}")
+    print(f"  Error signals: {errors}")
+
+    failures = 0
+
+    # X1 -- the words went to the backend that typed them
+    if PHRASE in B.delivered_text():
+        failures += 1
+        print("    FAIL (X1): the transcript was delivered by the NEW backend "
+              "after the swap -- #46, on the dead-mic exit")
+    elif PHRASE not in A.delivered_text():
+        failures += 1
+        print(f"    FAIL (X1): the transcript never reached the cursor at all "
+              f"(A delivered {A.delivered_text()}) -- the dead recorder cost "
+              f"the user their words")
+    else:
+        print("    OK (X1): the words were delivered by the pinned backend")
+
+    # X2 -- the mic is still reported, exactly once, IN ADDITION to the text
+    mic = [e for e in errors if "icrophone" in e]
+    if len(mic) != 1:
+        failures += 1
+        print(f"    FAIL (X2): expected exactly one microphone Error, got "
+              f"{len(mic)}: {mic}")
+    else:
+        print("    OK (X2): the lost microphone was reported exactly once")
+
+    # X3 -- released, and released after delivering
+    d = A.deliveries_at()
+    if not A.ends():
+        failures += 1
+        print("    FAIL (X3): the pinned backend was never released -- it "
+              "re-acquired on the post-swap delivery and holds the input "
+              "method until SESSION_MAX_SECONDS")
+    elif d and not any(ts > d[-1] for ts in A.ends()):
+        failures += 1
+        print("    FAIL (X3): the pinned backend was released BEFORE its last "
+              "delivery -- a coalesced commit would be truncated, and the "
+              "dead-mic report would be promising words that never landed")
+    else:
+        print("    OK (X3): released, and only after the words were delivered")
+
+    print()
+    if failures:
+        print(f"FAIL: {failures} -- the pin and the dead-mic verdict do not compose")
+        return 1
+    print("PASS: words to the pinned backend, mic reported once, pin released "
+          "after delivery")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/pin-lifecycle/repro_compound_reply_pin.py
+++ b/tests/repros/pin-lifecycle/repro_compound_reply_pin.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""#87: the AI-reply <type> paste resolves get_injector() inside the pinned scope.
+
+Drives the REAL _streaming_stt_cycle in conversation mode -- not the reply
+worker on its own thread. That distinction is the whole point:
+
+  * production calls `self._conversation_worker(user_text)` SYNCHRONOUSLY from
+    inside the cycle (the line above is `inj.send_backspaces(...)`), so the
+    cycle's `finally` -- and its `inj.end()` from #61 -- runs AFTER the reply
+    finishes;
+  * every existing reply repro (subtitle e3/e4, begin-refused j/k/l) starts the
+    worker on its OWN thread, which does not have that release at all.
+
+A worker-only test therefore reports a strand that production does not have.
+This one keeps the cycle in the picture so the verdict is about the service.
+
+The window under test, on d92166c:
+
+    4583   get_injector().paste(type_text)          <- resolution #1
+    4588   if spoke_anything and half_duplex: sleep(0.5)
+    4591   self._set_state("idle") -> 1935 get_injector().end()   <- #2
+
+Assertions, per backend:
+  R1  the <type> paste landed on the backend the cycle PINNED
+  R2  every backend this utterance ACQUIRED was released (end or cancel)
+  R3  exactly one release of the backend that took the paste
+
+exit 0 = clean, exit 1 = at least one violated.
+"""
+import logging
+import atexit
+import shutil
+import os
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "..", "cancel-tokens"))
+import harness  # noqa: E402
+
+logging.disable(logging.INFO)
+# Repo-relative by construction: this file lives at
+# tests/repros/<suite>/<file>.py, so four dirnames reach the repo root. #59:
+# the old defaults were absolute paths into ~/Projects/gnome-speaks-wt/<name>/
+# worktrees that no longer existed, so a bare run died with FileNotFoundError
+# instead of testing anything.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+# Scratch lives in the repo's gitignored tmp/, keyed by PID. Never a fixed
+# shared path: two agents running a suite at once used to corrupt each other
+# and it read exactly like a service regression.
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+# Clean up on exit, but ONLY a directory this process chose. repro_pin_lifecycle
+# forks a child per scenario with GS_REPRO_SCRATCH pointing INTO its own
+# scratch, so a child that cleaned up a caller-pinned path would delete the
+# still-running parent's tree out from under it -- the same reason the shared
+# harnesses read this variable with get() and never setdefault().
+_OWNED = "GS_REPRO_SCRATCH" not in os.environ
+SCRATCH = os.environ.get("GS_REPRO_SCRATCH") or os.path.join(SCRATCH_ROOT, f"reply-pin-{os.getpid()}")
+os.makedirs(SCRATCH, exist_ok=True)
+if _OWNED:
+    atexit.register(shutil.rmtree, SCRATCH, True)
+
+REPLY = "Sure. <type>print('hello')</type>"
+
+
+class Backend:
+    def __init__(self, name):
+        self.name = name
+        self.acquired = False
+        self.ops = []
+        self.lifecycle = []
+
+    def prepare(self): return True
+
+    def acquire(self):
+        self.acquired = True
+        self.lifecycle.append(("acquire", time.monotonic())); return True
+
+    def end(self):
+        self.acquired = False
+        self.lifecycle.append(("end", time.monotonic())); return True
+
+    def cancel(self):
+        self.acquired = False
+        self.lifecycle.append(("cancel", time.monotonic())); return True
+
+    def recover(self): return True
+    def available(self): return True
+    def purpose_known(self): return False
+    def supports_preedit(self): return False
+
+    def _op(self, op, text=""):
+        self.acquired = True                    # every text op re-acquires
+        self.ops.append((op, text, time.monotonic())); return True
+
+    def commit(self, t): return self._op("commit", t)
+    def type_text(self, t): return self._op("type_text", t)
+    def paste(self, t): return self._op("paste", t)
+    def finalize(self, t): return self._op("finalize", t)
+    def set_preedit(self, t): return self._op("set_preedit", t)
+    def replace_text(self, o, n): return self._op("replace_text", n)
+    def send_backspaces(self, n): return self._op("send_backspaces")
+    def press_enter(self): return self._op("press_enter")
+
+    def pasted(self):
+        return [t for op, t, _ in self.ops if op == "paste"]
+
+    def releases(self):
+        return [ts for op, ts in self.lifecycle if op in ("end", "cancel")]
+
+
+class FakeStdout:
+    def __init__(self, n): self._f = b"\x00" * n
+    def read(self, n):
+        time.sleep(0.005); return self._f
+
+
+class FakeProc:
+    def __init__(self, n): self.stdout = FakeStdout(n)
+    def terminate(self): pass
+    def kill(self): pass
+    def poll(self): return None
+    def wait(self, timeout=None): return 0
+
+
+class FakeWS:
+    def __init__(self): self.closed = threading.Event()
+    def settimeout(self, t): pass
+    def send(self, p, opcode=None): pass
+    def recv(self):
+        if self.closed.is_set(): raise RuntimeError("closed")
+        time.sleep(0.02); return "MSG"
+
+
+def main():
+    mod, _events, _rec = harness.load()
+    print(f"service under test: {harness.SVC_PATH}")
+
+    A, B, C = Backend("ydotool"), Backend("ibus"), Backend("ydotool2")
+    reg = {"ydotool": A, "ibus": B, "ydotool2": C}
+    cur = {"obj": A, "method": "ydotool"}
+    lk = threading.Lock()
+
+    def get_injector():
+        m = str(mod.CONFIG.get("injection_method") or "ydotool").lower()
+        with lk:
+            if m != cur["method"]:
+                cur["obj"].cancel()          # the rebuild's only cleanup
+                cur["obj"] = reg.get(m, A)
+                cur["method"] = m
+            return cur["obj"]
+    mod.get_injector = get_injector
+
+    mod.CONFIG["injection_method"] = "ydotool"
+    mod.CONFIG["dictation_mode"] = True
+    mod.CONFIG["conversation_mode"] = True      # the reply path
+    mod.CONFIG["continuous_dictation"] = False
+    mod.CONFIG["half_duplex"] = True            # opens the 0.5 s window
+    mod.CONFIG["terminal_mode"] = True          # <type> tags are terminal-mode
+    mod.CONFIG["wake_word_secure_gate"] = False
+
+    # The reply: one sentence spoken, one <type> tag typed.
+    mod.stream_chat = lambda **kw: iter(["Sure. ", "<type>print('hello')</type>"])
+
+    proc, ws = FakeProc(mod.FRAME_BYTES), FakeWS()
+    mod.HAS_WS = True
+    mod.HAS_VAD = False
+    mod._take_prewarmed_rec = lambda *a, **k: proc
+    mod._get_stt_ws = lambda *a, **k: (ws, True)
+    mod._init_stt_ws_session = lambda *a, **k: None
+    mod._make_ws_audio_msg = lambda *a, **k: b""
+    mod.calibrate_noise = lambda p: (1000.0, [])
+    mod.rms_energy = lambda c: 5000.0
+    mod.is_speech_energy = lambda c, v, t: True
+    mod._rest_stt_fallback = lambda *a, **k: ""
+    mod._invalidate_stt_ws = lambda *a, **k: None
+
+    served = []
+
+    def fake_parse(msg, phrases, partial_holder, end_word_event, end_word,
+                   _log, raw_partial_holder=None, use_lexical=False):
+        if not served:
+            served.append(True)
+            phrases.append("write me a hello world")
+            partial_holder[0] = "write me a hello world"
+            return "turn_end"
+        return None
+    mod._parse_ws_msg = fake_parse
+
+    # THE EVENT UNDER TEST: the user casts "typing engine" while the reply is
+    # typing -- placed deterministically inside the paste itself, which is the
+    # top of the 0.5 s half-duplex window between the two resolutions.
+    swaps = {"n": 0}
+    orig_paste = {}
+    for be in (A, B, C):
+        orig_paste[be.name] = be.paste
+
+    def make_paste(be):
+        def paste(t):
+            r = orig_paste[be.name](t)
+            if swaps["n"] == 0:                 # first paste only
+                swaps["n"] += 1
+                mod.CONFIG["injection_method"] = "ibus"
+            return r
+        return paste
+    for be in (A, B, C):
+        be.paste = make_paste(be)
+
+    svc = harness.make_service(mod)
+    svc._stt_mode = "streaming"
+    assert svc.start_listening() == "ok", "setup: start_listening refused"
+    harness.wait_for(lambda: svc.current_state == "idle", 25.0)
+    time.sleep(0.8)
+    ws.closed.set()
+
+    for be in (A, B, C):
+        ops = str([o for o, _, _ in be.ops])
+        print(f"  {be.name:9s} ops={ops:<44} "
+              f"lifecycle={[o for o, _ in be.lifecycle]} acquired={be.acquired}")
+    print(f"  swaps fired: {swaps['n']}")
+
+    failures = 0
+    pasters = [be for be in (A, B, C) if be.pasted()]
+    if not pasters:
+        print("    SETUP FAILURE: the <type> paste never happened at all")
+        return 2
+    if swaps["n"] == 0:
+        print("    SETUP FAILURE: the engine swap never fired")
+        return 2
+
+    paster = pasters[0]
+    # R1 -- the paste belongs to the backend the cycle pinned (A: pinned before
+    # the swap, and the swap only fires DURING the paste).
+    if paster is not A:
+        failures += 1
+        print(f"    FAIL (R1): the <type> paste landed on {paster.name}, not on "
+              f"the pinned backend")
+    else:
+        print("    OK (R1): the <type> paste landed on the pinned backend")
+
+    # R2 -- nothing this utterance acquired may be left holding the IME.
+    stranded = [be.name for be in (A, B, C) if be.acquired]
+    if stranded:
+        failures += 1
+        print(f"    FAIL (R2): {stranded} left acquired -- holds the input "
+              f"method until SESSION_MAX_SECONDS=120")
+    else:
+        print("    OK (R2): every backend this utterance touched was released")
+
+    # R3 -- the paster is released, after its paste.
+    last = paster.ops[-1][2]
+    after = [ts for ts in paster.releases() if ts > last]
+    if not after:
+        failures += 1
+        print(f"    FAIL (R3): {paster.name} was never released after its paste")
+    else:
+        print(f"    OK (R3): {paster.name} released after its paste")
+
+    print()
+    if failures:
+        print(f"FAIL: {failures} -- the reply path and the cycle's pin do not compose")
+        return 1
+    print("PASS: paste on the pinned backend, nothing left holding the IME")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/pin-lifecycle/repro_pin_lifecycle.py
+++ b/tests/repros/pin-lifecycle/repro_pin_lifecycle.py
@@ -1,0 +1,686 @@
+#!/usr/bin/env python3
+"""Issue #46 / PR #61: the per-cycle injector pin must also be RELEASED.
+
+PR #61 pins `inj = get_injector()` once per STT cycle so a mid-utterance
+"cast typing engine" cannot retract with the wrong backend.  That half is
+necessary and this repro guards it (P1a/P2a).  But pinning alone strands an
+input method:
+
+  * `get_injector()` rebuilds on a config flip and only `cancel()`s the
+    outgoing backend.
+  * A cancelled `IbusInjector` RE-ACQUIRES on its next replace_text /
+    type_text / commit -- and the cycle keeps typing through the pin, so it
+    does exactly that.
+  * The only `end()` on the path is the idle hook
+    (`_set_state('idle')` -> `get_injector().end()`), which ends whatever is
+    CURRENT.  After a swap that is a different object from the pin.
+
+  => the swapped-away backend holds the user's input method until
+     `SESSION_MAX_SECONDS = 120` (ibus_injector.py).  Per CLAUDE.md that is
+     the "no input method at all" hazard, not merely "the wrong one".
+
+Assertions
+  P1  single-shot, swap mid-utterance (the deterministic POST /cast trigger)
+      a. every text op for the utterance went to the PINNED backend
+      b. the pinned backend was end()ed -- not left acquired
+  P2  loop mode, swap during cycle 1 (the racy spoken-cast trigger:
+      _drain_speech_gap returns instantly on an empty queue, so the next
+      cycle re-pins right as the spell thread flips CONFIG)
+      a. cycle 1's text ops went to the pinned backend
+      b. the outgoing backend was end()ed AT THE RE-PIN -- strictly before
+         cycle 2 put any text through the new one
+      c. no backend is left acquired-but-not-ended when the worker returns
+
+Run:  GS_SVC_PATH=<path to a gnome-speaks-service.py> python3 repro_pin_lifecycle.py
+exit 0 = clean, exit 1 = bug present.
+"""
+import logging
+import atexit
+import shutil
+import os
+import subprocess
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "..", "cancel-tokens"))
+import harness  # noqa: E402
+
+logging.disable(logging.INFO)  # the service is chatty; assertions are the output
+
+# Scratch isolation, same idiom as the other suites (2026-09-06 sweep): get(),
+# never setdefault -- setdefault EXPORTS the value, so a scenario child would
+# inherit the PARENT's directory and the per-PID isolation would collapse to a
+# shared path. The parent passes it down deliberately instead (see main()).
+# Repo-relative by construction: this file lives at
+# tests/repros/<suite>/<file>.py, so four dirnames reach the repo root. #59:
+# the old defaults were absolute paths into ~/Projects/gnome-speaks-wt/<name>/
+# worktrees that no longer existed, so a bare run died with FileNotFoundError
+# instead of testing anything.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+# Scratch lives in the repo's gitignored tmp/, keyed by PID. Never a fixed
+# shared path: two agents running a suite at once used to corrupt each other
+# and it read exactly like a service regression.
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+# Clean up on exit, but ONLY a directory this process chose. repro_pin_lifecycle
+# forks a child per scenario with GS_REPRO_SCRATCH pointing INTO its own
+# scratch, so a child that cleaned up a caller-pinned path would delete the
+# still-running parent's tree out from under it -- the same reason the shared
+# harnesses read this variable with get() and never setdefault().
+_OWNED = "GS_REPRO_SCRATCH" not in os.environ
+SCRATCH = os.environ.get("GS_REPRO_SCRATCH") or os.path.join(SCRATCH_ROOT, f"pin-lifecycle-{os.getpid()}")
+os.makedirs(SCRATCH, exist_ok=True)
+if _OWNED:
+    atexit.register(shutil.rmtree, SCRATCH, True)
+
+
+class FakeBackend:
+    """One injection backend, with the lifecycle facts we need to assert on.
+
+    Models the two properties that make the leak real:
+      * cancel() drops the session (that is all the rebuild does)
+      * ANY text op re-acquires it   (IbusInjector.commit -> acquire())
+    """
+
+    def __init__(self, name, preedit):
+        self.name = name
+        self._preedit = preedit
+        self.acquired = False
+        self.ops = []        # [(op, monotonic)] -- text ops only
+        self.lifecycle = []  # [(op, monotonic)] -- acquire/end/cancel
+
+    # -- lifecycle ---------------------------------------------------------
+    def prepare(self):
+        return True
+
+    def acquire(self):
+        self.acquired = True
+        self.lifecycle.append(("acquire", time.monotonic()))
+        return True
+
+    def end(self):
+        self.acquired = False
+        self.lifecycle.append(("end", time.monotonic()))
+        return True
+
+    def cancel(self):
+        self.acquired = False
+        self.lifecycle.append(("cancel", time.monotonic()))
+        return True
+
+    def recover(self):
+        return True
+
+    def available(self):
+        return True
+
+    def purpose_known(self):
+        return False
+
+    def supports_preedit(self):
+        return self._preedit
+
+    # -- text ops (every one of these re-acquires, like IbusInjector) ------
+    def _text(self, op):
+        self.acquired = True
+        self.ops.append((op, time.monotonic()))
+        return True
+
+    def commit(self, text):
+        return self._text("commit")
+
+    def type_text(self, text):
+        return self._text("type_text")
+
+    def paste(self, text):
+        return self._text("paste")
+
+    def set_preedit(self, text):
+        return self._text("set_preedit")
+
+    def replace_text(self, old, new):
+        return self._text("replace_text")
+
+    def send_backspaces(self, count):
+        return self._text("send_backspaces")
+
+    def finalize(self, text):
+        return self._text("finalize")
+
+    def press_enter(self):
+        return self._text("press_enter")
+
+    # -- assertions --------------------------------------------------------
+    def first_op_at(self):
+        return self.ops[0][1] if self.ops else None
+
+    def ends(self):
+        return [t for op, t in self.lifecycle if op == "end"]
+
+    DELIVERY = ("commit", "paste", "finalize", "type_text")
+
+    def deliveries(self):
+        """Ops that actually put final text in the field. On IBus these are
+        COALESCED -- end() flushes the buffer (`_flush(allowed=True)`), while
+        cancel() discards it -- so when they happen relative to end()/cancel()
+        is the whole question."""
+        return [t for op, t in self.ops if op in self.DELIVERY]
+
+    def end_before_delivery(self):
+        """An end() landing between the first and last delivery would flush a
+        half-finished utterance; one landing before any delivery on a backend
+        that then delivers means the release was hoisted above the text."""
+        d = self.deliveries()
+        if not d:
+            return False
+        return any(d[0] <= t < d[-1] for t in self.ends())
+
+    def released_after_delivery(self):
+        d = self.deliveries()
+        return bool(d) and any(t > d[-1] for t in self.ends())
+
+    def stranded(self):
+        """Acquired, and no end() after the last text op."""
+        if not self.ops:
+            return False
+        last_op = self.ops[-1][1]
+        return self.acquired and not any(t > last_op for t in self.ends())
+
+
+class FakeStdout:
+    def __init__(self, frame_bytes):
+        self._frame = b"\x00" * frame_bytes
+
+    def read(self, n):
+        time.sleep(0.005)
+        return self._frame
+
+
+class FakeProc:
+    def __init__(self, frame_bytes):
+        self.stdout = FakeStdout(frame_bytes)
+        self.terminated = False
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.terminated = True
+
+    def poll(self):
+        return 0 if self.terminated else None
+
+    def wait(self, timeout=None):
+        return 0
+
+
+class FakeWS:
+    def __init__(self):
+        self.closed = threading.Event()
+
+    def settimeout(self, t):
+        pass
+
+    def send(self, payload, opcode=None):
+        if self.closed.is_set():
+            raise RuntimeError("ws closed")
+
+    def recv(self):
+        if self.closed.is_set():
+            raise RuntimeError("ws closed")
+        time.sleep(0.02)
+        return "MSG"
+
+
+def build(loop_mode):
+    """Wire the real service up to fake audio/WS and a two-backend registry."""
+    mod, _events, _rec = harness.load()
+
+    A = FakeBackend("ydotool", preedit=False)
+    B = FakeBackend("ibus", preedit=True)
+    registry = {"ydotool": A, "ibus": B}
+    cur = {"obj": A, "method": "ydotool"}
+    reg_lock = threading.Lock()
+
+    def get_injector():
+        """Mirrors the real one: rebuild on method change, cancel() the old."""
+        method = str(mod.CONFIG.get("injection_method") or "ydotool").lower()
+        with reg_lock:
+            if method != cur["method"]:
+                cur["obj"].cancel()          # the ONLY thing the rebuild does
+                cur["obj"] = registry.get(method, A)
+                cur["method"] = method
+            return cur["obj"]
+
+    mod.get_injector = get_injector
+    # Real _save_config_flag semantics (CONFIG[key] = value) with the disk
+    # write removed: a repro must NEVER touch ~/.config/speech-to-cli/config.json.
+    def _save_flag(self, key, value):
+        mod.CONFIG[key] = value
+    mod.GnomeSpeaksService._save_config_flag = _save_flag
+    # ...and never let it READ that file back over the scenario's flags:
+    # start_listening() calls _reload_config_flags(), which copies every
+    # _SYNC_FLAGS key off disk into CONFIG. Without this stub the repro runs
+    # against whatever mode JP's desktop happens to be in -- measured: it
+    # silently reset continuous_dictation and the loop scenario never looped.
+    mod.GnomeSpeaksService._reload_config_flags = lambda self, *a, **k: None
+    # Pin every flag this repro's verdict depends on. harness.load() already
+    # neutralizes the CONFIG_PATH read, but the verdict must not rest on that.
+    mod.CONFIG["injection_method"] = "ydotool"
+    mod.CONFIG["dictation_mode"] = True
+    mod.CONFIG["conversation_mode"] = False
+    mod.CONFIG["continuous_dictation"] = loop_mode
+    mod.CONFIG["skip_final_paste"] = False
+    mod.CONFIG["wake_word_secure_gate"] = False
+
+    proc = FakeProc(mod.FRAME_BYTES)
+    ws = FakeWS()
+    mod.HAS_WS = True
+    mod.HAS_VAD = False
+    mod._take_prewarmed_rec = lambda *a, **k: proc
+    mod._get_stt_ws = lambda *a, **k: (ws, True)
+    mod._init_stt_ws_session = lambda *a, **k: None
+    mod._make_ws_audio_msg = lambda *a, **k: b""
+    mod.calibrate_noise = lambda p: (1000.0, [])
+    mod.rms_energy = lambda chunk: 5000.0
+    mod.is_speech_energy = lambda chunk, vad, thr: True
+    mod._rest_stt_fallback = lambda *a, **k: ""
+    return mod, ws, A, B
+
+
+def cast_typing_engine(svc):
+    """Fire the real spell the way /cast and a spoken cast do: on another
+    thread, and note that _spell_ctx_dbus('injection_toggle') itself calls
+    get_injector() to compose its reply -- so the REBUILD (and the outgoing
+    backend's cancel()) lands before the STT cycle types another character."""
+    box = {}
+
+    def go():
+        box["reply"] = svc._spell_ctx_dbus("injection_toggle")
+
+    t = threading.Thread(target=go, name="spell-thread")
+    t.start()
+    t.join(5.0)
+    return box.get("reply")
+
+
+def run_p1():
+    """Single-shot: swap the engine mid-utterance, after live text is typed."""
+    mod, ws, A, B = build(loop_mode=False)
+    swapped = threading.Event()
+    step = {"n": 0}
+    box = {}
+
+    def fake_parse(msg, phrases, partial_holder, end_word_event, end_word,
+                   _log, raw_partial_holder=None, use_lexical=False):
+        step["n"] += 1
+        if step["n"] == 1:
+            partial_holder[0] = "alpha"
+            if raw_partial_holder is not None:
+                raw_partial_holder[0] = "alpha"
+            return "hypothesis"
+        if step["n"] == 2:
+            # Wait until the live typer really put text on screen through the
+            # pinned backend -- that is what makes the retract ambiguous.
+            harness.wait_for(lambda: bool(A.ops), 3.0)
+            cast_typing_engine(box["svc"])       # <= POST /cast typing-engine
+            swapped.set()
+            return "hypothesis"
+        phrases.append("alpha beta")
+        partial_holder[0] = "alpha beta"
+        return "turn_end"
+
+    mod._parse_ws_msg = fake_parse
+    svc = harness.make_service(mod)
+    box["svc"] = svc
+    svc._stt_mode = "streaming"
+    assert svc.start_listening() == "ok", "setup: start_listening refused"
+    assert swapped.wait(6.0), "setup: the engine swap never fired"
+    harness.wait_for(lambda: svc.current_state == "idle", 8.0)
+    time.sleep(0.4)
+    ws.closed.set()
+    return A, B
+
+
+class MinimalBackend:
+    """A backend that implements the seam and nothing more -- notably NO
+    `name`, which the Injector base supplies a default for precisely so a
+    partial backend degrades instead of crashing (injector.py).
+
+    A real one arrived from the offline-handoff suite's `_Inj`, and it found a
+    genuine bug: an unguarded `inj.name` in the re-pin's DIAGNOSTIC took the
+    whole STT cycle down with an AttributeError -- 0 frames to the recognizer,
+    nothing typed, on the ordinary healthy-Azure path.
+    """
+
+    def prepare(self): return True
+    def acquire(self): return True
+    def end(self): return True
+    def cancel(self): return True
+    def recover(self): return True
+    def available(self): return True
+    def purpose_known(self): return False
+    def supports_preedit(self): return False
+
+    def __init__(self): self.text = []
+    def commit(self, t): self.text.append(t); return True
+    def type_text(self, t): return True
+    def paste(self, t): self.text.append(t); return True
+    def finalize(self, t): self.text.append(t); return True
+    def set_preedit(self, t): return True
+    def replace_text(self, o, n): return True
+    def send_backspaces(self, n): return True
+    def press_enter(self): return True
+
+
+def run_p3():
+    """Swapping TO a backend with no `name` must not crash the cycle.
+
+    Config-driven flip (what prefs.js does when it writes injection_method),
+    not the spell -- `_spell_ctx_dbus` reads `get_injector().name` itself, so
+    routing through it would be measuring that line rather than the re-pin.
+    """
+    # LOOP mode: the re-pin runs at the TOP of a cycle, so a single-shot
+    # session never reaches it and would "pass" without executing the line
+    # under test at all. (Measured: the single-shot version of this scenario
+    # passed against the unguarded build.)
+    mod, ws, A, _B = build(loop_mode=True)
+    partial = MinimalBackend()
+    real_get = mod.get_injector
+
+    def get_injector():
+        if str(mod.CONFIG.get("injection_method") or "").lower() == "ibus":
+            return partial
+        return real_get()
+    mod.get_injector = get_injector
+
+    cycles = {}
+    steps = {}
+    done = set()             # cycles whose phrase has already been appended
+    swapped = threading.Event()
+
+    def fake_parse(msg, phrases, partial_holder, end_word_event, end_word,
+                   _log, raw_partial_holder=None, use_lexical=False):
+        key = id(phrases)
+        if key not in cycles:
+            cycles[key] = len(cycles) + 1
+            steps[key] = 0
+        cyc = cycles[key]
+        steps[key] += 1
+        idx = steps[key]
+        if idx == 1:
+            partial_holder[0] = f"cycle {cyc} alpha"
+            if raw_partial_holder is not None:
+                raw_partial_holder[0] = f"cycle {cyc} alpha"
+            return "hypothesis"
+        if cyc == 1 and idx == 2:
+            harness.wait_for(lambda: bool(A.ops), 3.0)
+            mod.CONFIG["injection_method"] = "ibus"    # prefs.js writes the key
+            swapped.set()
+            return "hypothesis"
+        if steps[key] > 90 or key in done:
+            return None            # drain loop: do not append twice
+        done.add(key)
+        if cyc >= 2:
+            mod.CONFIG["continuous_dictation"] = False
+        phrases.append(f"cycle {cyc} beta")
+        partial_holder[0] = f"cycle {cyc} beta"
+        return "turn_end"
+
+    mod._parse_ws_msg = fake_parse
+    svc = harness.make_service(mod)
+    svc._stt_mode = "streaming"
+    errors = []
+    svc._emit_error = lambda m: errors.append(m)
+    assert svc.start_listening() == "ok", "setup: start_listening refused"
+    assert swapped.wait(6.0), "setup: the swap never fired"
+    harness.wait_for(lambda: len(cycles) >= 2, 10.0)
+    harness.wait_for(lambda: svc.current_state == "idle", 10.0)
+    time.sleep(0.4)
+    ws.closed.set()
+    return A, partial, errors, len(cycles)
+
+
+def run_p2():
+    """Loop mode: swap during cycle 1; cycle 2 must re-pin AND release."""
+    mod, ws, A, B = build(loop_mode=True)
+    swapped = threading.Event()
+    cycles = {}      # id(phrases) -> cycle number
+    steps = {}       # id(phrases) -> messages delivered this cycle
+    order = []
+    marks = {}       # 'swap' / 'cycle2' -> monotonic, for window assertions
+    box = {}
+
+    def fake_parse(msg, phrases, partial_holder, end_word_event, end_word,
+                   _log, raw_partial_holder=None, use_lexical=False):
+        key = id(phrases)
+        if key not in cycles:
+            cycles[key] = len(cycles) + 1
+            steps[key] = 0
+            if cycles[key] == 2:
+                marks["cycle2"] = time.monotonic()
+        cyc = cycles[key]
+        steps[key] += 1
+        idx = steps[key]
+        order.append((cyc, idx))
+
+        if idx == 1:
+            partial_holder[0] = f"cycle {cyc} alpha"
+            if raw_partial_holder is not None:
+                raw_partial_holder[0] = f"cycle {cyc} alpha"
+            return "hypothesis"
+        if cyc == 1 and idx == 2:
+            # The live text is really on screen through the pinned backend --
+            # NOW flip the engine, exactly as the spoken cast's thread does.
+            harness.wait_for(lambda: bool(A.ops), 3.0)
+            marks["swap"] = time.monotonic()
+            cast_typing_engine(box["svc"])       # <= the spoken cast lands
+            swapped.set()
+            return "hypothesis"
+        if cyc >= 2:
+            mod.CONFIG["continuous_dictation"] = False   # unwind after cycle 2
+        phrases.append(f"cycle {cyc} beta")
+        partial_holder[0] = f"cycle {cyc} beta"
+        return "turn_end"
+
+    mod._parse_ws_msg = fake_parse
+    svc = harness.make_service(mod)
+    box["svc"] = svc
+    svc._stt_mode = "streaming"
+    assert svc.start_listening() == "ok", "setup: start_listening refused"
+    assert swapped.wait(6.0), "setup: the engine swap never fired"
+    harness.wait_for(lambda: len(cycles) >= 2, 10.0)
+    harness.wait_for(lambda: svc.current_state == "idle", 10.0)
+    time.sleep(0.4)
+    ws.closed.set()
+    return A, B, len(cycles), marks
+
+
+def scenario_p1():
+    failures = 0
+    print("  P1: single-shot, engine swapped mid-utterance")
+    A, B = run_p1()
+    print(f"    A(ydotool) ops={[o for o, _ in A.ops]} "
+          f"lifecycle={[o for o, _ in A.lifecycle]}")
+    print(f"    B(ibus)    ops={[o for o, _ in B.ops]} "
+          f"lifecycle={[o for o, _ in B.lifecycle]}")
+    if not A.ops:
+        failures += 1
+        print("    FAIL (P1a): nothing was typed through the pinned backend")
+    elif B.ops:
+        failures += 1
+        print(f"    FAIL (P1a): {len(B.ops)} op(s) ({[o for o, _ in B.ops]}) went "
+              f"to the NEW backend mid-utterance -- this is #46, the "
+              f"wrong-backend retraction")
+    else:
+        print("    OK (P1a): the whole utterance stayed on the pinned backend")
+    if not A.ends():
+        failures += 1
+        print("    FAIL (P1b): the pinned backend was never end()ed. It was "
+              "cancel()ed by the rebuild, then RE-ACQUIRED by the retract "
+              "(_ensure_session -> acquire), and now holds the input method "
+              "until SESSION_MAX_SECONDS=120s")
+    elif A.stranded():
+        failures += 1
+        print("    FAIL (P1b): pinned backend still acquired after its last op")
+    else:
+        print("    OK (P1b): the pinned backend was handed back")
+    failures += check_release_ordering("P1c", A, B)
+    return failures
+
+
+def scenario_p2():
+    failures = 0
+    print("  P2: loop mode, engine swapped during cycle 1")
+    A, B, ncycles, marks = run_p2()
+    print(f"    cycles observed: {ncycles}")
+    print(f"    A(ydotool) ops={[o for o, _ in A.ops]} "
+          f"lifecycle={[o for o, _ in A.lifecycle]}")
+    print(f"    B(ibus)    ops={[o for o, _ in B.ops]} "
+          f"lifecycle={[o for o, _ in B.lifecycle]}")
+    if ncycles < 2:
+        print("    FAIL (setup): the loop never reached a second cycle")
+        return failures + 1
+    swap_at, cycle2_at = marks.get("swap"), marks.get("cycle2")
+    # Cycle 1's FINAL ops land after the swap but before cycle 2 opens. That
+    # window is the whole question: they belong to the backend cycle 1 pinned.
+    a_after_swap = [o for o, t in A.ops if swap_at and t > swap_at]
+    b_before_c2 = [o for o, t in B.ops if cycle2_at and t < cycle2_at]
+    if not A.ops:
+        failures += 1
+        print("    FAIL (P2a): cycle 1 typed nothing through the pin")
+    elif b_before_c2:
+        failures += 1
+        print(f"    FAIL (P2a): cycle 1's final ops {b_before_c2} went to the "
+              f"NEW backend -- the mid-utterance swap reached the cursor (#46)")
+    elif not a_after_swap:
+        failures += 1
+        print("    FAIL (P2a): nothing reached the pinned backend after the "
+              "swap -- cycle 1's final text went nowhere")
+    else:
+        print(f"    OK (P2a): cycle 1's post-swap ops {a_after_swap} stayed on "
+              f"the pinned backend")
+    ends = A.ends()
+    if not ends:
+        failures += 1
+        print("    FAIL (P2b): the outgoing backend was never end()ed at the "
+              "re-pin -- only cancel()ed, and it re-acquired on cycle 1's "
+              "final commit")
+    elif cycle2_at and not any(swap_at < t for t in ends):
+        failures += 1
+        print("    FAIL (P2b): the outgoing backend was not released after "
+              "the swap")
+    elif B.ops and not any(t < B.first_op_at() for t in ends):
+        failures += 1
+        print("    FAIL (P2b): the outgoing backend was not released before "
+              "cycle 2 started typing through the new one")
+    else:
+        print("    OK (P2b): the outgoing backend was released at the re-pin")
+    stranded = [be.name for be in (A, B) if be.stranded()]
+    if stranded:
+        failures += len(stranded)
+        print(f"    FAIL (P2c): {stranded} left acquired with no end() after "
+              f"the last op -- stranded until the 120 s watchdog")
+    else:
+        print("    OK (P2c): no backend left holding the input method")
+    failures += check_release_ordering("P2d", A, B)
+    return failures
+
+
+def check_release_ordering(label, *backends):
+    """#57/#72 interaction: the pinned backend is released in the post-loop
+    cleanup, which runs AFTER step 9 delivers -- including on the latched
+    dead-recorder path, which delivers through that same normal path and only
+    then reports. Encoded so a future edit that hoists end() above the
+    delivery (or swaps it for cancel(), which DISCARDS) fails loudly."""
+    failures = 0
+    for be in backends:
+        if be.end_before_delivery():
+            failures += 1
+            print(f"    FAIL ({label}): {be.name} was end()ed mid-delivery -- "
+                  f"a coalesced commit would be flushed half-finished")
+        elif be.deliveries() and not be.released_after_delivery():
+            failures += 1
+            print(f"    FAIL ({label}): {be.name} delivered text but was never "
+                  f"released afterwards")
+    if not failures:
+        delivered = [b.name for b in backends if b.deliveries()]
+        print(f"    OK ({label}): every delivery on {delivered} precedes its "
+              f"release; nothing flushed mid-utterance")
+    return failures
+
+
+def scenario_p3():
+    failures = 0
+    print("  P3: swapping to a backend with no `name` must not crash the cycle")
+    A, partial, errors, ncycles = run_p3()
+    crash = [e for e in errors if "STT failed" in e or "AttributeError" in e]
+    print(f"    A(ydotool) ops={[o for o, _ in A.ops]}")
+    print(f"    cycles={ncycles}; partial backend received {partial.text}")
+    print(f"    Error signals: {errors}")
+    if ncycles < 2:
+        why = (f"the cycle died first: {crash}" if crash
+               else "the loop never produced a second utterance")
+        print(f"    FAIL (P3): never reached the re-pin, which is the line "
+              f"under test -- {why}")
+        return failures + 1
+    if crash:
+        failures += 1
+        print(f"    FAIL (P3): the cycle died on the partial backend: {crash} "
+              f"-- an unguarded attribute in a diagnostic must never take the "
+              f"utterance down")
+    elif not A.ops:
+        failures += 1
+        print("    FAIL (P3): nothing was typed at all before the swap")
+    else:
+        print("    OK (P3): the swap logged and released without crashing")
+    return failures
+
+
+SCENARIOS = {"p1": scenario_p1, "p2": scenario_p2, "p3": scenario_p3}
+
+
+def main():
+    # P1 and P2 must not share a process: gnome-speaks-service.py takes its
+    # CONFIG from the speech-to-cli `state` module, which lives in sys.modules
+    # -- so two harness.load()s hand back the SAME dict and the scenarios
+    # would silently overwrite each other's mode flags. (Measured: the second
+    # scenario ran with loop=False.)
+    if len(sys.argv) > 1:
+        return SCENARIOS[sys.argv[1]]()
+
+    print(f"service under test: {harness.SVC_PATH}")
+    print()
+    failures = 0
+    for name in ("p1", "p2", "p3"):
+        env = dict(os.environ, GS_REPRO_SCRATCH=os.path.join(SCRATCH, name))
+        proc = subprocess.run([sys.executable, os.path.abspath(__file__), name], env=env,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              text=True, timeout=180)
+        sys.stdout.write(proc.stdout)
+        if proc.returncode and not proc.stdout.strip():
+            # The scenario died before it could assert anything -- usually a
+            # bad GS_SVC_PATH (the harness puts dirname(SVC_PATH) on sys.path,
+            # so the file needs its sibling injector.py/spellbook.py beside
+            # it). Silence here reads as "no findings", which is worse than
+            # noise.
+            print(f"    ERROR: scenario {name} crashed before asserting:")
+            for line in proc.stderr.strip().splitlines()[-4:]:
+                print(f"      {line}")
+        failures += proc.returncode
+        print()
+    if failures:
+        print(f"FAIL: {failures} assertion(s) violated -- the injector pin is "
+              f"not released when it changes / at cycle exit.")
+        return 1
+    print("PASS: the pin holds for the whole utterance AND is released both "
+          "when it changes and at cycle exit.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/prefs-rig/README.md
+++ b/tests/repros/prefs-rig/README.md
@@ -1,0 +1,91 @@
+# prefs-rig — a test rig for prefs.js
+
+prefs.js had **no** way to be tested before this. `gnome-extensions prefs
+gnome-speaks@jphein` loads the copy installed in
+`~/.local/share/gnome-shell/extensions`, **not your worktree**, so it silently
+verifies the old file — and the headless-shell harness in CLAUDE.md §Testing
+doesn't help either, because gnome-shell never loads prefs.js at all (the prefs
+window is a separate process). Written for issue #54 / PR #76.
+
+## What it does
+
+`run.sh` builds a **real, mapped `Adw.PreferencesWindow`** from a prefs.js you
+name, on a `gtk4-broadwayd` virtual display. Nothing appears on the live
+session and no focus is stolen, so it is safe to run while someone is dictating.
+It sandboxes `HOME` and forces `GSETTINGS_BACKEND=memory`, so a run can never
+write the real `~/.config/speech-to-cli/config.json` or touch dconf.
+
+```bash
+./run.sh ~/Projects/gnome-speaks-wt/<wt>/prefs.js                # one file
+./run.sh ~/Projects/gnome-speaks-wt/<wt>/prefs.js /tmp/main.js   # + baseline diff
+```
+
+It reports, for the Audio page: build time, each combo row's options and
+selected index **synchronously** and again **after the async probes land**, and
+any config write attempted during the fill (must be `none`).
+
+## Always take a baseline
+
+`main` emits **5 pre-existing `Gtk-WARNING`s** (keybinding markup x4, an
+unescaped `&` in `Privacy & Debug` x1). A run that shows warnings is not
+automatically your fault — pass a second argument to diff against `main` and
+judge only the delta.
+
+## The three requirements it exists to enforce
+
+1. **No blocking spawns.** `bench.js` measures the old cost directly:
+   `2x wpctl status` = ~20 ms, `6x which` = ~6 ms, vs `find_program_in_path` =
+   0.1 ms. Run it on any machine to re-derive the numbers rather than trusting
+   these.
+2. **An async fill must never write config.** Swapping a `Gtk.StringList` moves
+   `selected` and emits `notify::selected`, which `_addComboRow` treats as a
+   user choice. The harness monkeypatches `_setConfigValue`/`_deleteConfigKey`
+   and prints `WRITES` — anything but `none` means the model swap is silently
+   rewriting the setting it is still loading.
+3. **A row must not lie while loading.** With `speaker_sink` set in config, the
+   synchronous snapshot must show that device *selected*, not "System Default".
+
+## Failure paths worth re-running
+
+- **Window closed mid-probe** — `sed 's|^win.present();|&\nwin.close();|'` on
+  harness.js. Rows must stay on the placeholder, with no crash and no warning.
+- **PipeWire down** — put a `wpctl` that `exit 1`s first on `PATH`. Expect empty
+  lists, the "No PipeWire devices found" subtitle, and the saved value **not**
+  wiped from config.
+- **wpctl absent** — `Gio.Subprocess.new` throws; the catch must still call
+  `callback([], [])`. (Verified reachable; don't assume it — a dead catch branch
+  looks identical to a working one.)
+
+## Config containment — proven, not asserted
+
+`probe_write_containment.js` exercises the REAL writer with the harness's
+monkeypatch removed: it calls `_setConfigValue` + `_flushConfigSave` with a
+sentinel and checks where it lands.
+
+```
+GLib.get_home_dir() = .../wc-<pid>/home     <- honors $HOME
+SANDBOX file contains sentinel: true
+JP's REAL config: UNCHANGED, sentinel count 0
+```
+
+⭐ **Containment comes from `GLib.get_home_dir()` honoring `$HOME`, NOT from the
+monkeypatch.** The harness's `_setConfigValue`/`_deleteConfigKey` stubs are a
+*reporting* mechanism (they produce the `WRITES` line); they are not what keeps
+JP's config safe. That distinction matters because someone will eventually
+remove a stub to test a save path -- and this probe says that is safe to do.
+
+⚠️ **This is a GJS/bash suite: 0 `.py` files, by design.** A `find -name '*.py'`
+check reports it empty. It runs `gjs` and needs `gtk4-broadwayd`; it will never
+be collected by a python test runner.
+
+## Gotchas that cost time
+
+- `BROADWAY_DISPLAY=:7` maps to `broadway8.socket` (off by one). `:8`, `8` and
+  `7` all fail with `Failed to open display`.
+- The resource import chain needs gnome-shell's private `Shew` typelib:
+  `GI_TYPELIB_PATH=/usr/lib/gnome-shell/girepository-1.0` **and**
+  `LD_LIBRARY_PATH=/usr/lib/gnome-shell`. The typelib is in
+  `/usr/lib/gnome-shell/...`, *not* `/usr/lib/x86_64-linux-gnu/gnome-shell/`.
+- `gjs -m -c '<script>'` does not work; the module must be a file.
+- In `gjs -m`, `ARGV` is absent — use `import system from 'system'` and
+  `system.programArgs`.

--- a/tests/repros/prefs-rig/bench.js
+++ b/tests/repros/prefs-rig/bench.js
@@ -1,0 +1,15 @@
+import GLib from 'gi://GLib';
+const CMDS = ['aplay','pw-play','pw-cat','ffplay','pw-record','arecord'];
+const ms = t => (t/1000).toFixed(1);
+for (let run = 1; run <= 3; run++) {
+    let t = GLib.get_monotonic_time();
+    for (let i = 0; i < 2; i++) GLib.spawn_command_line_sync('wpctl status');
+    const wpctl = GLib.get_monotonic_time() - t;
+    t = GLib.get_monotonic_time();
+    for (const c of CMDS) GLib.spawn_command_line_sync(`which ${c}`);
+    const which = GLib.get_monotonic_time() - t;
+    t = GLib.get_monotonic_time();
+    for (const c of CMDS) GLib.find_program_in_path(c);
+    const fpip = GLib.get_monotonic_time() - t;
+    print(`run${run}  OLD blocking: 2x wpctl=${ms(wpctl)}ms + 6x which=${ms(which)}ms = ${ms(wpctl+which)}ms   |   NEW blocking: find_program_in_path x6=${ms(fpip)}ms + wpctl async=0ms`);
+}

--- a/tests/repros/prefs-rig/harness.js
+++ b/tests/repros/prefs-rig/harness.js
@@ -1,0 +1,117 @@
+// Standalone prefs harness: loads a prefs.js by path, builds a REAL mapped
+// Adw.PreferencesWindow on a broadway display, and reports on the Audio page.
+// Usage: gjs -m tmp/harness.js <abs-path-to-prefs.js>
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Gtk from 'gi://Gtk?version=4.0';
+import Adw from 'gi://Adw?version=1';
+import system from 'system';
+
+Gio.resources_register(Gio.resource_load(
+    '/usr/share/gnome-shell/org.gnome.Shell.Extensions.src.gresource'));
+
+const PREFS = system.programArgs[0];
+const EXTDIR = GLib.getenv('GS_PREFS_EXTDIR') ||
+    (GLib.get_current_dir() + '/fakeext');
+
+Gtk.init();
+Adw.init();
+
+const {default: Prefs} = await import(`file://${PREFS}`);
+
+// Pass-through instrumentation: capture rows by title, and flag ANY config
+// write, since a programmatic model swap must never write.
+const rows = new Map();
+const writes = [];
+const origCombo = Prefs.prototype._addComboRow;
+Prefs.prototype._addComboRow = function (group, title, ...rest) {
+    const row = origCombo.call(this, group, title, ...rest);
+    rows.set(title, row);
+    return row;
+};
+Prefs.prototype._setConfigValue = function (k, v) { writes.push(`set ${k}=${v}`); };
+Prefs.prototype._deleteConfigKey = function (k) { writes.push(`delete ${k}`); };
+
+const dir = Gio.File.new_for_path(EXTDIR);
+const metadata = JSON.parse(new TextDecoder().decode(
+    GLib.file_get_contents(`${EXTDIR}/metadata.json`)[1]));
+metadata.dir = dir;
+metadata.path = EXTDIR;
+
+const prefs = new Prefs(metadata);
+const win = new Adw.PreferencesWindow();
+
+const t0 = GLib.get_monotonic_time();
+prefs.fillPreferencesWindow(win);
+const buildMs = (GLib.get_monotonic_time() - t0) / 1000;
+
+const snap = title => {
+    const row = rows.get(title);
+    if (!row) return '<missing row>';
+    const m = row.model;
+    const items = [];
+    for (let i = 0; i < m.get_n_items(); i++) items.push(m.get_string(i));
+    return `selected=${row.get_selected()} [${items.join(' | ')}] sub="${row.subtitle}"`;
+};
+
+print(`BUILD_MS ${buildMs.toFixed(1)}`);
+print(`SYNC Speaker    ${snap('Speaker')}`);
+print(`SYNC Microphone ${snap('Microphone')}`);
+print(`SYNC Player     ${snap('Player')}`);
+print(`SYNC Recorder   ${snap('Recorder')}`);
+
+win.present();
+
+const loop = new GLib.MainLoop(null, false);
+GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2500, () => {
+    print(`ASYNC Speaker    ${snap('Speaker')}`);
+    print(`ASYNC Microphone ${snap('Microphone')}`);
+    function* walk(w) {
+        if (!w) return;
+        yield w;
+        let c = w.get_first_child();
+        while (c) { yield* walk(c); c = c.get_next_sibling(); }
+    }
+    // A markup failure leaves the PROPERTY intact and the LABEL empty, so a
+    // property snapshot cannot see it. Anything whose text is set but renders
+    // blank is the signature -- generic, no per-row knowledge required.
+    const blanks = [];
+    for (const w of walk(win)) {
+        const isRow = w instanceof Adw.ActionRow;
+        const isGrp = w instanceof Adw.PreferencesGroup;
+        if (!isRow && !isGrp) continue;
+        const shown = new Set([...walk(w)]
+            .filter(x => x instanceof Gtk.Label).map(x => x.get_text()));
+        for (const [prop, val] of [['title', w.title],
+            ['subtitle', isRow ? w.subtitle : null]]) {
+            if (!val) continue;
+            // markup is stripped when rendered, so compare on the escaped form too
+            const plain = val.replace(/&amp;/g, '&').replace(/&lt;/g, '<')
+                .replace(/&gt;/g, '>');
+            if (!shown.has(val) && !shown.has(plain))
+                blanks.push(`${w.constructor.$gtype.name}.${prop}="${val}"`);
+        }
+    }
+    print(`BLANK_RENDERED ${blanks.length === 0 ? 'none' : blanks.length + ' -> ' + blanks.join(' ; ')}`);
+    // Positive assertion, not just absence: for every markup-risky string
+    // (contains '<' or '&'), show property vs what get_text() actually returns.
+    for (const w of walk(win)) {
+        const isRow = w instanceof Adw.ActionRow;
+        const isGrp = w instanceof Adw.PreferencesGroup;
+        if (!isRow && !isGrp) continue;
+        const shown = [...walk(w)].filter(x => x instanceof Gtk.Label).map(x => x.get_text());
+        for (const [prop, val] of [['title', w.title], ['subtitle', isRow ? w.subtitle : null]]) {
+            if (!val || !/[<&]/.test(val)) continue;
+            const plain = val.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+            const hit = shown.find(t => t === val || t === plain);
+            print(`RENDERED ${prop} property="${val}" -> get_text()=` +
+                (hit === undefined ? '"" <<BLANK>>' : `"${hit}" ${hit === plain ? 'MATCHES' : '?'}`));
+        }
+    }
+    print(`WRITES ${writes.length === 0 ? 'none' : writes.join(', ')}`);
+    win.close();
+    loop.quit();
+    return GLib.SOURCE_REMOVE;
+});
+loop.run();
+print('EXIT_CLEAN');

--- a/tests/repros/prefs-rig/probe_dialog.js
+++ b/tests/repros/prefs-rig/probe_dialog.js
@@ -1,0 +1,36 @@
+import GLib from 'gi://GLib';
+import Gtk from 'gi://Gtk?version=4.0';
+import Adw from 'gi://Adw?version=1';
+Gtk.init(); Adw.init();
+function* walk(w) { yield w; let c = w.get_first_child();
+    while (c) { yield* walk(c); c = c.get_next_sibling(); } }
+const labels = w => [...walk(w)].filter(x => x instanceof Gtk.Label)
+    .map(l => `"${l.get_text()}"`).join(' , ');
+const win = new Adw.PreferencesWindow(); win.present();
+const BODY = 'Enter a keyboard shortcut (e.g. <Super><Alt>space):';
+print('--- A: body as written on main ---');
+const a = new Adw.AlertDialog({heading: 'Set shortcut', body: BODY});
+print('--- B: body_use_markup false, body assigned after ---');
+const b = new Adw.AlertDialog({heading: 'Set shortcut'});
+b.body_use_markup = false; b.body = BODY;
+print('--- C: escaped body ---');
+const c = new Adw.AlertDialog({heading: 'Set shortcut',
+    body: GLib.markup_escape_text(BODY, -1)});
+print('--- end ---');
+print(`has body_use_markup? ${'body_use_markup' in a}`);
+a.present(win); 
+GLib.timeout_add(GLib.PRIORITY_DEFAULT, 400, () => {
+    print(`A rendered: ${labels(a)}`);
+    a.close(); b.present(win);
+    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 300, () => {
+        print(`B rendered: ${labels(b)}`);
+        b.close(); c.present(win);
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 300, () => {
+            print(`C rendered: ${labels(c)}`);
+            c.close(); win.close(); loop.quit(); return GLib.SOURCE_REMOVE;
+        });
+        return GLib.SOURCE_REMOVE;
+    });
+    return GLib.SOURCE_REMOVE;
+});
+const loop = new GLib.MainLoop(null, false); loop.run();

--- a/tests/repros/prefs-rig/probe_markup.js
+++ b/tests/repros/prefs-rig/probe_markup.js
@@ -1,0 +1,33 @@
+import GLib from 'gi://GLib';
+import Gtk from 'gi://Gtk?version=4.0';
+import Adw from 'gi://Adw?version=1';
+Gtk.init(); Adw.init();
+
+function* walk(w) { yield w; let c = w.get_first_child();
+    while (c) { yield* walk(c); c = c.get_next_sibling(); } }
+const labels = w => [...walk(w)].filter(x => x instanceof Gtk.Label)
+    .map(l => `"${l.get_text()}"`).join(' , ');
+
+const win = new Adw.PreferencesWindow();
+const page = new Adw.PreferencesPage();
+const grp = new Adw.PreferencesGroup({title: 'Privacy & Debug'});
+const rawRow = new Adw.ActionRow({title: 'Toggle Listening', subtitle: '<Super><Alt>space'});
+const escRow = new Adw.ActionRow({title: 'Escaped',
+    subtitle: GLib.markup_escape_text('<Super><Alt>space', -1)});
+const [okParse, key, mods] = Gtk.accelerator_parse('<Super><Alt>space');
+const human = okParse ? Gtk.accelerator_get_label(key, mods) : '(unparseable)';
+const humanRow = new Adw.ActionRow({title: 'Human', subtitle: human});
+grp.add(rawRow); grp.add(escRow); grp.add(humanRow);
+page.add(grp); win.add(page); win.present();
+
+GLib.timeout_add(GLib.PRIORITY_DEFAULT, 400, () => {
+    print(`subtitle PROPERTY (raw row) : "${rawRow.subtitle}"`);
+    print(`RENDERED labels, raw row    : ${labels(rawRow)}`);
+    print(`RENDERED labels, escaped    : ${labels(escRow)}`);
+    print(`RENDERED labels, human      : ${labels(humanRow)}`);
+    print(`accelerator_get_label()     : "${human}"`);
+    print(`group has use-markup prop?  : ${'use_markup' in grp}`);
+    print(`row has subtitle-use-markup?: ${GLib.getenv('X') === null ? ('use_markup' in rawRow) : ''}`);
+    win.close(); loop.quit(); return GLib.SOURCE_REMOVE;
+});
+const loop = new GLib.MainLoop(null, false); loop.run();

--- a/tests/repros/prefs-rig/probe_markup2.js
+++ b/tests/repros/prefs-rig/probe_markup2.js
@@ -1,0 +1,25 @@
+import GLib from 'gi://GLib';
+import Gtk from 'gi://Gtk?version=4.0';
+import Adw from 'gi://Adw?version=1';
+Gtk.init(); Adw.init();
+function* walk(w) { yield w; let c = w.get_first_child();
+    while (c) { yield* walk(c); c = c.get_next_sibling(); } }
+const labels = w => [...walk(w)].filter(x => x instanceof Gtk.Label)
+    .map(l => `"${l.get_text()}"`).join(' , ');
+
+const win = new Adw.PreferencesWindow();
+const page = new Adw.PreferencesPage();
+const bad  = new Adw.PreferencesGroup({title: 'Privacy & Debug'});
+const good = new Adw.PreferencesGroup({title: 'Privacy &amp; Debug'});
+// Does a combo's StringList label get markup-parsed? Device names can hold '&'.
+const combo = new Adw.ComboRow({title: 'Speaker',
+    model: Gtk.StringList.new(['Scarlett Solo & Co', 'Plain Device'])});
+bad.add(combo); page.add(bad); page.add(good); win.add(page); win.present();
+
+GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+    print(`GROUP TITLE unescaped '&' renders: ${labels(bad).split(' , ')[0]}`);
+    print(`GROUP TITLE escaped '&amp;' renders: ${labels(good)}`);
+    print(`COMBO row labels (device w/ '&'): ${labels(combo)}`);
+    win.close(); loop.quit(); return GLib.SOURCE_REMOVE;
+});
+const loop = new GLib.MainLoop(null, false); loop.run();

--- a/tests/repros/prefs-rig/probe_order.js
+++ b/tests/repros/prefs-rig/probe_order.js
@@ -1,0 +1,28 @@
+import GLib from 'gi://GLib';
+import Gtk from 'gi://Gtk?version=4.0';
+import Adw from 'gi://Adw?version=1';
+Gtk.init(); Adw.init();
+function* walk(w) { yield w; let c = w.get_first_child();
+    while (c) { yield* walk(c); c = c.get_next_sibling(); } }
+const labels = w => [...walk(w)].filter(x => x instanceof Gtk.Label)
+    .map(l => `"${l.get_text()}"`).join(' , ');
+const win = new Adw.PreferencesWindow();
+const page = new Adw.PreferencesPage();
+const g = new Adw.PreferencesGroup({title: 'probe'});
+
+print('--- A: use_markup FIRST in the literal ---');
+const a = new Adw.ActionRow({use_markup: false, title: 'A', subtitle: '<Super><Alt>space'});
+print('--- B: use_markup LAST in the literal ---');
+const b = new Adw.ActionRow({title: 'B', subtitle: '<Super><Alt>c', use_markup: false});
+print('--- C: construct without subtitle, assign after ---');
+const c = new Adw.ActionRow({title: 'C', use_markup: false});
+c.subtitle = '<Super><Alt>r';
+print('--- end (warnings above are attributable to the block they follow) ---');
+g.add(a); g.add(b); g.add(c); page.add(g); win.add(page); win.present();
+GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+    print(`A -> ${labels(a)}`);
+    print(`B -> ${labels(b)}`);
+    print(`C -> ${labels(c)}`);
+    win.close(); loop.quit(); return GLib.SOURCE_REMOVE;
+});
+const loop = new GLib.MainLoop(null, false); loop.run();

--- a/tests/repros/prefs-rig/probe_usemarkup.js
+++ b/tests/repros/prefs-rig/probe_usemarkup.js
@@ -1,0 +1,27 @@
+import GLib from 'gi://GLib';
+import Gtk from 'gi://Gtk?version=4.0';
+import Adw from 'gi://Adw?version=1';
+Gtk.init(); Adw.init();
+function* walk(w) { yield w; let c = w.get_first_child();
+    while (c) { yield* walk(c); c = c.get_next_sibling(); } }
+const labels = w => [...walk(w)].filter(x => x instanceof Gtk.Label)
+    .map(l => `"${l.get_text()}"`).join(' , ');
+
+const win = new Adw.PreferencesWindow();
+const page = new Adw.PreferencesPage();
+const g = new Adw.PreferencesGroup({title: 'probe'});
+// Does use_markup:false reach the SUBTITLE, or only the title?
+const off = new Adw.ActionRow({title: 'Toggle Listening',
+    subtitle: '<Super><Alt>space', use_markup: false});
+// And does it survive a LATER subtitle assignment (the dialog's save path)?
+const later = new Adw.ActionRow({title: 'Later', use_markup: false});
+g.add(off); g.add(later); page.add(g); win.add(page); win.present();
+later.subtitle = '<Super><Alt>c';
+
+GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+    print(`use_markup:false at construction -> ${labels(off)}`);
+    print(`use_markup:false, subtitle set LATER -> ${labels(later)}`);
+    print(`(any Gtk-WARNING above means it did NOT cover the subtitle)`);
+    win.close(); loop.quit(); return GLib.SOURCE_REMOVE;
+});
+const loop = new GLib.MainLoop(null, false); loop.run();

--- a/tests/repros/prefs-rig/probe_write_containment.js
+++ b/tests/repros/prefs-rig/probe_write_containment.js
@@ -1,0 +1,30 @@
+// Does an UNPATCHED config write stay in the sandbox? The main harness stubs
+// _setConfigValue/_deleteConfigKey, so the real _saveConfig path is never
+// exercised there -- meaning containment was asserted, not proven. If HOME
+// sandboxing did not cover it, a rig run would edit JP's live config while he
+// is dictating. This exercises the real writer deliberately.
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Gtk from 'gi://Gtk?version=4.0';
+import Adw from 'gi://Adw?version=1';
+import system from 'system';
+Gio.resources_register(Gio.resource_load(
+    '/usr/share/gnome-shell/org.gnome.Shell.Extensions.src.gresource'));
+Gtk.init(); Adw.init();
+const PREFS = system.programArgs[0];
+const EXTDIR = GLib.getenv('GS_PREFS_EXTDIR');
+const {default: Prefs} = await import(`file://${PREFS}`);
+const dir = Gio.File.new_for_path(EXTDIR);
+const metadata = JSON.parse(new TextDecoder().decode(
+    GLib.file_get_contents(`${EXTDIR}/metadata.json`)[1]));
+metadata.dir = dir; metadata.path = EXTDIR;
+const prefs = new Prefs(metadata);
+const win = new Adw.PreferencesWindow();
+prefs.fillPreferencesWindow(win);          // NO monkeypatch this time
+print(`GLib.get_home_dir() = ${GLib.get_home_dir()}`);
+prefs._setConfigValue('speaker_sink', 'SENTINEL-DO-NOT-SHIP');
+prefs._flushConfigSave();                  // force the real writer to run
+const sandbox = `${GLib.get_home_dir()}/.config/speech-to-cli/config.json`;
+const [ok, buf] = GLib.file_get_contents(sandbox);
+print(`SANDBOX file contains sentinel: ${ok && new TextDecoder().decode(buf).includes('SENTINEL-DO-NOT-SHIP')}`);
+win.close();

--- a/tests/repros/prefs-rig/run.sh
+++ b/tests/repros/prefs-rig/run.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Build a REAL mapped Adw.PreferencesWindow from any prefs.js and report on the
+# Audio page. Uses gtk4-broadwayd, so it never touches the live GNOME session:
+# no window appears, no focus is stolen, safe while someone is dictating.
+#
+#   ./run.sh <abs-path-to-prefs.js>            # test one file
+#   ./run.sh <branch-prefs.js> <main-prefs.js> # test + baseline + stderr diff
+#
+# Why this exists: `gnome-extensions prefs <uuid>` loads the INSTALLED copy in
+# ~/.local/share/gnome-shell/extensions, not your worktree, so it cannot verify
+# an uncommitted prefs.js change. This can.
+#
+# ISOLATION CONTRACT (do not weaken any of these):
+#   - Everything a run writes lives under $HERE/run-$$ and is deleted on exit.
+#     Nothing is at a fixed path, so two concurrent rigs cannot share state.
+#   - The config.json handed to prefs.js is a RIG-OWNED FIXTURE with pinned
+#     keys. JP's ~/.config/speech-to-cli/config.json is NEVER read: a live
+#     config steering a verdict is how a rig starts lying.
+#   - HOME and GSETTINGS_BACKEND are exported into the gjs child only, never
+#     into this shell, so a run cannot write the real config or dconf.
+#   - The broadway display number is per-PID and probed until one binds.
+set -u
+HERE=$(cd "$(dirname "$0")" && pwd)
+BRANCH=${1:?usage: run.sh <prefs.js> [baseline-prefs.js]}
+BASE=${2:-}
+EXT=$(dirname "$BRANCH")
+
+RUN="$HERE/run-$$"
+BWPID=""
+cleanup() { [ -n "$BWPID" ] && kill "$BWPID" 2>/dev/null; rm -rf "$RUN"; }
+trap cleanup EXIT
+mkdir -p "$RUN/home/.config/speech-to-cli" "$RUN/fakeext/schemas"
+
+glib-compile-schemas --targetdir "$RUN/fakeext/schemas" "$EXT/schemas/" || exit 1
+cp "$EXT/metadata.json" "$RUN/fakeext/" || exit 1
+
+# ── Rig-owned fixture ────────────────────────────────────────────────────────
+# Pinned keys only. Device ids are derived from THIS machine's live wpctl so the
+# "config names a device" path is exercised anywhere, not just where node 63
+# happens to exist -- still rig-owned, since it never touches JP's config.
+python3 - "$RUN" <<'PY'
+import json, re, subprocess, sys
+
+def first_ids():
+    try:
+        out = subprocess.run(['wpctl', 'status'], capture_output=True,
+                             text=True, timeout=10).stdout
+    except Exception:
+        return None, None
+    found, in_audio, section = {}, False, None
+    for line in out.split('\n'):
+        t = line.strip()
+        if t == 'Audio':
+            in_audio = True; continue
+        if in_audio and re.match(r'^(Video|Settings)$', t):
+            break
+        if not in_audio:
+            continue
+        if t.endswith('Sinks:'):
+            section = 'sink'; continue
+        if t.endswith('Sources:'):
+            section = 'source'; continue
+        if section:
+            m = re.match(r'^(\*?)\s*(\d+)\.\s+(.+?)(?:\s+\[.*\])?\s*$',
+                         re.sub(r'^[│├└─┬┤┼╌╎\s]+', '', t))
+            if m:
+                found.setdefault(section, m.group(2))
+    return found.get('sink'), found.get('source')
+
+sink, source = first_ids()
+cfg = {                      # pinned -- the ONLY things steering a verdict
+    'player': 'aplay',
+    'recorder': 'pw-record',
+    'half_duplex': 'auto',
+    'enable_echo_cancel': False,
+    'enable_pause': True,
+    'debug': False,
+}
+if sink:
+    cfg['speaker_sink'] = sink
+if source:
+    cfg['mic_source'] = source
+json.dump(cfg, open(sys.argv[1] + '/home/.config/speech-to-cli/config.json', 'w'),
+          indent=2)
+print(f"FIXTURE rig-owned, {len(cfg)} pinned keys "
+      f"(speaker_sink={cfg.get('speaker_sink')} mic_source={cfg.get('mic_source')} "
+      f"from live wpctl); JP's config NOT read")
+PY
+
+# ── Per-PID broadway display ─────────────────────────────────────────────────
+DISP=""
+start=$(( 20 + ($$ % 60) ))
+for n in $(seq $start $((start + 25))); do
+    sock="/run/user/$(id -u)/broadway$((n + 1)).socket"   # display :N -> socket N+1
+    [ -S "$sock" ] && continue
+    gtk4-broadwayd ":$n" >"$RUN/broadwayd.log" 2>&1 &
+    BWPID=$!
+    for _ in $(seq 1 400); do [ -S "$sock" ] && break; done
+    if [ -S "$sock" ]; then DISP=":$n"; break; fi
+    kill "$BWPID" 2>/dev/null; BWPID=""
+done
+[ -n "$DISP" ] || { echo "no free broadway display; see $RUN/broadwayd.log" >&2; exit 1; }
+echo "DISPLAY broadway $DISP (per-PID), run dir $RUN"
+
+# A run that CRASHED also produces "no new warnings". Require the harness to
+# have actually reached the end before any stderr comparison is believed --
+# a clean diff between two crashes is not a passing test.
+run() {   # run <prefs.js> <stderr-file>
+    local out
+    out=$( cd "$RUN" && GI_TYPELIB_PATH=/usr/lib/gnome-shell/girepository-1.0 \
+      LD_LIBRARY_PATH=/usr/lib/gnome-shell HOME="$RUN/home" \
+      GS_PREFS_EXTDIR="$RUN/fakeext" \
+      GSETTINGS_BACKEND=memory GDK_BACKEND=broadway BROADWAY_DISPLAY=$DISP \
+      timeout 60 gjs -m "$HERE/harness.js" "$1" 2>"$2" )
+    echo "$out"
+    case "$out" in
+        *EXIT_CLEAN*) return 0 ;;
+        *) echo "!! harness DID NOT COMPLETE for $1 -- stderr below, comparison is meaningless" >&2
+           cat "$2" >&2; return 1 ;;
+    esac
+}
+
+if [ -n "$BASE" ]; then
+    echo "=== BASELINE $BASE ==="; run "$BASE" "$RUN/base.stderr" || exit 1
+fi
+echo "=== BRANCH $BRANCH ==="; run "$BRANCH" "$RUN/branch.stderr" || exit 1
+echo "--- stderr ---"; cat "$RUN/branch.stderr"
+rc=0
+if [ -n "$BASE" ]; then
+    bl=$(grep -c 'Gtk-WARNING\|Adw-WARNING' "$RUN/base.stderr")
+    br=$(grep -c 'Gtk-WARNING\|Adw-WARNING' "$RUN/branch.stderr")
+    echo "=== Gtk/Adw warning counts ==="
+    printf 'baseline=%s  branch=%s\n' "$bl" "$br"
+    echo "=== stderr delta vs baseline ('<' = fixed, '>' = INTRODUCED) ==="
+    scrub() { sed 's/gjs:[0-9]*//; s/[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9]*//' "$1"; }
+    diff <(scrub "$RUN/base.stderr") <(scrub "$RUN/branch.stderr") \
+        && echo "NONE — stderr identical to baseline"
+    # EXIT CONTRACT: the diff exiting non-zero is NOT failure -- a fix is
+    # SUPPOSED to change stderr. Only a regression or an incomplete run fails.
+    if [ "$br" -gt "$bl" ]; then
+        echo "!! REGRESSION: branch emits more warnings than baseline ($br > $bl)" >&2
+        rc=1
+    fi
+fi
+exit $rc

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Run every repro suite against one gnome-speaks-service.py.
+#
+#   tests/repros/run_all.sh                       # the service in this repo
+#   tests/repros/run_all.sh /path/to/service.py   # a worktree, or an extracted SHA
+#
+# Exits non-zero if any suite fails. One line per check.
+#
+# NO TEST FRAMEWORK, by project rule: these are plain scripts that exit 0 (clean),
+# 1 (the defect is present) or 2 (SETUP FAILURE -- the repro could not create the
+# window it needed, so it is reporting neither a pass nor a bug).
+#
+# ENV CONTRACT: GS_SVC_PATH -- the service file under test -- is the only input,
+# and this runner sets it. The worktree dir (for sibling modules) and the scratch
+# dir are DERIVED. GS_WT overrides the dir only to mix trees deliberately.
+#
+# SERIAL, on purpose. Scratch is keyed by PID so concurrent agents no longer
+# corrupt each other, but several suites are timing-sensitive (silence timeouts,
+# audio-level throttles, pipe back-pressure) and overlapping runs make their
+# measurements unreliable.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+SVC="${1:-$REPO/gnome-speaks-service.py}"
+[ -f "$SVC" ] || { echo "no such service file: $SVC" >&2; exit 2; }
+export GS_SVC_PATH="$SVC"
+rc=0
+
+# Summarise a suite's stdout. Order matters: a per-case "[PASS] D ..." line is
+# more informative than the trailing "ALL GREEN", and a red must name its
+# scenario, so bracketed case lines win over the roll-up.
+#
+# NOTE the shape here: each pattern's result is captured and TESTED FOR
+# CONTENT, not chained with `grep ... | tail -1 && ...`. In that form `tail`
+# exits 0 on empty input, so the first pattern always "succeeds" and every
+# summary comes out blank -- the same pipeline-exit-status trap that makes a
+# script ending in `diff` return 1 on success.
+summarise() {
+    _s_out=""
+    for _s_pat in '^\[(PASS|FAIL)\]' '^(PASS|FAIL|RESULT):' '^(all checks passed|FAILURES:|ALL )'; do
+        _s_out=$(printf '%s\n' "$1" | grep -E "$_s_pat" | tail -1)
+        if [ -n "$_s_out" ]; then printf '%s\n' "$_s_out"; return; fi
+    done
+    printf '%s\n' "$1" | tail -1
+}
+line() { printf '%-16s %-34s rc=%s  %s\n' "$1" "$2" "$3" "$(summarise "$4" | cut -c1-80)"; }
+
+run() {   # run <suite> <script>...
+    suite="$1"; shift
+    for f in "$@"; do
+        out=$(cd "$HERE/$suite" && timeout 300 python3 "$f" 2>/dev/null); st=$?
+        [ $st -ne 0 ] && rc=1
+        line "$suite" "$f" "$st" "$out"
+    done
+}
+
+run service-audit  repro_c1_dispatch_gate.py repro_c2_hold.py repro_c3_config.py \
+                   repro_c4_timer.py smoke_queue_ops.py verify_queue_invariants.py
+run chronicle-perf repro_chronicle_stall.py verify_archive.py \
+                   verify_chronicle_contract.py verify_endpoints.py
+run cancel-tokens  repro_a_outcome_mislabel.py repro_b_transcript_after_stop.py \
+                   repro_c_streaming_after_stop.py repro_d_mic_disconnect.py \
+                   verify_cancel_invariants.py
+run subtitle-token repro_e1_stale_complete_frame.py repro_e2_foreign_cancel_freeze.py \
+                   repro_e3_streaming_reply_subtitle.py repro_e4_compound_cycle_then_reply.py
+run begin-refused  repro_j_first_sentence.py repro_k_remainder.py repro_l_healthy_reply.py
+run dead-recorder  repro_e_single_shot_turn_end.py repro_f_text_survives_yank.py \
+                   repro_g_ws_init_unbound.py repro_h_stale_prewarm.py \
+                   repro_i_healthy_loop.py
+run pin-lifecycle  repro_pin_lifecycle.py repro_compound_pin_x_deadmic.py \
+                   repro_compound_reply_pin.py
+run injector-seam  verify_injector_seam.py verify_ibus_injector.py
+run version-cache  verify_version_cache.py repro_a_fork_storm.py
+
+# ---------------------------------------------------------------------------
+# offline-handoff: ONE PROCESS PER CASE, on purpose.
+#
+# (1) A red must name its scenario. This suite caught
+#     `[FAIL] D azure-healthy-unchanged` on a trial merge while every other
+#     suite was green, because nothing else exercises the ordinary
+#     healthy-Azure dictation path; a single rc=1 line would not have said so.
+# (2) Case ordering is load bearing. Case H replaces stt.wyoming.transcribe and
+#     never restores it, and is safe only because build() re-stubs it on every
+#     call; case G restores _rest_stt_fallback explicitly because build() does
+#     NOT re-stub that one. A process per case makes this irrelevant instead of
+#     merely currently-true.
+# ---------------------------------------------------------------------------
+for c in A B C D E F G H I; do
+    out=$(cd "$HERE/offline-handoff" && timeout 300 python3 repro_offline_handoff.py "$c" 2>/dev/null)
+    st=$?; [ $st -ne 0 ] && rc=1
+    line offline-handoff "case $c" "$st" "$out"
+done
+
+# ---------------------------------------------------------------------------
+# prefs-rig is GJS/bash, not python: run.sh -> gjs + gtk4-broadwayd. A *.py
+# inventory returns a false negative on it and a python collector must never
+# import it. It needs a BASELINE prefs.js to mean anything, so we hand it the
+# merge base rather than a moving origin/main -- a fast-moving main manufactures
+# false regressions.
+#
+# Its exit contract is its own and is NOT the usual one: 0 = both runs
+# completed; 1 = a run did not complete, or the branch emits MORE warnings than
+# the baseline. A DIFFERING stderr is not a failure -- a fix is supposed to
+# change stderr.
+# ---------------------------------------------------------------------------
+if [ -x "$HERE/prefs-rig/run.sh" ] && command -v gjs >/dev/null 2>&1; then
+    base_dir=$(mktemp -d "$REPO/tmp/prefs-baseline-$$-XXXX" 2>/dev/null) \
+        || base_dir=$(mktemp -d)
+    ref=$(git -C "$REPO" merge-base origin/main HEAD 2>/dev/null || echo origin/main)
+    if git -C "$REPO" show "$ref:prefs.js" > "$base_dir/prefs.js" 2>/dev/null; then
+        out=$(cd "$HERE/prefs-rig" && timeout 300 ./run.sh "$REPO/prefs.js" "$base_dir/prefs.js" 2>&1)
+        st=$?; [ $st -ne 0 ] && rc=1
+        printf '%-16s %-34s rc=%s  %s\n' prefs-rig "run.sh (gjs/broadway)" "$st" \
+            "$(printf '%s\n' "$out" | grep -E 'EXIT_CLEAN|REGRESSION' | tail -1 | cut -c1-80)"
+    else
+        printf '%-16s %-34s SKIP (no %s:prefs.js baseline)\n' prefs-rig "run.sh" "$ref"
+    fi
+    rm -rf "$base_dir"
+else
+    printf '%-16s %-34s SKIP (gjs not installed)\n' prefs-rig "run.sh"
+fi
+
+echo
+[ $rc -eq 0 ] && echo "ALL SUITES GREEN" || echo "SOME SUITES FAILED"
+exit $rc

--- a/tests/repros/service-audit/harness.py
+++ b/tests/repros/service-audit/harness.py
@@ -1,0 +1,305 @@
+"""Shared harness: import gnome-speaks-service.py with every dangerous seam stubbed.
+
+No audio, no network, no mic, no D-Bus, no port 7710, no writes outside /tmp.
+"""
+import atexit
+import contextlib
+import glob
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import time
+
+# ---------------------------------------------------------------------------
+# ISOLATION -- read this before changing any path or CONFIG line below.
+#
+# Two external inputs used to decide these repros' verdicts, and both produced
+# results that read as product regressions:
+#
+# 1. JP's LIVE ~/.config/speech-to-cli/config.json.  state.load_config() reads
+#    it at import, so CONFIG started as ~47 live desktop keys (terminal_mode
+#    and wake_word are True on this machine right now).  Worse,
+#    _reload_config_flags() RE-READS that file mid-run and overwrites CONFIG
+#    for every key in _SYNC_FLAGS, so a pin applied after load() is silently
+#    clobbered unless the repro also stubs that method; and _save_config_flag()
+#    WRITES it.  _isolate_config() below cuts all three wires.
+#
+# 2. Another agent running these same suites.  Every scratch path used to be a
+#    fixed absolute directory, so two processes shared one chronicle file.
+#    MEASURED: two concurrent runs of verify_chronicle_contract.py both fail
+#    with 'equivalence [...]' mismatches; each alone passes.  Hence SCRATCH is
+#    keyed by PID and removed at exit.
+#
+# CONCURRENCY, precisely (an earlier note here overstated this):
+#   * verify_ibus_injector.py rmtree()s a FIXED runtime dir at import, so two
+#     concurrent runs OF IT destroy each other's breadcrumb -- that is the
+#     mechanism behind the one '[9] GetGlobalEngine raises' flake observed on
+#     2026-09-06, not an interaction with verify_wake_gate.py.  Now per-PID.
+#   * UNVERIFIED, flagged: the in-repo verify_wake_gate.py imports
+#     ibus_injector WITHOUT redirecting XDG_RUNTIME_DIR, so anything in it that
+#     reaches acquire() would write JP's REAL prior-engine breadcrumb -- which
+#     is also what verify_ibus_injector's check [12] asserts must not exist.
+# ---------------------------------------------------------------------------
+
+# ENV CONTRACT (unified 2026-09-06): GS_SVC_PATH is the ONE input -- the
+# service.py file under test. The worktree dir is DERIVED from its dirname,
+# so sibling modules (spellbook, injector, ibus_injector) always come from
+# the same tree as the service. GS_WT overrides the dir only if you really
+# mean to mix trees. Defaults to the main checkout; the old defaults pointed
+# at ~/Projects/gnome-speaks-wt/<name>/ worktrees that no longer exist, so a
+# bare run died with FileNotFoundError instead of testing anything.
+# Repo-relative by construction: this file lives at
+# tests/repros/<suite>/<file>.py, so four dirnames reach the repo root. #59:
+# the old defaults were absolute paths into ~/Projects/gnome-speaks-wt/<name>/
+# worktrees that no longer existed, so a bare run died with FileNotFoundError
+# instead of testing anything.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+# Scratch lives in the repo's gitignored tmp/, keyed by PID. Never a fixed
+# shared path: two agents running a suite at once used to corrupt each other
+# and it read exactly like a service regression.
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+SVC_PATH = os.environ.get("GS_SVC_PATH", SVC_DEFAULT)
+WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
+
+# get(), never setdefault(): setdefault EXPORTS the path, so any child python
+# this suite spawns would inherit the PARENT's dir and its atexit would delete
+# the still-running parent's scratch out from under it.
+_PINNED = os.environ.get("GS_REPRO_SCRATCH")
+SCRATCH = _PINNED or os.path.join(SCRATCH_ROOT, f"audit-repros-{os.getpid()}")
+STATE_DIR = os.path.join(SCRATCH, "state")
+os.environ["XDG_STATE_HOME"] = STATE_DIR        # BEFORE the module computes
+                                                # CHRONICLE_PATH from it
+if _PINNED is None:
+    # Only ever reset and remove a directory THIS process created. A dir the
+    # caller pinned belongs to the caller.
+    shutil.rmtree(SCRATCH, ignore_errors=True)  # a verdict must never depend
+    atexit.register(shutil.rmtree, SCRATCH, True)   # on who ran here before
+os.makedirs(STATE_DIR, exist_ok=True)
+
+
+def _sweep_stale_scratch():
+    """Remove scratch dirs whose owning process is gone.
+
+    atexit does NOT run when `timeout` SIGTERMs a run, which is exactly how
+    these are usually killed -- so the PID-keyed dirs accumulate. Only a dir
+    whose PID no longer exists is touched, so a live sibling run is never
+    swept out from under itself.
+    """
+    import re
+    for d in glob.glob(os.path.join(os.path.dirname(SCRATCH), "*-repros-*")):
+        m = re.search(r"-repros-(\d+)$", d)
+        if not m or d == SCRATCH:
+            continue
+        try:
+            os.kill(int(m.group(1)), 0)      # signal 0: liveness probe only
+        except ProcessLookupError:
+            shutil.rmtree(d, ignore_errors=True)
+        except PermissionError:
+            pass                              # someone else's live process
+        except Exception:
+            pass
+
+
+_sweep_stale_scratch()
+os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+
+
+
+# Every key below is pinned because a repro's verdict depends on it. Nothing
+# here may be read from JP's live config -- see the ISOLATION note above.
+CONFIG_PINS = {
+    "key": "test-key",              # speak() bails out early without one
+    "wake_word": False,             # the wake watcher must never open the mic
+    "wake_word_model": "",
+    "wake_word_secure_gate": False, # #55: gates live_typing for the session
+    "continuous_dictation": False,  # is_loop -- picks the whole cycle shape
+    "conversation_mode": False,
+    "dictation_mode": True,
+    "terminal_mode": False,         # use_lexical: rewrites text before asserts
+    "skip_final_paste": False,      # picks finalize() vs paste() in step 9
+    "injection_method": "ydotool",
+    "read_notifications": False,
+    "llm_thinking": False,
+    "spiel_provider": False,        # a second D-Bus name on the session bus
+    "debug": False,                 # else every run appends to /tmp/speech-debug.log
+    "live_subtitles": False,
+    "phrase_list": [],
+    "wyoming_host": "",             # no LAN fallback from a test
+    "chronicle": False,
+}
+
+
+
+REAL_STATE = os.path.join(os.path.expanduser("~/.local/state"), "gnome-speaks")
+
+
+
+@contextlib.contextmanager
+def config_scope(mod, **overrides):
+    """Run ONE scenario with its own CONFIG flags, restored afterwards.
+
+    Every load() in a process hands back the SAME dict -- `from state import
+    CONFIG` binds one shared object across the service, audio, stt, speech_tts
+    and wyoming -- so two scenarios in one process silently clobber each
+    other's flags, and the second one's verdict describes the first one's
+    configuration. Snapshot/restore rather than forking, so the repro stays
+    debuggable in one process:
+
+        with harness.config_scope(mod, continuous_dictation=True):
+            ...                      # loop-mode scenario
+        # flags are back to the pinned baseline here
+    
+
+    Three traps a scenario can hit that produce a GREEN run while measuring the
+    WRONG code path -- all three found by lucid-pin-lifecycle, and all three
+    cost an hour each to rediscover:
+
+    1. `_reload_config_flags()` restores conversation_mode=False at
+       start_listening(), so a conversation-mode scenario silently takes the
+       DICTATION path (send_backspaces + paste), the reply path never runs, and
+       the repro still prints a paste and looks like it passed. The CONFIG_PATH
+       redirect in _isolate_config() closes this -- the reload re-reads OUR
+       file and re-applies OUR pins -- but only for flags that are IN
+       CONFIG_PINS. Put a scenario's flags there or in config_scope(), never in
+       a bare CONFIG[...] assignment after load().
+    2. In SINGLE-SHOT, turn_end sets _stop_event and
+       _stream_conversation_worker aborts on it before stream_chat is ever
+       called. Any reply-path scenario needs loop mode, and should assert
+       stream_chat was actually invoked so it cannot pass while testing
+       something else.
+    3. Production calls _conversation_worker SYNCHRONOUSLY from inside
+       _streaming_stt_cycle, so the cycle's `finally` -- and its injector
+       release -- runs after the reply. A scenario that starts the worker on
+       its OWN thread has no such release and will report a stranded backend
+       that production does not have.
+    """
+    saved = dict(mod.CONFIG)
+    mod.CONFIG.update(overrides)
+    try:
+        yield mod.CONFIG
+    finally:
+        mod.CONFIG.clear()
+        mod.CONFIG.update(saved)
+
+
+def assert_isolated(mod):
+    """Prove the module under test cannot reach JP's live state, BEFORE any
+    scenario runs.
+
+    CHRONICLE_PATH is computed at MODULE IMPORT from $XDG_STATE_HOME, so this
+    only holds if the env var was set before exec_module -- which is easy to
+    break by moving an import. The chronicle archive and the rotated
+    generations are derived from CHRONICLE_PATH at call time, so pinning it
+    pins them too. Raises rather than warns: a repro that has quietly attached
+    itself to the real ledger must not be allowed to report a verdict.
+    """
+    root = os.path.realpath(SCRATCH)
+    checks = {
+        "CHRONICLE_PATH": getattr(mod, "CHRONICLE_PATH", None),
+        "CONFIG_PATH": getattr(mod, "CONFIG_PATH", None),
+        "XDG_STATE_HOME": os.environ.get("XDG_STATE_HOME"),
+    }
+    for name, value in checks.items():
+        if value is None:
+            raise AssertionError(f"{name} is unset -- cannot prove isolation")
+        real = os.path.realpath(value)
+        if not (real == root or real.startswith(root + os.sep)):
+            raise AssertionError(
+                f"{name}={value!r} resolves OUTSIDE the isolated scratch "
+                f"{SCRATCH!r} -- refusing to run")
+        if os.path.realpath(REAL_STATE) in (real, os.path.dirname(real)):
+            raise AssertionError(f"{name} points at JP's live state dir")
+    return True
+
+
+def _isolate_config(mod):
+    """Rebuild CONFIG from the service's OWN defaults plus CONFIG_PINS.
+
+    CONFIG is mutated IN PLACE: `from state import CONFIG` means audio, stt,
+    speech_tts and wyoming all hold the same dict object, so rebinding
+    mod.CONFIG would isolate the service module and miss every other one.
+    CONFIG_PATH is repointed at a file holding exactly the same values, so
+    _reload_config_flags() re-reading it is a no-op and _save_config_flag()
+    can never touch JP's real file.
+    """
+    real_defaults = mod.state.DEFAULTS_PATH
+    try:
+        mod.state.DEFAULTS_PATH = os.path.join(SCRATCH, "absent-config.json")
+        baseline = mod.state.load_config()
+    finally:
+        mod.state.DEFAULTS_PATH = real_defaults
+    baseline.update(CONFIG_PINS)
+    path = os.path.join(SCRATCH, "config.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(baseline, f)
+    mod.CONFIG_PATH = path
+    mod.CONFIG.clear()
+    mod.CONFIG.update(baseline)
+    return baseline
+
+
+def load(fake_tts_seconds=1.0):
+    sys.path.insert(0, os.path.dirname(SVC_PATH))  # sibling spellbook.py
+    spec = importlib.util.spec_from_file_location("gsvc_under_test", SVC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["gsvc_under_test"] = mod
+    spec.loader.exec_module(mod)  # main() is __main__-guarded; nothing starts
+
+    _isolate_config(mod)   # BEFORE anything reads CONFIG
+    assert_isolated(mod)   # and prove it, before any scenario
+
+    # --- neutralize every side effect before any instance exists ---
+    mod._schedule_warmup = lambda *a, **k: None
+    mod._refresh_audio_detection = lambda *a, **k: None
+    mod._prewarm_recorder = lambda *a, **k: None
+    mod.type_at_cursor = lambda *a, **k: None
+    mod.clipboard_write = lambda *a, **k: True
+
+    events = []          # (kind, tag, monotonic)
+    t0 = time.monotonic()
+
+    def fake_tts(text, **kw):
+        tag = text.split()[0]
+        events.append(("start", tag, time.monotonic() - t0))
+        deadline = time.monotonic() + fake_tts_seconds
+        while time.monotonic() < deadline:
+            if mod.state._cancel_event.is_set():
+                events.append(("cancel", tag, time.monotonic() - t0))
+                return {"spoken": False, "cancelled": True}
+            time.sleep(0.01)
+        events.append(("end", tag, time.monotonic() - t0))
+        return {"spoken": True}
+
+    mod.speech_tts.tts = fake_tts
+    return mod, events
+
+
+def make_service(mod):
+    svc = mod.GnomeSpeaksService()
+    svc._audio_detected = True
+    svc.play_sound = lambda *a, **k: True
+    return svc
+
+
+def spans(events):
+    """Collapse the event log into {tag: (start, end)} playback spans."""
+    out = {}
+    for kind, tag, ts in events:
+        if kind == "start":
+            out.setdefault(tag, [ts, None])
+        else:
+            if tag in out:
+                out[tag][1] = ts
+    return {k: tuple(v) for k, v in out.items()}
+
+
+def overlap(a, b):
+    (a0, a1), (b0, b1) = a, b
+    a1 = a1 if a1 is not None else 1e9
+    b1 = b1 if b1 is not None else 1e9
+    return max(0.0, min(a1, b1) - max(a0, b0))

--- a/tests/repros/service-audit/repro_c1_dispatch_gate.py
+++ b/tests/repros/service-audit/repro_c1_dispatch_gate.py
@@ -1,0 +1,51 @@
+"""C1: the dispatcher checks its hold conditions BEFORE dequeuing and never
+re-checks, so anything that arrives while it is parked in get(timeout=0.2)
+is spoken over an open mic.
+
+Schedule:
+  t0  queue empty, state idle -> dispatcher is parked inside
+      self._tts_queue.get(timeout=0.2)
+  t1  mic opens (start_listening / loop restart / _drain_speech_gap tail):
+      state -> "listening"
+  t2  an agent POSTs /speak: put_nowait wakes the parked get(), which returns
+      the item and plays it. The gate is never consulted again.
+
+The window is up to 200ms wide and reopens every 200ms, so a narrator agent
+plus a dictation keypress lands in it routinely. Each attempt below is one
+draw; the loop reports how many of N attempts spoke over the "open mic".
+"""
+import sys
+import time
+
+# No sys.path insert into a world-writable /tmp dir: those dirs held no
+# harness.py (the line was already a no-op), but a stale copy left there
+# would silently shadow this suite's own. See harness.py's ISOLATION note.
+import harness
+
+mod, events = harness.load(fake_tts_seconds=0.3)
+svc = harness.make_service(mod)
+time.sleep(0.3)
+
+ATTEMPTS = 12
+fired = 0
+for i in range(ATTEMPTS):
+    events.clear()
+    # Mic opens, then an agent posts speech a hair later.
+    svc._set_state("listening")
+    time.sleep(0.005)
+    item_id, pos, _ = svc.enqueue_speech(f"A{i} narrating", source="agent-x")
+    time.sleep(0.25)
+    spoke_over_mic = any(k == "start" for k, _t, _ts in events) and \
+        svc.current_state in ("listening", "speaking")
+    started = [t for k, t, _ in events if k == "start"]
+    if started:
+        fired += 1
+        print(f"attempt {i}: SPOKE while mic open -> {started}")
+    # reset for the next draw
+    svc._set_state("idle")
+    time.sleep(0.35)
+    svc._drain_tts_queue()
+
+print(f"\nRESULT: {fired}/{ATTEMPTS} attempts played queued speech "
+      f"while state == 'listening'")
+sys.exit(1 if fired else 0)

--- a/tests/repros/service-audit/repro_c2_hold.py
+++ b/tests/repros/service-audit/repro_c2_hold.py
@@ -1,0 +1,44 @@
+"""C2: _user_speech_active is a boolean Event shared by N user-speech paths.
+
+Schedule (deterministic, no tight race needed):
+  1. speak("USERONE")           -> hold set, worker A plays
+  2. POST /speak equivalent     -> agent item queued, dispatcher correctly HELD
+  3. speak("USERTWO")           -> sets hold (already set), then stop() joins A;
+                                   A's finally clears the hold; B starts with
+                                   the hold CLEAR.
+  => the dispatcher escapes and plays AGENT on top of the user's USERTWO.
+"""
+import sys
+import time
+
+# No sys.path insert into a world-writable /tmp dir: those dirs held no
+# harness.py (the line was already a no-op), but a stale copy left there
+# would silently shadow this suite's own. See harness.py's ISOLATION note.
+import harness
+
+mod, events = harness.load(fake_tts_seconds=1.2)
+svc = harness.make_service(mod)
+time.sleep(0.3)  # let the dispatcher thread reach its gate loop
+
+svc.speak("USERONE clipboard reading")
+time.sleep(0.2)
+svc.enqueue_speech("AGENT status line", source="agent-x")
+time.sleep(0.2)
+print("hold set while USERONE plays:", svc._user_speech_active.is_set())
+
+svc.speak("USERTWO selection reading")
+print("hold set while USERTWO plays:", svc._user_speech_active.is_set())
+time.sleep(2.5)
+
+sp = harness.spans(events)
+print("\nplayback spans (seconds since start):")
+for tag, (s, e) in sorted(sp.items(), key=lambda kv: kv[1][0]):
+    print(f"  {tag:9s} {s:.2f} -> {e if e is None else round(e, 2)}")
+
+ov = 0.0
+if "AGENT" in sp and "USERTWO" in sp:
+    ov = harness.overlap(sp["AGENT"], sp["USERTWO"])
+print(f"\nAGENT/USERTWO overlap: {ov:.2f}s")
+print("RESULT:", "BUG REPRODUCED (agent speech over user speech)" if ov > 0.05
+      else "no overlap")
+sys.exit(1 if ov > 0.05 else 0)

--- a/tests/repros/service-audit/repro_c3_config.py
+++ b/tests/repros/service-audit/repro_c3_config.py
@@ -1,0 +1,105 @@
+"""C3: _save_config_flag is an unlocked, non-atomic read-modify-write.
+
+Two distinct failures, both against the REAL function (the config path is
+redirected to /tmp for the duration of the test):
+
+  (a) lost update: two threads (D-Bus pool + HTTP spell thread) each
+      read-modify-write the whole file, so one flag silently vanishes.
+  (b) truncation window: open(path, "w") empties the file in place. Any
+      concurrent reader sees a partial document. prefs.js's merge-on-write
+      does exactly this read, and on a parse failure falls back to
+      `onDisk = {}` -> it then writes back a config.json containing ONLY the
+      key it was editing, destroying the Azure keys and every other setting.
+"""
+import json
+import os
+import sys
+import threading
+import time
+
+# No sys.path insert into a world-writable /tmp dir: those dirs held no
+# harness.py (the line was already a no-op), but a stale copy left there
+# would silently shadow this suite's own. See harness.py's ISOLATION note.
+import harness
+
+TMP = os.path.join(harness.SCRATCH, "c3-config.json")
+mod, _events = harness.load(fake_tts_seconds=0.1)
+
+# Redirect only the config path (this process only).
+CONFIG_PATH_STR = "~/.config/speech-to-cli/config.json"
+if hasattr(mod, "CONFIG_PATH"):
+    mod.CONFIG_PATH = TMP           # post-fix: module constant
+else:
+    _real = os.path.expanduser      # pre-fix: the path is inlined twice
+    os.path.expanduser = lambda p: TMP if p == CONFIG_PATH_STR else _real(p)
+
+svc = harness.make_service(mod)
+
+
+def seed():
+    with open(TMP, "w") as f:
+        json.dump({"key": "AZURE-SECRET", "region": "eastus",
+                   "voice": "en-US-BrianNeural"}, f, indent=2)
+
+
+# --- (a) lost update ------------------------------------------------------
+seed()
+N = 8
+barrier = threading.Barrier(N)
+
+
+def writer(i):
+    barrier.wait()
+    svc._save_config_flag(f"flag{i}", i)
+
+
+threads = [threading.Thread(target=writer, args=(i,)) for i in range(N)]
+for t in threads:
+    t.start()
+for t in threads:
+    t.join()
+with open(TMP) as f:
+    disk = json.load(f)
+present = [k for k in (f"flag{i}" for i in range(N)) if k in disk]
+lost = N - len(present)
+print(f"(a) lost update: {len(present)}/{N} flags survived "
+      f"({lost} silently lost); azure key present={'key' in disk}")
+
+# --- (b) truncation window ------------------------------------------------
+seed()
+stop = threading.Event()
+bad = {"parse_error": 0, "empty": 0, "reads": 0}
+
+
+def prefs_like_reader():
+    """Exactly what prefs.js _saveConfig does before merging."""
+    while not stop.is_set():
+        bad["reads"] += 1
+        try:
+            with open(TMP, "rb") as f:
+                raw = f.read()
+            if not raw:
+                bad["empty"] += 1
+                continue
+            json.loads(raw)
+        except FileNotFoundError:
+            bad["empty"] += 1
+        except (json.JSONDecodeError, ValueError):
+            bad["parse_error"] += 1
+
+
+r = threading.Thread(target=prefs_like_reader, daemon=True)
+r.start()
+for i in range(400):
+    svc._save_config_flag("chronicle", bool(i % 2))
+stop.set()
+r.join(timeout=2)
+partial = bad["parse_error"] + bad["empty"]
+print(f"(b) truncation window: {partial} of {bad['reads']} concurrent reads "
+      f"saw a partial/empty config "
+      f"(parse_error={bad['parse_error']}, empty={bad['empty']})")
+print("    -> each one is a prefs.js save that would rewrite config.json "
+      "from {} and drop the Azure keys")
+
+print("\nRESULT:", "BUG REPRODUCED" if (lost or partial) else "clean")
+sys.exit(1 if (lost or partial) else 0)

--- a/tests/repros/service-audit/repro_c4_timer.py
+++ b/tests/repros/service-audit/repro_c4_timer.py
@@ -1,0 +1,60 @@
+"""C4: _reset_inactivity_timer read-remove-adds an unsynchronized source id
+from every _set_state, i.e. from concurrent worker threads.
+
+Two threads that read the same id both remove it (the second gets a GLib
+"Source ID N was not found" warning) and then both store their own, orphaning
+a live 10-minute timer. Every orphan eventually fires; a fire that finds the
+service idle calls _main_loop.quit(), so the service exits while in use. A
+fire that finds it busy reschedules AND clobbers the tracked id -> more
+orphans.
+
+Counts timers that are still alive in the main context but no longer tracked.
+"""
+import sys
+import threading
+import time
+
+# No sys.path insert into a world-writable /tmp dir: those dirs held no
+# harness.py (the line was already a no-op), but a stale copy left there
+# would silently shadow this suite's own. See harness.py's ISOLATION note.
+import harness
+
+mod, _events = harness.load(0.05)
+from gi.repository import GLib  # noqa: E402
+
+svc = harness.make_service(mod)
+loop = GLib.MainLoop()
+svc._main_loop = loop
+threading.Thread(target=loop.run, daemon=True).start()
+time.sleep(0.2)
+svc._reset_inactivity_timer()
+
+seen = set()
+stop = threading.Event()
+
+
+def churn(a, b):
+    while not stop.is_set():
+        svc._set_state(a)
+        svc._set_state(b)
+        seen.add(svc._inactivity_source_id)
+
+
+t1 = threading.Thread(target=churn, args=("idle", "speaking"), daemon=True)
+t2 = threading.Thread(target=churn, args=("speaking", "idle"), daemon=True)
+t1.start()
+t2.start()
+time.sleep(3)
+stop.set()
+time.sleep(0.3)
+
+ctx = GLib.MainContext.default()
+tracked = svc._inactivity_source_id
+orphans = [i for i in seen
+           if i is not None and i != tracked and ctx.find_source_by_id(i)]
+print(f"distinct ids observed: {len(seen)}")
+print(f"tracked id: {tracked}")
+print(f"ORPHANED live timers: {len(orphans)}")
+loop.quit()
+print("RESULT:", "BUG REPRODUCED" if orphans else "no orphans")
+sys.exit(1 if orphans else 0)

--- a/tests/repros/service-audit/smoke_queue_ops.py
+++ b/tests/repros/service-audit/smoke_queue_ops.py
@@ -1,0 +1,79 @@
+"""Smoke test for the queue control surface after the audit fixes:
+coalesce, skip (scoped + unscoped), stop/drain, pause/resume, respeak.
+Checks the outcome ring stays one-terminal-outcome-per-id and nothing hangs.
+"""
+import sys
+import time
+
+# No sys.path insert into a world-writable /tmp dir: those dirs held no
+# harness.py (the line was already a no-op), but a stale copy left there
+# would silently shadow this suite's own. See harness.py's ISOLATION note.
+import harness
+
+mod, events = harness.load(fake_tts_seconds=0.6)
+svc = harness.make_service(mod)
+time.sleep(0.3)
+fail = []
+
+# --- coalesce: only the newest of a source survives ------------------------
+svc._set_state("listening")           # hold the dispatcher so we can stack up
+time.sleep(0.1)
+a, _, _ = svc.enqueue_speech("C1 old", source="agent-a")
+b, _, _ = svc.enqueue_speech("C2 old", source="agent-a")
+c, _, dropped = svc.enqueue_speech("C3 new", source="agent-a", coalesce=True)
+other, _, _ = svc.enqueue_speech("D1 peer", source="agent-b")
+print("coalesced away:", dropped, "(expected", [a, b], ")")
+if sorted(dropped) != sorted([a, b]):
+    fail.append("coalesce dropped the wrong set")
+with svc._tts_queue.mutex:
+    pending = [i.id for i in svc._tts_queue.queue]
+print("pending after coalesce:", pending, "(expected", [c, other], ")")
+if pending != [c, other]:
+    fail.append("coalesce broke FIFO order")
+
+# --- pause holds the dispatcher even once the mic closes -------------------
+mod.state.pause_active()
+svc._set_state("idle")
+time.sleep(0.5)
+if any(k == "start" for k, _t, _ in events):
+    fail.append("paused dispatcher started an item")
+mod.state.resume_active()
+time.sleep(0.4)
+started = [t for k, t, _ in events if k == "start"]
+print("started after resume:", started)
+if not started:
+    fail.append("resume did not release the dispatcher")
+
+# --- scoped skip: wrong id is a no-op, right id cancels --------------------
+with svc._queue_current_lock:
+    cur = svc._queue_current
+if cur is not None:
+    if svc.skip_current(cur.id + 999) is not None:
+        fail.append("scoped skip hit the wrong item")
+    if svc.skip_current(cur.id) != cur.id:
+        fail.append("scoped skip missed its own item")
+time.sleep(0.8)
+
+# --- drain: everything pending gets exactly one 'canceled' -----------------
+svc._set_state("listening")
+time.sleep(0.1)
+ids = [svc.enqueue_speech(f"E{i} x", source="agent-c")[0] for i in range(5)]
+cleared = svc._drain_tts_queue()
+print("drained:", cleared, "of", len(ids))
+if cleared != len(ids):
+    fail.append("drain missed items")
+svc._set_state("idle")
+time.sleep(0.5)
+
+ring = list(svc._queue_recent)
+ring_ids = [o["id"] for o in ring]
+dupes = [i for i in set(ring_ids) if ring_ids.count(i) > 1]
+print("outcome ring:", [(o["id"], o["outcome"]) for o in ring])
+if dupes:
+    fail.append(f"duplicate terminal outcomes: {dupes}")
+
+# --- respeak with the chronicle disabled must fail cleanly, not hang -------
+print("respeak (chronicle off):", svc.respeak(None))
+
+print("\nRESULT:", "SMOKE OK" if not fail else f"FAILURES: {fail}")
+sys.exit(1 if fail else 0)

--- a/tests/repros/service-audit/verify_queue_invariants.py
+++ b/tests/repros/service-audit/verify_queue_invariants.py
@@ -1,0 +1,70 @@
+"""Invariant check for the dispatcher fix: with the mic flapping open/closed
+under load, every queued item must play EXACTLY ONCE, IN ORDER, and never
+while state == 'listening'/'processing' or while paused.
+
+Also checks the outcomes ring: exactly one terminal outcome per id.
+"""
+import sys
+import threading
+import time
+
+# No sys.path insert into a world-writable /tmp dir: those dirs held no
+# harness.py (the line was already a no-op), but a stale copy left there
+# would silently shadow this suite's own. See harness.py's ISOLATION note.
+import harness
+
+mod, events = harness.load(fake_tts_seconds=0.05)
+svc = harness.make_service(mod)
+time.sleep(0.3)
+
+N = 24
+violations = []
+
+
+def flapper():
+    for _ in range(60):
+        svc._set_state("listening")
+        # any playback that starts now is speaking over an open mic
+        time.sleep(0.02)
+        if svc.current_state == "speaking":
+            violations.append("spoke while listening")
+        svc._set_state("idle")
+        time.sleep(0.02)
+
+
+f = threading.Thread(target=flapper)
+f.start()
+ids = []
+for i in range(N):
+    item_id, _pos, _dropped = svc.enqueue_speech(f"I{i:02d} line", source="agent")
+    ids.append(item_id)
+    time.sleep(0.01)
+f.join()
+
+# let the backlog drain
+deadline = time.time() + 30
+while time.time() < deadline:
+    with svc._queue_current_lock:
+        busy = svc._queue_current is not None
+    if not busy and svc._tts_queue.empty():
+        break
+    time.sleep(0.1)
+time.sleep(0.5)
+
+starts = [t for k, t, _ in events if k == "start"]
+expected = [f"I{i:02d}" for i in range(N)]
+print("played:", len(starts), "of", N)
+print("order preserved:", starts == expected)
+dupes = [t for t in set(starts) if starts.count(t) > 1]
+print("duplicates:", dupes)
+missing = [t for t in expected if t not in starts]
+print("missing:", missing)
+outcomes = list(svc._queue_recent)
+ring_ids = [o["id"] for o in outcomes]
+print("outcome ring (last 16):", len(ring_ids), "entries, dupe ids:",
+      [i for i in set(ring_ids) if ring_ids.count(i) > 1])
+print("mic violations:", len(violations))
+ok = (starts == expected and not dupes and not missing and not violations
+      and not [i for i in set(ring_ids) if ring_ids.count(i) > 1])
+print("RESULT:", "INVARIANTS HOLD" if ok else "VIOLATION")
+sys.exit(0 if ok else 1)

--- a/tests/repros/subtitle-token/repro_e1_stale_complete_frame.py
+++ b/tests/repros/subtitle-token/repro_e1_stale_complete_frame.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Issue #42 (a): a cancelled utterance still emits its 100 % "finished" frame.
+
+THE INTERLEAVING -- all real code paths; only one real window is widened.
+
+  1. The queue dispatcher is playing agent item AAA.  _speak_worker started a
+     subtitle thread that emits a SubtitleUpdate every 200 ms and, when the
+     loop ends, one final frame at 100 %.
+  2. The user speaks.  The real preempt is stop(drain_queue=False) followed by
+     the user's own utterance: cancel_all() records the verdict "cancelled" on
+     AAA's token and raises the process-global wire (state._cancel_event).
+     AAA's tts returns {"cancelled": True} and _speak_worker's finally sets
+     sub_stop.
+  3. The user's utterance BBB enters _speak_worker and calls
+     CancelRegistry.begin(), which LOWERS the wire -- correctly, because BBB is
+     not cancelled.  The wire is one process-global bit; it now says nothing
+     about AAA.
+  4. AAA's subtitle thread reaches its final check.  On origin/main that check
+     is `if not state._cancel_event.is_set()`, which now reads False, so it
+     emits 100 % for an utterance that was cut off mid-word and is recorded in
+     GET /queue as "interrupted".
+
+  Step 4 is a narrow window on its own.  This script pins it open by stalling
+  ONE frame's GLib.idle_add -- which is not a fiction: publishing to a busy
+  GNOME Shell main loop really does block the emitting thread.  Everything
+  else is the real code: svc.stop(drain_queue=False) and svc.speak() are the
+  user-preempt path, and BBB is only started once AAA's tts has actually
+  observed the cancel (the same rendezvous repro_a uses), so the sequence
+  cancel -> observe -> begin() is fixed rather than lucky.
+
+  The run is only meaningful if the wire really was down when the subtitle
+  thread regained control -- otherwise origin/main would pass for the wrong
+  reason -- so that is checked and reported as a SETUP FAILURE, not a pass.
+
+exit 0 = no stale 100 % frame; 1 = bug present; 2 = setup failure.
+"""
+import sys
+import threading
+import time
+
+import subtitle_spy
+import harness
+
+STALL = 0.9
+
+
+def main():
+    print(f"service under test: {subtitle_spy.SVC_PATH}")
+
+    mod, events, _inj = harness.load(fake_tts_seconds=4.0)
+    subtitle_spy.assert_isolated(mod)
+    spy = subtitle_spy.install_spy(mod)
+    svc = harness.make_service(mod)
+    print(f"  token-aware subtitle thread: {subtitle_spy.subtitle_takes_token(mod)}")
+
+    item_id, _pos, _dropped = svc.enqueue_speech("AAA agent queue utterance")
+    if not harness.wait_for(lambda: any(k == "start" for k, _t, _ts in events), 5.0):
+        print("  ! dispatcher never started the item")
+        return 2
+    if not harness.wait_for(lambda: len(spy.frames_for("AAA")) >= 2, 5.0):
+        print("  ! subtitle progress never emitted -- cannot observe anything")
+        return 2
+    print(f"  AAA playing, {len(spy.frames_for('AAA'))} progress frames so far")
+
+    # Pin open the window between sub_stop.set() and the final check.
+    spy.arm_stall(STALL)
+    if not spy.stalling.wait(5.0):
+        print("  ! the stall never armed")
+        return 2
+
+    # The user preempt, in its real order, with BBB held until AAA's tts has
+    # actually seen the cancel so that begin() cannot precede the observation.
+    def preempt():
+        if harness.wait_for(lambda: any(k == "cancel" for k, _t, _ts in events), 3.0):
+            svc.speak("BBB user speech")
+
+    threading.Thread(target=preempt, daemon=True).start()
+    svc.stop(drain_queue=False)
+
+    if not spy.stall_done.wait(5.0):
+        print("  ! the stalled frame never returned")
+        return 2
+
+    harness.wait_for(lambda: harness.outcome_of(svc, item_id) is not None, 5.0)
+    outcome = harness.outcome_of(svc, item_id)
+    # Give any final frame time to land before declaring there is none.
+    harness.wait_for(lambda: spy.completed("AAA"), 1.5)
+    stale = spy.completed("AAA")
+
+    saw_cancel = any(k == "cancel" for k, _t, _ts in events)
+    mod.state.cancel_active()          # let BBB end early; keep the run short
+    time.sleep(0.2)
+
+    print(f"  AAA's tts observed the cancel: {saw_cancel}")
+    print(f"  wire when AAA's subtitle thread regained control: "
+          f"{'UP' if spy.wire_at_stall_exit else 'DOWN (BBB begin() lowered it)'}")
+    print(f"  AAA outcome recorded for GET /queue: {outcome!r}")
+    print(f"  AAA subtitle frames: {[p for _t, p, _ts in spy.frames_for('AAA')]}")
+
+    if not saw_cancel or outcome != "interrupted":
+        print("  ! SETUP FAILURE — AAA was not actually cancelled mid-play")
+        return 2
+    if spy.wire_at_stall_exit:
+        print("  ! SETUP FAILURE — the preempt's begin() never lowered the wire, "
+              "so the interleaving under test did not happen")
+        return 2
+
+    if stale:
+        print("\nFAIL: a cancelled utterance emitted its 100% 'finished' "
+              "subtitle frame — the final check read the wire, which by then "
+              "belonged to the preempting utterance.")
+        return 1
+    print("\nPASS: the cancelled utterance emitted no 100% frame; the subtitle "
+          "thread judged by its own token.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/subtitle-token/repro_e2_foreign_cancel_freeze.py
+++ b/tests/repros/subtitle-token/repro_e2_foreign_cancel_freeze.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Issue #42 (b): another operation's cancel freezes THIS subtitle mid-word.
+
+A contract test of the seam the issue names, not a claim about one production
+caller: _run_subtitle_progress belongs to exactly one utterance and must stop
+for that utterance's cancellation only.
+
+  1. Utterance AAA issues a token and begins; its subtitle thread runs.
+  2. A DIFFERENT live operation is cancelled -- registry.cancel(other), which
+     records that operation's verdict and raises the shared wire.  AAA's token
+     is untouched: AAA was not cancelled.
+  3. On origin/main AAA's subtitle thread reads `state._cancel_event.is_set()`
+     at the top of its loop, sees a bit that is not about it, and breaks -- the
+     subtitle freezes mid-word and the final 100 % frame is suppressed even
+     though AAA runs to completion.
+
+kill_procs=False is the registry's own code path (CancelRegistry._raise_wire);
+it keeps the harness from signalling subprocesses.  The wire semantics -- the
+only thing under test here -- are identical either way.
+
+exit 0 = the subtitle ignored the foreign cancel; 1 = bug present.
+"""
+import sys
+import threading
+import time
+
+import subtitle_spy
+import harness
+
+EST_DURATION = 6.0
+
+
+def main():
+    print(f"service under test: {subtitle_spy.SVC_PATH}")
+    mod, _events, _inj = harness.load(fake_tts_seconds=1.0)
+    subtitle_spy.assert_isolated(mod)
+    spy = subtitle_spy.install_spy(mod)
+    svc = harness.make_service(mod)
+    print(f"  token-aware subtitle thread: {subtitle_spy.subtitle_takes_token(mod)}")
+
+    token = svc._cancels.issue("speech")
+    assert svc._cancels.begin(token), "AAA should own the wire"
+
+    stop_ev = threading.Event()
+    t = threading.Thread(
+        target=subtitle_spy.run_subtitle_progress,
+        args=(mod, svc, "AAA live utterance", EST_DURATION, stop_ev, token),
+        daemon=True)
+    t.start()
+
+    if not harness.wait_for(lambda: len(spy.frames_for("AAA")) >= 2, 5.0):
+        print("  ! subtitle progress never emitted -- cannot observe anything")
+        return 2
+    before = len(spy.frames_for("AAA"))
+
+    # A different operation is cancelled. AAA's token is NOT touched.
+    other = svc._cancels.issue("stt")
+    svc._cancels.cancel(other, kill_procs=False)
+    assert not token.cancelled, "AAA's own verdict must be untouched"
+    print(f"  foreign cancel raised the wire; AAA cancelled={token.cancelled}")
+
+    time.sleep(0.7)                    # >= 3 more 200 ms ticks
+    after = len(spy.frames_for("AAA"))
+
+    stop_ev.set()                      # AAA's playback finished normally
+    t.join(timeout=2.0)
+    completed = spy.completed("AAA")
+
+    svc._cancels.retire(other)
+    svc._cancels.retire(token)         # drops the wire (owner)
+
+    kept_going = after - before
+    print(f"  progress frames after the foreign cancel: {kept_going}")
+    print(f"  final 100% frame emitted: {completed}")
+
+    if kept_going == 0 or not completed:
+        print("\nFAIL: an unrelated operation's cancel froze this utterance's "
+              "subtitle" + ("" if kept_going else " (0 further frames)") +
+              ("" if completed else " and suppressed its 100% frame") + ".")
+        return 1
+    print("\nPASS: the subtitle ignored the foreign cancel and finished at 100%.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/subtitle-token/repro_e3_streaming_reply_subtitle.py
+++ b/tests/repros/subtitle-token/repro_e3_streaming_reply_subtitle.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Issue #42, second call path: the streaming AI reply's subtitle queue.
+
+_stream_conversation_worker does not start a subtitle thread per sentence; it
+puts items on subtitle_q for one long-lived _subtitle_queue_worker.  The token
+therefore has to travel through the queue tuple, which is both the fix and the
+regression risk: an arity mismatch between put() and the unpack would kill that
+daemon thread on the first sentence and silently take AI-reply subtitles with
+it.  This script drives the real worker with a stubbed stream_chat so both are
+covered:
+
+  * PLUMBING -- sentences really do produce subtitle frames through the queue.
+  * VERDICT  -- the reply's token is cancelled and then an unrelated operation
+    calls begin(), lowering the shared wire.  On origin/main the in-flight
+    sentence's final check reads that lowered wire and emits 100 % for a reply
+    the user cancelled; the token says otherwise.
+
+The one widened window is the same stalled GLib.idle_add as repro_e1.
+
+exit 0 = clean; 1 = bug present; 2 = setup failure.
+"""
+import sys
+import threading
+import time
+
+import subtitle_spy
+import harness
+
+STALL = 0.9
+
+
+def main():
+    print(f"service under test: {subtitle_spy.SVC_PATH}")
+    mod, events, _inj = harness.load(fake_tts_seconds=4.0)
+    subtitle_spy.assert_isolated(mod)
+    spy = subtitle_spy.install_spy(mod)
+    svc = harness.make_service(mod)
+    print(f"  token-aware subtitle thread: {subtitle_spy.subtitle_takes_token(mod)}")
+
+    # Two tokens: the second completes the first sentence, so "Alpha one." is
+    # spoken while the stream is still open — the in-flight case we need.
+    mod.stream_chat = lambda **kw: iter(["Alpha one. ", "Beta two. "])
+
+    worker = threading.Thread(target=svc._stream_conversation_worker,
+                              args=("hello",), daemon=True)
+    worker.start()
+
+    if not harness.wait_for(lambda: len(spy.frames_for("Alpha")) >= 2, 8.0):
+        print("  ! no subtitle frames from the streaming reply — the queue "
+              "worker never ran (tuple arity?)")
+        return 1
+    print(f"  streaming subtitles flowing: {len(spy.frames_for('Alpha'))} frames")
+
+    reply_token = svc._speak_token
+    if reply_token is None:
+        print("  ! SETUP FAILURE — no ai-reply token was issued")
+        return 2
+
+    spy.arm_stall(STALL)
+    if not spy.stalling.wait(5.0):
+        print("  ! the stall never armed")
+        return 2
+
+    # The user cancels the reply, and only once the in-flight tts has actually
+    # observed it does an unrelated operation take the wire — so the sequence
+    # cancel -> observe -> begin() is fixed rather than lucky.
+    svc._cancels.cancel(reply_token, kill_procs=False)
+    if not harness.wait_for(lambda: any(k == "cancel" for k, _t, _ts in events), 3.0):
+        print("  ! SETUP FAILURE — the sentence's tts never observed the cancel")
+        return 2
+    other = svc._cancels.issue("speech")
+    svc._cancels.begin(other)
+
+    if not spy.stall_done.wait(5.0):
+        print("  ! the stalled frame never returned")
+        return 2
+
+    harness.wait_for(lambda: spy.completed("Alpha"), 2.5)
+    stale = spy.completed("Alpha")
+
+    svc._cancels.retire(other)
+    mod.state.cancel_active()          # end the remainder early
+    worker.join(timeout=5.0)
+    time.sleep(0.2)
+
+    print(f"  reply token cancelled: {reply_token.cancelled}")
+    print(f"  wire when the subtitle thread regained control: "
+          f"{'UP' if spy.wire_at_stall_exit else 'DOWN (an unrelated begin() lowered it)'}")
+    print(f"  'Alpha one.' subtitle frames: "
+          f"{[p for _t, p, _ts in spy.frames_for('Alpha')]}")
+
+    if not reply_token.cancelled:
+        print("  ! SETUP FAILURE — the reply was never cancelled")
+        return 2
+    if spy.wire_at_stall_exit:
+        print("  ! SETUP FAILURE — the wire was never lowered, so the "
+              "interleaving under test did not happen")
+        return 2
+
+    if stale:
+        print("\nFAIL: a cancelled AI reply emitted its 100% 'finished' "
+              "subtitle frame — the queued sentence read the shared wire.")
+        return 1
+    print("\nPASS: streaming subtitles flow through the queue and stop for "
+          "their own reply's verdict.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/subtitle-token/repro_e4_compound_cycle_then_reply.py
+++ b/tests/repros/subtitle-token/repro_e4_compound_cycle_then_reply.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""COMPOSED case: #77's streaming-cycle exits + #42's subtitle token.
+
+Project rule since #77: composed changes need composed tests.  The two changes
+do meet, and not where a file-level diff suggests — `_report_recorder_dead`
+touches no token and no subtitle, but `_streaming_stt_cycle` **calls**
+`_conversation_worker` -> `_stream_conversation_worker` from inside its own
+loop (gnome-speaks-service.py ~L2943), before its `finally` retires the cycle's
+token.  So at the moment the AI reply issues its own token:
+
+  * the cycle's "stt-stream" token is still LIVE and is the registry's wire
+    owner, and
+  * the reply's begin() takes the wire from it,
+
+which is precisely the two-live-tokens state that made reading the wire wrong.
+The composition this pins is therefore the real one:
+
+  live cycle token -> AI reply speaks -> panic stop -> the NEXT operation
+  begins (a loop restart or the resuming speech queue) and lowers the wire
+
+and the assertion is that BOTH HALVES OF THE SERVICE AGREE: the reply's audio
+is abandoned AND no subtitle claims the reply finished.  On origin/main the
+subtitle half disagrees.
+
+The cycle's token is issued directly rather than by driving the whole recorder
++ WebSocket cycle: the composition under test is the registry state at the call
+site, and faking the recorder would import another suite's fixtures that are
+themselves being rewritten this hour.  The call into `_conversation_worker` is
+the real one.
+
+exit 0 = both halves agree; 1 = they disagree; 2 = setup failure.
+"""
+import sys
+import threading
+import time
+
+import subtitle_spy
+import harness
+
+STALL = 0.9
+
+
+def main():
+    print(f"service under test: {subtitle_spy.SVC_PATH}")
+    mod, events, _inj = harness.load(fake_tts_seconds=4.0)
+    subtitle_spy.assert_isolated(mod)
+    spy = subtitle_spy.install_spy(mod)
+    svc = harness.make_service(mod)
+    print(f"  token-aware subtitle thread: {subtitle_spy.subtitle_takes_token(mod)}")
+
+    subtitle_spy.scenario(mod, conversation_mode=True)
+    mod.stream_chat = lambda **kw: iter(["Alpha one. ", "Beta two. "])
+
+    # The state _streaming_stt_cycle is in when it calls _conversation_worker:
+    # its own token live, registered, owning the wire, not yet retired.
+    cycle_token = svc._cancels.issue("stt-stream")
+    assert svc._cancels.begin(cycle_token), "the cycle should own the wire"
+
+    threading.Thread(target=svc._conversation_worker,
+                     args=("hello",), daemon=True).start()
+
+    if not harness.wait_for(lambda: len(spy.frames_for("Alpha")) >= 2, 10.0):
+        print("  ! the AI reply never produced subtitle frames")
+        return 2
+    reply_token = svc._speak_token
+    if reply_token is None or reply_token is cycle_token:
+        print("  ! SETUP FAILURE — the reply did not issue its own token")
+        return 2
+    live = {t.label for t in svc._cancels.live()}
+    print(f"  two live tokens at the composition point: {sorted(live)}")
+
+    spy.arm_stall(STALL)
+    if not spy.stalling.wait(5.0):
+        print("  ! the stall never armed")
+        return 2
+
+    # Panic stop: cancel_all() records a verdict on BOTH tokens and raises the
+    # wire; then the next operation (loop restart / resuming queue) begins.
+    threading.Thread(target=svc.stop, daemon=True).start()
+    if not harness.wait_for(lambda: any(k == "cancel" for k, _t, _ts in events), 3.0):
+        print("  ! SETUP FAILURE — the reply's tts never observed the stop")
+        return 2
+    # Measured, not asserted: the fake tts logs a "cancel" event only when it
+    # actually observed the stop and returned {"cancelled": True}.
+    audio_abandoned = any(k == "cancel" for k, _t, _ts in events)
+    nxt = svc._cancels.issue("speech")
+    svc._cancels.begin(nxt)
+
+    if not spy.stall_done.wait(5.0):
+        print("  ! the stalled frame never returned")
+        return 2
+
+    harness.wait_for(lambda: spy.completed("Alpha"), 2.5)
+    subtitle_claims_finished = spy.completed("Alpha")
+
+    svc._cancels.retire(nxt)
+    svc._cancels.retire(cycle_token)
+    mod.state.cancel_active()
+    time.sleep(0.3)
+
+    print(f"  reply token cancelled:        {reply_token.cancelled}")
+    print(f"  cycle token cancelled:        {cycle_token.cancelled}")
+    print(f"  wire at the subtitle's final check: "
+          f"{'UP' if spy.wire_at_stall_exit else 'DOWN (the next operation took it)'}")
+    print(f"  audio half  — reply abandoned mid-sentence: {audio_abandoned}")
+    print(f"  subtitle half — reply reported finished:    {subtitle_claims_finished}")
+    print(f"  'Alpha one.' frames: {[p for _t, p, _ts in spy.frames_for('Alpha')]}")
+
+    if not reply_token.cancelled or not cycle_token.cancelled:
+        print("  ! SETUP FAILURE — stop() did not cancel both live tokens")
+        return 2
+    if spy.wire_at_stall_exit:
+        print("  ! SETUP FAILURE — the wire was never lowered, so the "
+              "composed interleaving did not happen")
+        return 2
+
+    if subtitle_claims_finished:
+        print("\nFAIL: the two halves disagree — the reply's audio was "
+              "abandoned mid-sentence while its subtitle reported 100% "
+              "finished, because the subtitle read a wire that by then "
+              "belonged to the next operation.")
+        return 1
+    print("\nPASS: audio abandoned and no subtitle claimed completion — both "
+          "halves of the service agree across the composed path.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/subtitle-token/run_all.sh
+++ b/tests/repros/subtitle-token/run_all.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Usage: ./run_all.sh /path/to/gnome-speaks-service.py
+set -u
+# Default to the service in THIS checkout: tests/repros/<suite>/ -> repo root.
+# A hardcoded absolute path is both a public-repo leak and a broken contract --
+# it silently tests some other tree than the one the caller is standing in.
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+SVC="${1:-$REPO/gnome-speaks-service.py}"
+cd "$(dirname "$0")" || exit 2
+rc=0
+for f in repro_e1_stale_complete_frame.py repro_e2_foreign_cancel_freeze.py repro_e3_streaming_reply_subtitle.py repro_e4_compound_cycle_then_reply.py; do
+    echo "=== $f ==="
+    GS_SVC_PATH="$SVC" python3 "$f"; s=$?
+    echo "--- exit $s"
+    [ $s -ne 0 ] && rc=$s
+done
+exit $rc

--- a/tests/repros/subtitle-token/subtitle_spy.py
+++ b/tests/repros/subtitle-token/subtitle_spy.py
@@ -1,0 +1,175 @@
+"""Shared bits for the issue #42 subtitle-token repros.
+
+Reuses ./.../cancel-tokens/harness.py verbatim (same stubs, no
+audio, no network, no mic, no D-Bus, no port 7710, no ~/.config writes, no
+service restart).  Since 2026-09-06 that harness isolates its scratch per PID
+(/var/tmp/cancel-repros-<pid>) and repoints CONFIG_PATH at a temp file, so
+concurrent runs no longer contaminate each other -- re-verified on both sides
+after that rewrite, identical frame sequences.  What this file adds is the one
+instrument the cancel-token repros did not need: a way to see the
+SubtitleUpdate frames.
+
+_run_subtitle_progress publishes every frame through GLib.idle_add, and the
+harness runs no GLib main loop, so those callbacks are queued and never
+executed -- the frames are invisible.  GLibSpy proxies the module's GLib and
+intercepts exactly the _emit_subtitle_update calls, recording (text, percent).
+Every other GLib call is forwarded to the real GLib untouched, so the service
+behaves as it does under the other suites.
+
+GLibSpy can also STALL one frame's idle_add.  That is not a trick to make a bug
+appear: publishing a subtitle frame to a busy GNOME Shell main loop really can
+block the emitting thread, and the stall is how a repro pins a real but narrow
+window to a deterministic width -- the same discipline repro_a uses when it
+makes the already-stubbed _schedule_warmup take 250 ms.
+"""
+import atexit
+import contextlib
+import inspect
+import os
+import sys
+import threading
+import time
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(_HERE), "cancel-tokens"))
+
+import harness  # noqa: E402  (path must be set first)
+
+SVC_PATH = harness.SVC_PATH
+
+
+class GLibSpy:
+    """Proxy for the service module's GLib that records subtitle frames.
+
+    ⭐ THIS IS AN INSTRUMENT, NOT A CONVENIENCE — do not drop it in a refactor
+    or a suite move.  _run_subtitle_progress publishes every frame through
+    GLib.idle_add, and these repros run no GLib main loop, so those callbacks
+    are queued and NEVER EXECUTED.  A subtitle assertion written without this
+    shim reads an empty list, measures nothing, and PASSES.  That is a green
+    test with no writer behind it — the failure mode that hides the bug it was
+    written to catch.
+
+    Everything except _emit_subtitle_update is forwarded to the real GLib
+    untouched, so the service under test behaves exactly as it does under the
+    other suites.
+    """
+
+    def __init__(self, real, state_mod):
+        self._real = real
+        self._state = state_mod
+        self.frames = []                 # [(text, percent, t)]
+        self.t0 = time.monotonic()
+        self._arm = threading.Event()    # stall the next frame
+        self.stalling = threading.Event()
+        self.stall_done = threading.Event()
+        self.stall_seconds = 0.0
+        self.wire_at_stall_exit = None   # state._cancel_event when the stall ended
+
+    def __getattr__(self, name):         # everything else is real GLib
+        return getattr(self._real, name)
+
+    def arm_stall(self, seconds):
+        self.stall_seconds = seconds
+        self.stall_done.clear()
+        self.stalling.clear()
+        self._arm.set()
+
+    def idle_add(self, fn, *args, **kwargs):
+        if getattr(fn, "__name__", "") == "_emit_subtitle_update":
+            text, _dur, pct = args
+            self.frames.append((text, pct, time.monotonic() - self.t0))
+            if self._arm.is_set():
+                self._arm.clear()
+                self.stalling.set()
+                time.sleep(self.stall_seconds)
+                # Read the wire at the moment the thread regains control --
+                # this is what the buggy final check is about to read.
+                self.wire_at_stall_exit = self._state._cancel_event.is_set()
+                self.stall_done.set()
+            return 0
+        return self._real.idle_add(fn, *args, **kwargs)
+
+    # -- assertions --------------------------------------------------------
+    def frames_for(self, prefix):
+        return [f for f in self.frames if f[0].startswith(prefix)]
+
+    def completed(self, prefix):
+        """Did a 100% 'this utterance finished' frame go out for prefix?"""
+        return any(pct == 100 for _t, pct, _ts in self.frames_for(prefix))
+
+
+ISOLATION_PINS = {
+    # Values this suite's assertions depend on. terminal_mode is the sharp one:
+    # use_lexical rewrites transcripts before they are asserted on, and JP's
+    # live config really does carry terminal_mode=True sometimes.
+    "terminal_mode": False,
+    "chronicle": False,
+    "wake_word": False,
+    "key": "test-key",
+}
+
+
+def assert_isolated(mod):
+    """Prove the harness's isolation is in effect before asserting anything.
+
+    The path checks (CHRONICLE_PATH, CONFIG_PATH, XDG_STATE_HOME) belong to the
+    harness and are strictly stronger than the copy this file used to carry --
+    CHRONICLE_PATH in particular is computed at module import, which no check
+    living out here could see.  Delegate to it rather than maintain a second,
+    weaker version that will drift.
+
+    What stays here is the other half: proving the CONFIG pins actually TOOK.
+    A path can be redirected correctly while a pin is silently missing, and
+    terminal_mode is the one that matters -- use_lexical rewrites transcripts
+    before they are asserted on, and JP's live config really does carry
+    terminal_mode=True sometimes.
+
+    Raises SystemExit(2) -- a SETUP FAILURE, never a pass and never a bug.
+    """
+    harness.assert_isolated(mod)          # paths; raises on its own
+    problems = [f"CONFIG[{k!r}] is {mod.CONFIG.get(k)!r}, expected {want!r}"
+                for k, want in ISOLATION_PINS.items()
+                if mod.CONFIG.get(k) != want]
+    if problems:
+        print("  ! SETUP FAILURE — harness CONFIG pins are not in effect:")
+        for pr in problems:
+            print(f"      - {pr}")
+        raise SystemExit(2)
+    return True
+
+
+def scenario(mod, **overrides):
+    """Per-scenario CONFIG for a single-scenario script, via config_scope.
+
+    The swept harness owns per-scenario flags now.  These repros are one
+    scenario per process, so the `with` block would wrap the whole body and
+    buy nothing but an indent; entering the context and closing it at exit
+    keeps the restore semantics without pretending there is a second scenario
+    to protect.
+    """
+    stack = contextlib.ExitStack()
+    stack.enter_context(harness.config_scope(mod, **overrides))
+    atexit.register(stack.close)
+    return mod.CONFIG
+
+
+def install_spy(mod):
+    spy = GLibSpy(mod.GLib, mod.state)
+    mod.GLib = spy
+    return spy
+
+
+def subtitle_takes_token(mod):
+    """True when _run_subtitle_progress carries its utterance's verdict.
+
+    Lets one script run against both origin/main (3 params) and the fix
+    (4 params) instead of two divergent copies.
+    """
+    params = inspect.signature(mod.GnomeSpeaksService._run_subtitle_progress).parameters
+    return "token" in params
+
+
+def run_subtitle_progress(mod, svc, text, est, stop_event, token):
+    if subtitle_takes_token(mod):
+        return svc._run_subtitle_progress(text, est, stop_event, token)
+    return svc._run_subtitle_progress(text, est, stop_event)

--- a/tests/repros/version-cache/dump_payload.py
+++ b/tests/repros/version-cache/dump_payload.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Print the /api/version payload of the service at $GS_SVC_PATH as JSON.
+
+Runs with the counting subprocess shim in place, so the git facts are canned
+and two different service files can be compared field-for-field.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import VersionClient, load  # noqa: E402
+
+payload = VersionClient(load()).get(1)
+print(json.dumps(payload))

--- a/tests/repros/version-cache/harness.py
+++ b/tests/repros/version-cache/harness.py
@@ -1,0 +1,232 @@
+"""Shared harness for the /api/version fork-storm repro (issue #53).
+
+Same discipline as the sibling suites: import the real gnome-speaks-service.py
+in-process with every dangerous seam stubbed.  No audio, no network, no mic,
+no D-Bus, no port 7710, no ~/.config writes, no service restart -- and, the
+point of this suite, NO REAL GIT PROCESSES: `subprocess` is swapped for a
+counting shim inside the module under test only, so the stdlib module the rest
+of the interpreter sees is untouched.
+
+Run any repro with:
+    GS_SVC_PATH=<path to a gnome-speaks-service.py> python3 <script>
+exit 0 = clean, exit 1 = bug present.
+"""
+import atexit
+import contextlib
+import importlib.util
+import json
+import os
+import shutil
+import sys
+
+# ENV CONTRACT: GS_SVC_PATH is the ONE input -- the service.py under test.
+# The worktree dir is DERIVED from its dirname so sibling modules always come
+# from the same tree; GS_WT overrides the dir only to mix trees deliberately.
+# Repo-relative by construction: this file lives at
+# tests/repros/<suite>/<file>.py, so four dirnames reach the repo root. #59:
+# the old defaults were absolute paths into ~/Projects/gnome-speaks-wt/<name>/
+# worktrees that no longer existed, so a bare run died with FileNotFoundError
+# instead of testing anything.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+# Scratch lives in the repo's gitignored tmp/, keyed by PID. Never a fixed
+# shared path: two agents running a suite at once used to corrupt each other
+# and it read exactly like a service regression.
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+SVC_PATH = os.environ.get(
+    "GS_SVC_PATH",
+    SVC_DEFAULT)
+WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
+
+# Per-PID scratch: several agents run these suites concurrently and a SHARED
+# fixed state path fails toward a false regression (fleet notice, 2026-09-06;
+# same fix as lucid-cancel-tokens-repros).  One deliberate difference from that
+# harness: GS_REPRO_SCRATCH is read with get(), NOT setdefault().  This suite
+# SPAWNS a child (dump_payload.py), and an exported scratch path would be
+# inherited by it -- whereupon the child's atexit would delete the still-running
+# parent's directory.  So the child gets its own, and we only clean up a
+# directory we chose ourselves; a caller-pinned path is left alone.
+_OWNED = "GS_REPRO_SCRATCH" not in os.environ
+SCRATCH = os.environ.get("GS_REPRO_SCRATCH",
+                         os.path.join(SCRATCH_ROOT, "version-cache-%d" % os.getpid()))
+STATE_DIR = os.path.join(SCRATCH, "state")
+os.environ["XDG_STATE_HOME"] = STATE_DIR
+os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+if _OWNED:
+    # Reset at start as well as exit: a verdict must never depend on who ran
+    # here before. Gated on _OWNED for the reason above -- and because rmtree
+    # at start on a SHARED path is what made the chronicle suite destroy a peer
+    # agent's live directory (see that suite's ISOLATION note).
+    shutil.rmtree(SCRATCH, ignore_errors=True)
+    atexit.register(shutil.rmtree, SCRATCH, True)   # disposable byproduct, not state
+os.makedirs(STATE_DIR, exist_ok=True)
+
+
+class _CompletedProcess:
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.stderr = ""
+        self.returncode = returncode
+
+
+class CountingSubprocess:
+    """Stands in for the `subprocess` module inside the service's globals.
+
+    Records every argv it is handed and answers git queries from a canned
+    repo state, so a repro never depends on the real checkout being clean.
+    """
+
+    def __init__(self, hash_="abc1234", branch="perf/version-cache", dirty=False):
+        self.calls = []            # [argv]
+        self.hash = hash_
+        self.branch = branch
+        self.dirty = dirty
+
+    # -- the only seam _handle_version uses --------------------------------
+    def run(self, argv, *a, **kw):
+        self.calls.append(list(argv))
+        tail = [x for x in argv if x not in ("git",)]
+        text = ""
+        if "rev-parse" in tail and "--short" in tail:
+            text = self.hash
+        elif "rev-parse" in tail and "--abbrev-ref" in tail:
+            text = self.branch
+        elif "status" in tail:
+            text = " M gnome-speaks-service.py\n" if self.dirty else ""
+        elif "diff" in tail:
+            return _CompletedProcess("", 1 if self.dirty else 0)
+        return _CompletedProcess(text + "\n")
+
+    # -- assertions ---------------------------------------------------------
+    def git_calls(self):
+        return [c for c in self.calls if c and c[0] == "git"]
+
+    def git_count(self):
+        return len(self.git_calls())
+
+    def reset(self):
+        self.calls = []
+
+
+
+CONFIG_PINS = {
+    "key": "test-key", "wake_word": False, "wake_word_model": "",
+    "wake_word_secure_gate": False, "chronicle": False,
+    "continuous_dictation": False, "conversation_mode": False,
+    "dictation_mode": True, "terminal_mode": False, "skip_final_paste": False,
+    "injection_method": "ydotool", "read_notifications": False,
+    "llm_thinking": False, "spiel_provider": False, "debug": False,
+    "live_subtitles": False, "phrase_list": [], "wyoming_host": "",
+}
+
+REAL_STATE = os.path.join(os.path.expanduser("~/.local/state"), "gnome-speaks")
+
+
+def _isolate_config(mod):
+    """Rebuild CONFIG from the service's OWN defaults plus CONFIG_PINS.
+
+    CONFIG arrived holding JP's LIVE ~/.config/speech-to-cli/config.json (~47
+    keys), and _reload_config_flags() re-reads that file MID-RUN for every
+    _SYNC_FLAGS key, so pinning a couple of keys after load() was never
+    enough. Mutated IN PLACE: `from state import CONFIG` means audio, stt,
+    speech_tts and wyoming share the one dict object, so rebinding mod.CONFIG
+    would isolate the service module and miss all of them. CONFIG_PATH is
+    repointed at a file holding the same values, so the mid-run re-read
+    becomes a no-op and _save_config_flag() can never touch the real file.
+    """
+    real_defaults = mod.state.DEFAULTS_PATH
+    try:
+        mod.state.DEFAULTS_PATH = os.path.join(SCRATCH, "absent-config.json")
+        baseline = mod.state.load_config()
+    finally:
+        mod.state.DEFAULTS_PATH = real_defaults
+    baseline.update(CONFIG_PINS)
+    path = os.path.join(SCRATCH, "config.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(baseline, f)
+    mod.CONFIG_PATH = path
+    mod.CONFIG.clear()
+    mod.CONFIG.update(baseline)
+    return baseline
+
+
+@contextlib.contextmanager
+def config_scope(mod, **overrides):
+    """Run ONE scenario with its own CONFIG flags, restored afterwards."""
+    saved = dict(mod.CONFIG)
+    mod.CONFIG.update(overrides)
+    try:
+        yield mod.CONFIG
+    finally:
+        mod.CONFIG.clear()
+        mod.CONFIG.update(saved)
+
+
+def assert_isolated(mod):
+    """Prove the module cannot reach JP's live state, BEFORE any scenario.
+
+    CHRONICLE_PATH is computed at MODULE IMPORT from $XDG_STATE_HOME, so this
+    only holds if the env var was set before exec_module -- one moved import
+    away from breaking. Raises rather than warns: a repro that has quietly
+    attached itself to the real ledger must not report a verdict.
+    """
+    root = os.path.realpath(SCRATCH)
+    for name in ("CHRONICLE_PATH", "CONFIG_PATH"):
+        value = getattr(mod, name, None)
+        if value is None:
+            raise AssertionError(f"{name} is unset -- cannot prove isolation")
+        real = os.path.realpath(value)
+        if not (real == root or real.startswith(root + os.sep)):
+            raise AssertionError(
+                f"{name}={value!r} resolves OUTSIDE the isolated scratch "
+                f"{SCRATCH!r} -- refusing to run")
+        if os.path.realpath(REAL_STATE) in (real, os.path.dirname(real)):
+            raise AssertionError(f"{name} points at JP's live state dir")
+    return True
+
+
+def load():
+    """Import the module under test with the dangerous seams neutralized."""
+    sys.path.insert(0, os.path.dirname(SVC_PATH))  # sibling spellbook.py etc.
+    spec = importlib.util.spec_from_file_location("gsvc_under_test", SVC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["gsvc_under_test"] = mod
+    spec.loader.exec_module(mod)  # main() is __main__-guarded; nothing starts
+
+    _isolate_config(mod)   # BEFORE anything reads CONFIG
+    assert_isolated(mod)   # and prove it, before any scenario
+    mod._schedule_warmup = lambda *a, **k: None
+    mod._refresh_audio_detection = lambda *a, **k: None
+    mod._prewarm_recorder = lambda *a, **k: None
+    return mod
+
+
+class VersionClient:
+    """Calls _handle_version the way the HTTP server would, minus the socket."""
+
+    def __init__(self, mod, counter=None):
+        self.mod = mod
+        self.counter = counter or CountingSubprocess()
+        mod.subprocess = self.counter          # module-under-test globals only
+        self.payloads = []
+        # A BaseHTTPRequestHandler that never touches a socket: __init__ is the
+        # part that reads the request, so bypass it entirely.
+        self.handler = object.__new__(mod.SpeechHTTPHandler)
+        self.handler._send_json = self._send_json
+        self.handler.service = None
+
+    def _send_json(self, payload, status=200):
+        self.payloads.append(payload)
+
+    def get(self, n=1):
+        for _ in range(n):
+            self.handler._handle_version()
+        return self.payloads[-1]
+
+
+def fresh_cache(mod):
+    """Drop any cached payload so a repro measures a cold process."""
+    if hasattr(mod.SpeechHTTPHandler, "_version_cache"):
+        mod.SpeechHTTPHandler._version_cache = None

--- a/tests/repros/version-cache/repro_a_fork_storm.py
+++ b/tests/repros/version-cache/repro_a_fork_storm.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Repro for issue #53 -- GET /api/version forks three git processes per request.
+
+Measured on origin/main (7eaeb02):
+
+    20 requests -> 60 git processes, of which 20 are `git status --porcelain`.
+
+The git facts in the payload describe the code THIS PROCESS LOADED.  They
+cannot change while it runs, so every fork after the first three buys nothing;
+under the status poller they are a fork storm on the desktop session bus.
+
+exit 0 = fixed (<= 3 forks total, contract intact)
+exit 1 = bug present
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import CountingSubprocess, VersionClient, load  # noqa: E402
+
+N = 20
+FAILURES = []
+
+
+def check(label, ok, detail=""):
+    print(("  PASS  " if ok else "  FAIL  ") + label + (("  -- " + detail) if detail else ""))
+    if not ok:
+        FAILURES.append(label)
+
+
+def main():
+    mod = load()
+    counter = CountingSubprocess()
+    client = VersionClient(mod, counter)
+
+    first = client.get(1)
+    after_first = counter.git_count()
+    client.get(N - 1)
+    total = counter.git_count()
+    last = client.payloads[-1]
+
+    status_forks = [c for c in counter.git_calls() if "status" in c or "diff" in c]
+
+    print("git processes: %d after 1 request, %d after %d requests "
+          "(%d of them a working-tree scan)"
+          % (after_first, total, N, len(status_forks)))
+
+    check("first request costs at most 3 git processes",
+          after_first <= 3, "got %d" % after_first)
+    check("%d requests cost at most 3 git processes in total" % N,
+          total <= 3, "got %d (%.1f per request)" % (total, total / N))
+    check("no working-tree scan per request",
+          len(status_forks) <= 1, "got %d" % len(status_forks))
+
+    # -- the contract must be byte-identical apart from the live field --------
+    check("payload keys unchanged between requests",
+          list(first.keys()) == list(last.keys()),
+          "%s vs %s" % (list(first.keys()), list(last.keys())))
+    check("hash/branch/dirty served from the cache",
+          (first.get("hash"), first.get("branch"), first.get("dirty"))
+          == (last.get("hash"), last.get("branch"), last.get("dirty")))
+    check("git facts came from git, not a placeholder",
+          first.get("hash") == counter.hash and first.get("branch") == counter.branch,
+          repr((first.get("hash"), first.get("branch"))))
+    check("uptime is still present and live (int, recomputed per request)",
+          isinstance(last.get("uptime"), int))
+
+    # realm-sigil contract keys (import succeeds on this host)
+    expected = {"name", "description", "version", "hash", "branch", "dirty",
+                "built", "realm", "repo", "commit_url", "started", "uptime",
+                "runtime", "host", "pid"}
+    missing = expected - set(last.keys())
+    check("realm-sigil contract keys all present",
+          not missing, "missing %s" % sorted(missing) if missing else "")
+
+    print("\n%s" % ("FAILURES: " + ", ".join(FAILURES) if FAILURES else "all checks passed"))
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/version-cache/verify_version_cache.py
+++ b/tests/repros/version-cache/verify_version_cache.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Verification suite for issue #53 — /api/version must not fork git per request.
+
+    GS_SVC_PATH=<service file> python3 verify_version_cache.py
+
+Checks
+  1. the fork-storm repro (repro_a) passes on this file
+  2. the payload is field-for-field identical to the PRE-FIX baseline's
+     (GS_BASELINE_REF, default 7eaeb02), apart from the four fields that are
+     per-process by definition (uptime, pid, built, started).  Comparing against
+     a moving origin/main goes vacuous the moment the fix lands there.
+  3. `uptime` is still live — it tracks _SERVICE_START_TIME, it is not frozen
+     into the cache
+  4. the realm-sigil-absent fallback still works, is cached too, and keeps a
+     live uptime
+  5. concurrent requests build the payload exactly once (ThreadingHTTPServer)
+
+exit 0 = clean.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import threading
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+from harness import CountingSubprocess, VersionClient, load  # noqa: E402
+
+# Repo-relative by construction: this file lives at
+# tests/repros/<suite>/<file>.py, so four dirnames reach the repo root. #59:
+# the old defaults were absolute paths into ~/Projects/gnome-speaks-wt/<name>/
+# worktrees that no longer existed, so a bare run died with FileNotFoundError
+# instead of testing anything.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+# Scratch lives in the repo's gitignored tmp/, keyed by PID. Never a fixed
+# shared path: two agents running a suite at once used to corrupt each other
+# and it read exactly like a service regression.
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+SVC_PATH = os.environ.get(
+    "GS_SVC_PATH", SVC_DEFAULT)
+MAIN_REPO = REPO_ROOT
+# The ref the payload is compared against.  Default origin/main -- but once the
+# #53 fix landed on main that comparison became a TAUTOLOGY (the fix vs itself),
+# so the durable proof pins the last PRE-FIX commit.  Override with
+# GS_BASELINE_REF=<ref> when re-checking against a moving main is what you want.
+BASELINE_REF = os.environ.get("GS_BASELINE_REF", "7eaeb02")
+
+# ---------------------------------------------------------------------------
+# THE TWO-SIDED CONTROL -- do not remove, and do not let both refs be pre-fix.
+#
+# 577a05f is the ONLY commit where /api/version is correct: #53 merged there and
+# was silently overwritten one commit later by e55e619 (a stale-buffer write, no
+# revert commit -- `--contains` and "PR merged" both still answer YES).  With
+# only pre-fix references a suite can agree with itself forever while testing
+# nothing, which is exactly what this one did until 2026-09-06.
+#   GOOD_REF must PASS, BAD_REF must FAIL, every run.
+# ---------------------------------------------------------------------------
+GOOD_REF = os.environ.get("GS_GOOD_REF", "577a05f")   # #53 fix, as merged
+BAD_REF = os.environ.get("GS_BAD_REF", "7eaeb02")     # last pre-fix main
+from harness import SCRATCH  # noqa: E402  (per-PID; see the harness isolation note)
+
+BASELINE_DIR = os.path.join(SCRATCH, "baseline")
+PER_PROCESS = {"uptime", "pid", "built", "started"}
+
+FAILURES = []
+
+
+def check(label, ok, detail=""):
+    print(("  PASS  " if ok else "  FAIL  ") + label + (("  -- " + detail) if detail else ""))
+    if not ok:
+        FAILURES.append(label)
+
+
+def dump(svc_path):
+    env = dict(os.environ, GS_SVC_PATH=svc_path)
+    out = subprocess.run([sys.executable, os.path.join(HERE, "dump_payload.py")],
+                         capture_output=True, text=True, env=env, timeout=120)
+    if out.returncode != 0:
+        raise RuntimeError("dump_payload failed for %s:\n%s" % (svc_path, out.stderr[-2000:]))
+    return json.loads(out.stdout.strip().splitlines()[-1])
+
+
+def snapshot(ref, subdir="baseline"):
+    """A historical service file in a dir where its siblings still resolve."""
+    BASELINE_DIR = os.path.join(SCRATCH, subdir)
+    os.makedirs(BASELINE_DIR, exist_ok=True)
+    for name in os.listdir(MAIN_REPO):
+        if name.endswith((".py", ".json")) and name != "gnome-speaks-service.py":
+            link = os.path.join(BASELINE_DIR, name)
+            if not os.path.lexists(link):
+                os.symlink(os.path.join(MAIN_REPO, name), link)
+    dest = os.path.join(BASELINE_DIR, "gnome-speaks-service.py")
+    # NB: the siblings are symlinked from the CURRENT tree while the service
+    # file comes from BASELINE_REF.  Fine for this suite (nothing in
+    # _handle_version touches them), but it is a mixed checkout -- do not reuse
+    # this dir for a repro that exercises the injector or the spellbook.
+    blob = subprocess.run(
+        ["git", "-C", MAIN_REPO, "show", "%s:gnome-speaks-service.py" % ref],
+        capture_output=True, text=True, timeout=60)
+    if blob.returncode != 0:
+        raise RuntimeError("cannot read %s service file: %s" % (ref, blob.stderr))
+    with open(dest, "w", encoding="utf-8") as fh:
+        fh.write(blob.stdout)
+    return dest
+
+
+def main():
+    print("service under test: %s\n" % SVC_PATH)
+
+    # -- 0. DISCRIMINATION: this suite must disagree with itself across a
+    #        known-good and a known-bad snapshot, or its verdict is worthless.
+    for ref, label, want_ok in ((GOOD_REF, "known-GOOD", True),
+                                (BAD_REF, "known-BAD", False)):
+        try:
+            svc = snapshot(ref, "control-%s" % ref)
+        except RuntimeError as exc:
+            check("control snapshot %s (%s) is reachable" % (ref, label), False, str(exc))
+            continue
+        rc = subprocess.run([sys.executable, os.path.join(HERE, "repro_a_fork_storm.py")],
+                            env=dict(os.environ, GS_SVC_PATH=svc),
+                            capture_output=True, text=True, timeout=300)
+        forks = next((l for l in rc.stdout.splitlines() if l.startswith("git processes")), "?")
+        check("positive/negative control: %s %s must %s" % (
+                  ref, label, "PASS" if want_ok else "FAIL"),
+              (rc.returncode == 0) == want_ok, forks)
+
+    # -- 1. the repro -------------------------------------------------------
+    rc = subprocess.run([sys.executable, os.path.join(HERE, "repro_a_fork_storm.py")],
+                        env=dict(os.environ, GS_SVC_PATH=SVC_PATH),
+                        capture_output=True, text=True, timeout=300)
+    check("repro_a_fork_storm passes", rc.returncode == 0,
+          rc.stdout.strip().splitlines()[-1] if rc.stdout.strip() else rc.stderr[-300:])
+
+    # -- 2. contract identity vs origin/main --------------------------------
+    mine = dump(SVC_PATH)
+    theirs = dump(snapshot(BASELINE_REF))
+    check("key order identical to baseline (%s)" % BASELINE_REF,
+          list(mine.keys()) == list(theirs.keys()),
+          "%s vs %s" % (list(mine.keys()), list(theirs.keys())))
+    diff = {k: (theirs.get(k), mine.get(k))
+            for k in set(mine) | set(theirs)
+            if k not in PER_PROCESS and mine.get(k) != theirs.get(k)}
+    check("every stable field identical to baseline (%s)" % BASELINE_REF,
+          not diff, repr(diff))
+    check("the per-process fields are all still present",
+          PER_PROCESS <= set(mine), "missing %s" % sorted(PER_PROCESS - set(mine)))
+    check("uptime/pid are ints in both",
+          all(isinstance(p[k], int) for p in (mine, theirs) for k in ("uptime", "pid")))
+
+    # -- 3. uptime is live, not frozen into the cache -----------------------
+    mod = load()
+    client = VersionClient(mod)
+    first = dict(client.get(1))
+    mod._SERVICE_START_TIME -= 42          # as if 42 s of service life passed
+    second = client.get(1)
+    check("uptime advances with service life (not cached)",
+          second["uptime"] - first["uptime"] >= 42,
+          "%s -> %s" % (first["uptime"], second["uptime"]))
+    check("uptime advanced without re-forking git",
+          client.counter.git_count() <= 3, "%d forks" % client.counter.git_count())
+
+    # -- 4. realm-sigil-absent fallback -------------------------------------
+    mod2 = load2 = None
+    sys.modules["realm_sigil"] = None      # makes `from realm_sigil import ...` raise
+    try:
+        mod2 = load()
+        fb = VersionClient(mod2)
+        p1 = dict(fb.get(1))
+        forks_after_first = fb.counter.git_count()
+        mod2._SERVICE_START_TIME -= 7
+        p2 = fb.get(9)
+        check("fallback payload keeps its minimal contract",
+              set(p1) == {"name", "version", "hash", "branch", "dirty", "uptime"},
+              repr(sorted(p1)))
+        check("fallback used the real git facts",
+              (p1["hash"], p1["branch"]) == (fb.counter.hash, fb.counter.branch),
+              repr((p1["hash"], p1["branch"])))
+        check("fallback is cached too (10 requests, <= 3 forks)",
+              fb.counter.git_count() <= 3,
+              "%d after 1, %d after 10" % (forks_after_first, fb.counter.git_count()))
+        check("fallback uptime stays live", p2["uptime"] - p1["uptime"] >= 7,
+              "%s -> %s" % (p1["uptime"], p2["uptime"]))
+    finally:
+        sys.modules.pop("realm_sigil", None)
+
+    # -- 5. concurrent pollers build it exactly once ------------------------
+    mod3 = load()
+    counter = CountingSubprocess()
+    clients = [VersionClient(mod3, counter) for _ in range(8)]
+    mod3.SpeechHTTPHandler._version_cache = None
+    errors = []
+
+    def hammer(c):
+        try:
+            for _ in range(25):
+                c.get(1)
+        except Exception as exc:      # pragma: no cover - a race would land here
+            errors.append(exc)
+
+    threads = [threading.Thread(target=hammer, args=(c,)) for c in clients]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(60)
+    check("8 threads x 25 requests raised nothing", not errors, repr(errors[:2]))
+    check("8 threads x 25 requests forked git at most 3 times",
+          counter.git_count() <= 3, "%d forks" % counter.git_count())
+    payloads = {json.dumps({k: v for k, v in p.items() if k != "uptime"}, sort_keys=True)
+                for c in clients for p in c.payloads}
+    check("every thread saw the same payload", len(payloads) == 1,
+          "%d distinct payloads" % len(payloads))
+
+    print("\n%s" % ("FAILURES: " + ", ".join(FAILURES) if FAILURES else "all checks passed"))
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    finally:
+        shutil.rmtree(BASELINE_DIR, ignore_errors=True)


### PR DESCRIPTION
Closes #59.

The verification bar for anything touching `gnome-speaks-service.py` was "all repro suites green" — and the suites were not in the repo. They lived in an unversioned scratch directory, with defaults pointing at deleted worktrees (a bare run died with `FileNotFoundError` instead of testing anything) and scratch output going to shared absolute paths.

**Eleven suites move in. 44 checks, all green from a bare `tests/repros/run_all.sh` with no environment set at all.**

```
service-audit  chronicle-perf  cancel-tokens  subtitle-token  begin-refused
dead-recorder  pin-lifecycle   injector-seam  version-cache   offline-handoff
prefs-rig
```

No test framework, per project rule. Exit codes are `0` clean · `1` the defect is present · `2` **SETUP FAILURE** — the repro could not create the window it needed, so it reports neither a pass nor a bug. Several repros force a narrow window and then check the window was actually hit; two early drafts passed on unfixed builds before that existed. **Collapsing `2` into `0`/`1` restores the ability to pass for the wrong reason.**

## One input

`GS_SVC_PATH` — the service file under test — is the only input, and the runner sets it. The worktree dir and the scratch dir are *derived*. `verify_ibus_injector.py` previously read `GS_WT` and **ignored** `GS_SVC_PATH`, so a caller following the suite-wide contract silently tested the wrong tree; #69's doc line can now say `GS_SVC_PATH`.

## Scratch isolation is not cosmetic

Scratch moves to the repo's gitignored `tmp/repros/`, keyed by PID. The suites shared fixed absolute paths, and **two agents running one suite at once corrupted each other** — two concurrent runs of `verify_chronicle_contract.py` both fail with bogus `equivalence [...]` mismatches while each alone passes. That failure looks exactly like a service regression; it appeared in a sweep table as *"the #72 merge broke the chronicle suite"* and nearly got a good commit reverted.

Reset and cleanup are gated on the running process having created the directory, because **`rmtree`-at-start on a shared path makes the best-behaved run the most destructive one**: a "clean" start deletes a peer's live directory while it still holds the file open. That is why the symptom read as "fails clean, passes dirty" — the inverse of the usual stateful-test signature.

## offline-handoff runs one process per case

Two reasons. A red must name its scenario: this is the suite that caught `[FAIL] D azure-healthy-unchanged` on a trial merge while every other suite was green, because nothing else exercises the ordinary healthy-Azure dictation path. And case ordering is load bearing — case H replaces `stt.wyoming.transcribe` and never restores it, safe *only* because `build()` re-stubs it each call, while case G restores `_rest_stt_fallback` explicitly because `build()` does not. A process per case makes that irrelevant rather than merely currently-true.

## prefs-rig is not python

GJS/bash (`run.sh` → `gjs` + `gtk4-broadwayd`): 10 files, zero `.py`, by design — a `*.py` inventory returns a false negative on it, and a python collector must never import it. Its exit contract is preserved exactly: **0** = both runs completed; **1** = incomplete, or the branch emits *more* warnings than the baseline; a **differing stderr is not failure**. Its baseline is the branch's **merge base**, never a moving `origin/main`.

## Baselines: three distinctions that are load bearing

Full table in `tests/repros/README.md`.

- **`begin-refused`'s `l` is green on both sides by design.** It guards against a fix that stops speaking replies nobody cancelled — the failure a user notices before any of the ones j and k catch. Seeing it green on main reads like dead weight; it is the repro most likely to be deleted by mistake.
- **`offline-handoff`'s baseline is `70ff468`, not `79594dd`.** `79594dd` already contains #72, so case I fails there for *one* reason, not two. "Fails for two reasons" is the kind of note that stops someone investigating one reason too early.
- **`version-cache` runs a two-sided control every invocation** (`577a05f` must pass, `7eaeb02` must fail). #53's fix merged, was then deleted by a stale-buffer write with no revert commit, and was re-landed by #85. A suite with only *pre-fix* references can agree with itself forever while testing nothing — which is exactly what this one did. The literal SHAs must stay literal.

## CLAUDE.md

Items **7 and 8** now point at the in-repo runner. `grep -c 'scratch/gnome-speaks-dreamteam' CLAUDE.md` = **0**, and every path named in §Testing exists in the tree. Item 8's substance (the broadway rig's isolation and exit contracts) is preserved — an earlier draft of this edit swallowed it and it was restored verbatim.

## Verification

`tests/repros/run_all.sh` with no env vars: **44 checks, ALL SUITES GREEN.**

Leak scan clean — **with a planted-canary positive control first**, which is what caught it: a hostname I had already scrubbed once came *back*, because re-syncing from the scratch originals overwrote the corrected repo copy. Fixed in both copies so a future sync cannot undo it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive repository-local regression suite covering speech cancellation, transcription handoff, microphone failures, subtitle updates, queue behavior, chronicle storage, injector backends, preferences, and version reporting.
  * Added consolidated test runners with isolated configuration, state, audio, network, and desktop-session environments.
  * Added checks for expected playback, cancellation, error reporting, state transitions, configuration safety, and performance behavior.

* **Documentation**
  * Documented how to run the regression suites, interpret results, and use the preferences verification rig.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->