### PR TITLE
fix: the AI reply types through the cycle's pinned injector (#87)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -2984,7 +2984,7 @@ class GnomeSpeaksService:
                         if live_typing:
                             inj.send_backspaces(len(typed_partial[0]))
                             time.sleep(0.02)
-                        self._conversation_worker(user_text)
+                        self._conversation_worker(user_text, inj)
                         if not CONFIG.get("continuous_dictation", False):
                             self._save_config_flag("conversation_mode", False)
                         # _conversation_worker handles its own restart/warmup
@@ -4365,10 +4365,18 @@ class GnomeSpeaksService:
 
     # -- Streaming LLM response with incremental TTS ----------------------
 
-    def _stream_conversation_worker(self, user_text):
+    def _stream_conversation_worker(self, user_text, inj=None):
         """Stream LLM response and start TTS on each complete sentence.
 
         Uses the unified llm_stream library for all providers (including bedrock).
+
+        `inj` is the caller's PINNED backend when there is one. The streaming
+        cycle calls this synchronously from inside its pinned scope (the line
+        above the call is `inj.send_backspaces(...)`), so the `<type>` paste
+        below belongs to that utterance and must use that utterance's backend
+        -- the same rule that put the pin into _LiveTyper (#46/#61). Callers
+        with no pin (the batch/offline `_deliver_stt_result`) pass nothing and
+        get the current backend, which is correct for them.
         """
         # AI replies are user-initiated speech: hold the agent speech queue
         # for the whole turn (LLM streaming + sentence TTS).
@@ -4580,7 +4588,11 @@ class GnomeSpeaksService:
                 if type_text and not (cancel_token is not None
                                       and cancel_token.cancelled):
                     log.info("Typing %d chars at cursor (from streamed reply)", len(type_text))
-                    get_injector().paste(type_text)
+                    # The utterance's backend, not whatever is current: a
+                    # "cast typing engine" mid-reply rebuilds the process-wide
+                    # injector, and this paste belongs to the cycle that is
+                    # still holding the old one.
+                    (inj or get_injector()).paste(type_text)
                 elif type_text:
                     log.info("AI reply cancelled — %d chars NOT typed",
                              len(type_text))
@@ -4613,16 +4625,21 @@ class GnomeSpeaksService:
 
     # -- Conversation worker ------------------------------------------------
 
-    def _conversation_worker(self, user_text):
+    def _conversation_worker(self, user_text, inj=None):
         """Send transcribed text to an LLM and speak the response.
 
         All providers (including bedrock) now stream via llm_stream.
+
+        `inj`: see _stream_conversation_worker. Optional and TRAILING on
+        purpose -- five repros across two suites call this as
+        `Thread(target=svc._conversation_worker, args=(text,))`, and a
+        required or leading parameter would break every one of them.
         """
         if not stream_chat:
             GLib.idle_add(self._emit_error, "LLM streaming library not available (llm_stream not found)")
             self._set_state("idle")
             return
-        return self._stream_conversation_worker(user_text)
+        return self._stream_conversation_worker(user_text, inj)
 
     def _load_cca_config(self):
         """Load cloud-chat-assistant config."""


### PR DESCRIPTION
Closes #87.

The streaming cycle pins `inj = get_injector()` per utterance (#46/#61) and calls `_conversation_worker(user_text)` **synchronously** from inside that scope — the line above the call is `inj.send_backspaces(...)`. The reply's `<type>` paste then resolved `get_injector()` afresh, so a "cast typing engine" landing mid-reply routed the paste to the **new** backend while the cycle still held the old one. Same class as the `_LiveTyper` hole #61 closed.

`inj` is threaded down as an optional **trailing** parameter (`_conversation_worker` → `_stream_conversation_worker` → the paste). Trailing and optional on purpose: five repros across two suites call this as `Thread(target=svc._conversation_worker, args=(text,))`, and `_deliver_stt_result` (batch/offline) has no pin and correctly keeps the current backend.

### Scope — narrower than the issue claimed, and I should say so plainly

The issue and the review both framed the harm as a **stranded input method for 120 s**. I measured it, and that part is wrong:

| swaps during the reply | paste lands on | idle hook ends | cycle `finally` ends | stranded |
|---|---|---|---|---|
| none | A (=pin) | A | A | — |
| one, before the paste | B | B | A | — |
| one, after the paste | A (=pin) | B | A | — |
| two | B | C | A | — (2nd rebuild `cancel()`s B) |

`get_injector()`'s rebuild calls `previous.cancel()` on the current global, and #61's `finally` covers the pin — so nothing is left holding the IME. Confirmed empirically: on the unfixed base the repro's R2/R3 (nothing left acquired; the paster is released) **pass**, and they still pass with #61's release deliberately removed. The strand-detection itself is sound — `P1b` in `repro_pin_lifecycle` fires on that same sabotaged build — so this is a difference of scenario, not a blind instrument.

**A strand needs something to type through the pinned backend *after* the swap.** The reply's paste is that utterance's last injector use, so there is nothing after it.

What is real, and what this PR fixes, is **wrong-backend delivery**: the paste is performed by a backend other than the one the utterance was pinned to.

`_set_state('idle')` → `get_injector().end()` is deliberately left resolving fresh — it's a global catch-all on every state transition, and the pin is already released by the cycle's own `finally`.

### Repro

`repro_compound_reply_pin.py` drives the **real** `_streaming_stt_cycle` in conversation mode — not the worker on its own thread, which is what all five existing reply repros do and which lacks the cycle's release entirely, so it would report a strand production doesn't have. The cast lands mid-reply, between the first spoken sentence and the `<type>` tag: the only ordering in which the two resolutions can disagree.

```
unfixed d92166c   FAIL (R1): the <type> paste landed on ibus, not the pinned backend
this commit       PASS
```

Two setup traps it now asserts against, both of which silently produced a *green* run while measuring the wrong code path: `_reload_config_flags()` restoring `conversation_mode=False` (so the cycle took the dictation path and the reply never ran), and single-shot `turn_end` setting `_stop_event` (so `_stream_conversation_worker` aborted before `stream_chat`).

### Gate

swept runner all green · offline-handoff A–I ALL GREEN · begin-refused j/k/l · subtitle e1–e4 · pin P1–P3 · compound X · wake gate 12/12 · `py_compile` · leak scan 0 · symbol check base-vs-tip clean.
