### PR TITLE
refactor: dedupe the selection readers, the restart callback, and the flag toggles (#44)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -3733,6 +3733,25 @@ class GnomeSpeaksService:
         self._spell_speak("Unknown field — press the hotkey to dictate here.")
         return True
 
+    def _toggle_config_flag(self, key, default=False):
+        """Flip a boolean mode flag, persist it, and return the NEW value.
+
+        Only the flip-and-persist is shared. What stays at each call site:
+        the spoken reply (some are one template, some are two distinct
+        sentences), and subtitles_toggle's extra GSettings dual-write.
+
+        `default` is a PARAMETER, not a constant: live_subtitles and
+        chronicle default to True and the rest to False, so a wrong default
+        here would silently invert which way a spell toggles on first use.
+
+        Always goes through _save_config_flag, never `CONFIG[key] = ...`:
+        that is the seam keeping the runtime dict and config.json from
+        drifting (CLAUDE.md, config dual-write).
+        """
+        new = not CONFIG.get(key, default)
+        self._save_config_flag(key, new)
+        return new
+
     def _spell_ctx_dbus(self, op):
         """Self-directed spell operations (dbus_self action type)."""
         if op == "stop":
@@ -3749,8 +3768,7 @@ class GnomeSpeaksService:
             self._save_config_flag("conversation_mode", False)
             self._save_config_flag("terminal_mode", False)
         elif op == "read_notifications_toggle":
-            new = not CONFIG.get("read_notifications", False)
-            self._save_config_flag("read_notifications", new)
+            new = self._toggle_config_flag("read_notifications")
             return "The notification herald is %s." % ("on" if new else "off")
         elif op == "injection_toggle":
             # The spell is the voice-recoverable way out of an IBus trial, so
@@ -3782,26 +3800,22 @@ class GnomeSpeaksService:
             get_injector().press_enter()
             return None
         elif op == "loop_toggle":
-            new = not CONFIG.get("continuous_dictation", False)
-            self._save_config_flag("continuous_dictation", new)
+            new = self._toggle_config_flag("continuous_dictation")
             if new:
                 return ("The loop is woven — I will keep listening "
                         "after each phrase.")
             return "The loop is broken — one phrase at a time."
         elif op == "wake_word_toggle":
-            new = not CONFIG.get("wake_word", False)
-            self._save_config_flag("wake_word", new)
+            new = self._toggle_config_flag("wake_word")
             return "The waking watch is %s." % ("on" if new else "off")
         elif op == "thinking_toggle":
-            new = not CONFIG.get("llm_thinking", False)
-            self._save_config_flag("llm_thinking", new)
+            new = self._toggle_config_flag("llm_thinking")
             if new:
                 return ("Deep thought engaged — replies will be slow "
                         "and thorough.")
             return "Deep thought off — fast replies."
         elif op == "subtitles_toggle":
-            new = not CONFIG.get("live_subtitles", True)
-            self._save_config_flag("live_subtitles", new)
+            new = self._toggle_config_flag("live_subtitles", default=True)
             # Dual-write: the extension gates its overlay on GSettings —
             # keep both layers in sync (see the config dual-write gotcha).
             schema_dir = os.path.expanduser(
@@ -3834,8 +3848,7 @@ class GnomeSpeaksService:
                 parts.append(f"{who}: {text}")
             return " … ".join(parts)
         elif op == "chronicle_toggle":
-            new = not CONFIG.get("chronicle", True)
-            self._save_config_flag("chronicle", new)
+            new = self._toggle_config_flag("chronicle", default=True)
             if new:
                 return "The chronicle records once more."
             return "The chronicle is sealed — nothing will be written."

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -643,9 +643,18 @@ def _chronicle_find(entry_id):
 # Clipboard helpers (our own — do not import from speech-to-cli)
 # ---------------------------------------------------------------------------
 
-def clipboard_read():
-    """Read text from the clipboard (Wayland-first, X11 fallback)."""
-    for cmd in [["wl-paste", "--no-newline"], ["xclip", "-selection", "clipboard", "-o"]]:
+def _read_via(cmds, label):
+    """Read text with the first of `cmds` that exists (Wayland-first, X11
+    fallback).
+
+    The clipboard and the PRIMARY selection differ only in which tools to ask
+    and what to call the failure in the log -- everything else (the 5 s
+    timeout, "returncode 0 means the text is stdout verbatim", falling through
+    on FileNotFoundError, and "" when nothing worked) is the same contract.
+    Deliberately returns stdout UNSTRIPPED: callers that want it trimmed do
+    their own trimming, and one of them also truncates.
+    """
+    for cmd in cmds:
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
             if result.returncode == 0:
@@ -653,8 +662,16 @@ def clipboard_read():
         except FileNotFoundError:
             continue
         except subprocess.TimeoutExpired:
-            log.debug("Clipboard read timed out: %s", cmd[0])
+            log.debug("%s read timed out: %s", label, cmd[0])
     return ""
+
+
+def clipboard_read():
+    """Read text from the clipboard (Wayland-first, X11 fallback)."""
+    return _read_via(
+        [["wl-paste", "--no-newline"],
+         ["xclip", "-selection", "clipboard", "-o"]],
+        "Clipboard")
 
 
 def clipboard_write(text):
@@ -1152,16 +1169,10 @@ def _terminal_lowercase(text):
 
 def selection_read():
     """Read the currently highlighted/selected text (PRIMARY selection)."""
-    for cmd in [["wl-paste", "--primary", "--no-newline"], ["xclip", "-selection", "primary", "-o"]]:
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
-            if result.returncode == 0:
-                return result.stdout
-        except FileNotFoundError:
-            continue
-        except subprocess.TimeoutExpired:
-            log.debug("Selection read timed out: %s", cmd[0])
-    return ""
+    return _read_via(
+        [["wl-paste", "--primary", "--no-newline"],
+         ["xclip", "-selection", "primary", "-o"]],
+        "Selection")
 
 
 # Voice commands: spoken punctuation → actual characters

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -2287,10 +2287,9 @@ class GnomeSpeaksService:
         _schedule_warmup()
 
         if user_text and CONFIG.get("continuous_dictation", False) and not self._stop_event.is_set():
-            GLib.idle_add(lambda: (self.start_listening(quick=True), False)[-1]
-                          if (CONFIG.get("continuous_dictation", False)
-                              and not self._stop_event.is_set())
-                          else False)
+            GLib.idle_add(self._restart_listening_cb(
+                lambda: (CONFIG.get("continuous_dictation", False)
+                         and not self._stop_event.is_set())))
 
     def _report_recorder_dead(self, cycle):
         """The single place the lost-microphone verdict reaches the user.
@@ -3606,11 +3605,10 @@ class GnomeSpeaksService:
                     and CONFIG.get("conversation_mode", False)
                     and not self._stop_event.is_set()):
                 log.info("Hands-free: auto-restarting listening after TTS")
-                GLib.idle_add(lambda: (self.start_listening(quick=True), False)[-1]
-                              if (CONFIG.get("continuous_dictation", False)
-                                  and CONFIG.get("conversation_mode", False)
-                                  and not self._stop_event.is_set())
-                              else False)
+                GLib.idle_add(self._restart_listening_cb(
+                    lambda: (CONFIG.get("continuous_dictation", False)
+                             and CONFIG.get("conversation_mode", False)
+                             and not self._stop_event.is_set())))
         return outcome
 
     def speak_clipboard(self):
@@ -4331,6 +4329,32 @@ class GnomeSpeaksService:
             history = list(self._conversation_history[-40:])
         return system_prompt, history
 
+    def _restart_listening_cb(self, still_wanted):
+        """A one-shot GLib source callback that restarts listening.
+
+        Collapses `lambda: (self.start_listening(quick=True), False)[-1] if
+        <guard> else False`, which appeared four times. The tuple-index trick
+        exists only to force the False that makes a GLib source fire once, and
+        it is easy to get subtly wrong -- that is what is worth having in one
+        place.
+
+        What deliberately STAYS at each call site:
+          * the guard, because all four differ (loop only; loop AND
+            conversation; stop-event only), and
+          * the scheduler, because `idle_add` and `timeout_add(2000)` are a
+            timing decision, not boilerplate.
+
+        `still_wanted` is re-checked HERE, when the source fires, not when it
+        was scheduled: between the two the user can stop or toggle the loop
+        off, and the restart must not happen then. That re-check is why the
+        guard is passed as a callable.
+        """
+        def _cb():
+            if still_wanted():
+                self.start_listening(quick=True)
+            return False
+        return _cb
+
     def _maybe_loop_restart(self):
         """Restart listening in AI+Loop mode. Called from worker thread."""
         if (CONFIG.get("continuous_dictation", False)
@@ -4342,9 +4366,8 @@ class GnomeSpeaksService:
             # audio detection since nothing changed within the loop.
             # Use GLib.idle_add because start_listening touches state
             # that must be set from the main thread context.
-            GLib.idle_add(lambda: (self.start_listening(quick=True), False)[-1]
-                          if not self._stop_event.is_set()
-                          else False)
+            GLib.idle_add(self._restart_listening_cb(
+                lambda: not self._stop_event.is_set()))
         else:
             _schedule_warmup()
 
@@ -4638,11 +4661,8 @@ class GnomeSpeaksService:
                     and CONFIG.get("conversation_mode", False)
                     and not self._stop_event.is_set()):
                 log.info("AI+Loop: retry after error (2s delay)")
-                GLib.timeout_add(2000, lambda: (
-                    (self.start_listening(quick=True), False)[-1]
-                    if not self._stop_event.is_set()
-                    else False
-                ))
+                GLib.timeout_add(2000, self._restart_listening_cb(
+                    lambda: not self._stop_event.is_set()))
         finally:
             self._cancels.retire(cancel_token)
             self._release_user_speech()


### PR DESCRIPTION
Closes #44. Three commits, one dedupe each, so a bisect can name one. Behaviour-preserving throughout — each commit was probed against `origin/main` and the outputs diffed, not eyeballed.

| commit | what collapsed | probe |
|---|---|---|
| `23af615` | `clipboard_read()` + `selection_read()` → one `_read_via(cmds, label)` | 4 scenarios × 2 fns: return value, command list, timeout — byte-identical |
| `1801898` | 4 hand-built restart callbacks → `_restart_listening_cb(guard)` | scheduler, return value, and call-count with the guard open vs broken — identical |
| `903d15f` | 6 toggle spells' flip-and-persist → `_toggle_config_flag(key, default)` | 6 spells × 3 starting states (unset/True/False): persisted `(key, value)` **and** spoken reply — identical across all 18 |

### What I deliberately did **not** collapse

The ticket reads as three tidy duplications. Two of them aren't, and collapsing them would have shipped a behaviour change wearing a dedupe's clothes:

- **`_get_clipboard_text()`** also reads the clipboard, but on a different contract: `timeout=1` (not 5), requires non-empty after strip, returns the text **stripped and truncated to 200 chars**, and answers `None` rather than `""` on failure. Four observable differences — left alone.
- **The restart guards.** All four call sites differ (loop only; loop *and* conversation; stop-event only ×2). Merging them changes *when* the mic reopens.
- **The restart schedulers.** Three are `idle_add`; the error-recovery path is `timeout_add(2000)`. Merging them moves a restart by two seconds.

So each helper takes the varying part as a parameter and the call sites keep their own semantics. The guard stays a *callable* so it's still re-evaluated when the source **fires**, not when it was scheduled — between the two the user can stop or toggle the loop off.

The one thing (3) could plausibly break is a default: `live_subtitles` and `chronicle` default `True`, the other four `False`, so a wrong default silently inverts which way a spell toggles on first use. That's why `default` is a parameter and why the probe includes the `unset` column. Writes still go through `_save_config_flag` rather than `CONFIG[key] = …` — the seam that keeps the runtime dict and `config.json` from drifting (CLAUDE.md, config dual-write).

### Symbol check (base → tip, fixed-string)

```
start_listening(quick=True), False)[-1]    4 -> 1   (remaining one is the helper's docstring)
new = not CONFIG.get                       6 -> 1   (remaining one is inside the helper)
_restart_listening_cb                      0 -> 5   (1 def + 3 idle_add + 1 timeout_add)
_toggle_config_flag                        0 -> 7   (1 def + 6 call sites)
_read_via                                  0 -> 3   (1 def + 2 call sites)
```

My first run of this check used `grep -c` on a pattern containing `[-1]`, which grep read as a character class and reported `base = 0` — a clean but fictional "already gone". Redone with `grep -F`.

### Gate

swept runner all `rc=0` · offline-handoff A–I ALL GREEN · pin P1–P3 · compound X · compound reply-pin · begin-refused j/k/l · wake gate 12/12 · `py_compile` · leak scan 0. Re-run after rebasing onto `2912ee2`.
