### PR TITLE
docs: the reply pin hand-down depends on the synchronous call (#87)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -2984,6 +2984,19 @@ class GnomeSpeaksService:
                         if live_typing:
                             inj.send_backspaces(len(typed_partial[0]))
                             time.sleep(0.02)
+                        # The pin is handed down so the reply's <type> paste
+                        # uses THIS utterance's backend: one utterance, one
+                        # backend, the same rule that put the pin into
+                        # _LiveTyper (#46/#61).
+                        #
+                        # ⚠️ This depends on the call being SYNCHRONOUS on the
+                        # cycle thread. The cleanup below releases `inj`, and
+                        # it only runs after this returns. Make the reply
+                        # async and inj.end() lands BEFORE the paste -- the
+                        # paste would then go through an ended backend, which
+                        # is worse than the fresh get_injector() this replaced.
+                        # (Note that every reply repro drives the worker on
+                        # its own thread, so none of them would catch it.)
                         self._conversation_worker(user_text, inj)
                         if not CONFIG.get("continuous_dictation", False):
                             self._save_config_flag("conversation_mode", False)


### PR DESCRIPTION
Comment only, no behaviour change. Recovers the design note that was written after #88 was pushed and so didn't make it in.

#88 handed the cycle's pinned injector down to the AI reply so the `<type>` paste uses that utterance's backend. Why that is *safe* isn't visible at the call site: `_conversation_worker` is called **synchronously** on the cycle thread, so the cleanup that releases `inj` only runs after the reply returns.

Make the reply async and `inj.end()` lands **before** the paste — the paste would then go through an ended backend, which is strictly worse than the fresh `get_injector()` #88 replaced. And nothing would catch it: all five existing reply repros (subtitle e3/e4, begin-refused j/k/l) drive the worker on their own thread, which doesn't have the cycle's release at all. So the invariant has no test coverage and has to be stated where someone would break it.

Verified: every added line is a comment (`git diff -U0` shows 0 added non-comment lines), `py_compile` clean, leak scan 0.

**Note on the branch name:** this rides `refactor/dedupe-clipboard-loop-flags` because that's the worktree I was given and I don't create branches. #44's dedupe commits will follow in a separate PR once this merges — flagged so the branch name doesn't mislead a reviewer.
