### PR TITLE
fix(repros): name the prefs-rig flake, split its exit codes, resolve paths

### DIFF
--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -16,6 +16,14 @@ tests/run-repros.sh /path/to/service.py   # a worktree, or an extracted SHA
 `GS_SVC_PATH` — the `gnome-speaks-service.py` under test — is the **only** input
 a suite needs, and `run-repros.sh` sets it. Everything else is derived:
 
+⚠️ **It must be ABSOLUTE.** Each suite runs via `cd "$HERE/<suite>"`, so a
+relative path resolves against the *suite* directory and every suite dies with
+`FileNotFoundError` naming a path inside it. The trap is that `run_all.sh`
+validates the path with `[ -f "$SVC" ]` in the *caller's* cwd, so a relative one
+passes the check and fails everywhere after — validated here, used there.
+`run_all.sh` now resolves its argument for you; pass an absolute path anyway if
+you export `GS_SVC_PATH` yourself for a single suite.
+
 | | |
 |---|---|
 | worktree dir (sibling modules: `spellbook.py`, `injector.py`, `ibus_injector.py`) | `dirname(GS_SVC_PATH)`; `GS_WT` overrides it only to mix trees deliberately |
@@ -123,6 +131,15 @@ Both forms have bitten this tree, and the **silent** one is the dangerous half:
 Same root cause: taking a pipeline's exit status as the answer to a question it
 never answered. `$?` after a pipe reads the LAST command, not the interesting
 one — that form once reported two red suites as green here.
+
+⚠️ **And do not "fix" this by reaching for `set -euo pipefail`, which is the
+obvious next move after reading the above.** `set -o pipefail` alone is right and
+all five runners now set it. **`-e` is not**: `grep -c` exits `1` when the count
+is `0`, and a zero count is the *passing* case for a warning counter, so `-e`
+aborts a run precisely when it succeeds — measured on `prefs-rig/run.sh`, whose
+two `grep -c` lines it kills on a clean run. The hardening against the silent
+form has its own short-form failure. If you do add `-e`, write every count as
+`$(grep -c X f || true)` first.
 
 ## Instruments that must survive a refactor
 

--- a/tests/repros/begin-refused/run_all.sh
+++ b/tests/repros/begin-refused/run_all.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Usage: ./run_all.sh /path/to/gnome-speaks-service.py
 set -u
+# pipefail so a pipeline's status reflects the interesting command, not just the
+# last one. Prophylactic here -- no pipeline in this file has its status consumed
+# today -- and set uniformly across all five runners so the next one added cannot
+# inherit `... | grep X | tail -1`, which returns 0 when the grep matched nothing.
+#
+# ⚠️ NOT `set -e`, deliberately: `grep -c` exits 1 on a zero count, and a zero
+# count is the PASSING case for a warning counter. `set -euo pipefail` aborts on
+# success. If you add -e, write every count as `$(grep -c X f || true)` first.
+set -o pipefail
 # Default to the service in THIS checkout: tests/repros/<suite>/ -> repo root,
 # so a bare run tests the tree you are standing in.
 REPO="$(cd "$(dirname "$0")/../../.." && pwd)"

--- a/tests/repros/dead-recorder/run_all.sh
+++ b/tests/repros/dead-recorder/run_all.sh
@@ -13,6 +13,15 @@
 # Against a moving ref this check goes vacuous the moment the fix merges: it
 # starts comparing the fix to itself and passes forever. Verified 2026-09-06.
 set -u
+# pipefail so a pipeline's status reflects the interesting command, not just the
+# last one. Prophylactic here -- no pipeline in this file has its status consumed
+# today -- and set uniformly across all five runners so the next one added cannot
+# inherit `... | grep X | tail -1`, which returns 0 when the grep matched nothing.
+#
+# ⚠️ NOT `set -e`, deliberately: `grep -c` exits 1 on a zero count, and a zero
+# count is the PASSING case for a warning counter. `set -euo pipefail` aborts on
+# success. If you add -e, write every count as `$(grep -c X f || true)` first.
+set -o pipefail
 # Default to the service in THIS checkout: tests/repros/<suite>/ -> repo root,
 # so a bare run tests the tree you are standing in.
 REPO="$(cd "$(dirname "$0")/../../.." && pwd)"

--- a/tests/repros/prefs-rig/README.md
+++ b/tests/repros/prefs-rig/README.md
@@ -16,9 +16,17 @@ It sandboxes `HOME` and forces `GSETTINGS_BACKEND=memory`, so a run can never
 write the real `~/.config/speech-to-cli/config.json` or touch dconf.
 
 ```bash
-./run.sh ~/Projects/gnome-speaks-wt/<wt>/prefs.js                # one file
-./run.sh ~/Projects/gnome-speaks-wt/<wt>/prefs.js /tmp/main.js   # + baseline diff
+./run.sh <checkout>/prefs.js                                  # one file
+./run.sh <checkout>/prefs.js --baseline-rev $(git merge-base origin/main HEAD)
+./run.sh <checkout>/prefs.js <some-dir>/prefs.js              # explicit baseline file
 ```
+
+Relative paths are fine. `--baseline-rev` extracts the baseline into the run
+dir, so there is no path of yours for the `>` in a `git show … > <file>` recipe
+to land on by accident.
+
+**Baseline against the MERGE BASE, not a moving `origin/main`** — otherwise a
+main that advances mid-review manufactures regressions that are not yours.
 
 It reports, for the Audio page: build time, each combo row's options and
 selected index **synchronously** and again **after the async probes land**, and

--- a/tests/repros/prefs-rig/harness.js
+++ b/tests/repros/prefs-rig/harness.js
@@ -1,6 +1,8 @@
 // Standalone prefs harness: loads a prefs.js by path, builds a REAL mapped
 // Adw.PreferencesWindow on a broadway display, and reports on the Audio page.
-// Usage: gjs -m tmp/harness.js <abs-path-to-prefs.js>
+// Usage: gjs -m harness.js <ABSOLUTE-path-to-prefs.js>
+// run.sh resolves relative paths before invoking this; a bare gjs call must
+// pass an absolute one (see the guard below for why).
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import Gtk from 'gi://Gtk?version=4.0';
@@ -11,6 +13,20 @@ Gio.resources_register(Gio.resource_load(
     '/usr/share/gnome-shell/org.gnome.Shell.Extensions.src.gresource'));
 
 const PREFS = system.programArgs[0];
+
+// A module URI needs an absolute path. `import('file://../prefs.js')` resolves
+// against THIS file's directory, not the caller's shell, and fails with
+// `ImportError: Unable to load file async from: file://../prefs.js` -- an error
+// naming a path the reader never typed. Resolving it here would be worse than
+// failing: gjs is invoked with cwd set to the run dir, so a path relative to the
+// caller's cwd would silently resolve somewhere else and test the WRONG FILE.
+// run.sh does the resolution while it still knows the caller's cwd; this only
+// has to refuse to guess.
+if (!PREFS || !GLib.path_is_absolute(PREFS)) {
+    printerr(`harness.js: need an ABSOLUTE path to prefs.js, got "${PREFS ?? ''}".`);
+    printerr('Use run.sh (which resolves relative paths), or pass an absolute path.');
+    system.exit(2);
+}
 const EXTDIR = GLib.getenv('GS_PREFS_EXTDIR') ||
     (GLib.get_current_dir() + '/fakeext');
 

--- a/tests/repros/prefs-rig/run.sh
+++ b/tests/repros/prefs-rig/run.sh
@@ -3,8 +3,13 @@
 # Audio page. Uses gtk4-broadwayd, so it never touches the live GNOME session:
 # no window appears, no focus is stolen, safe while someone is dictating.
 #
-#   ./run.sh <abs-path-to-prefs.js>            # test one file
-#   ./run.sh <branch-prefs.js> <main-prefs.js> # test + baseline + stderr diff
+#   ./run.sh <prefs.js>                          # test one file
+#   ./run.sh <prefs.js> <baseline-prefs.js>      # + baseline + stderr diff
+#   ./run.sh <prefs.js> --baseline-rev <sha>     # baseline straight from git
+#
+# Relative paths are fine -- they are resolved here, while the caller's cwd is
+# still known. --baseline-rev extracts into the managed run dir, so there is no
+# user-supplied path to point at a file you did not mean to overwrite.
 #
 # Why this exists: `gnome-extensions prefs <uuid>` loads the INSTALLED copy in
 # ~/.local/share/gnome-shell/extensions, not your worktree, so it cannot verify
@@ -20,19 +25,96 @@
 #     into this shell, so a run cannot write the real config or dconf.
 #   - The broadway display number is per-PID and probed until one binds.
 set -u
+# Prophylactic: this script has no pipeline whose exit status is consumed today,
+# so pipefail changes nothing here YET. It is set so that the next pipeline added
+# cannot silently inherit `... | grep X | tail -1`, which returns 0 when the grep
+# matched nothing.
+set -o pipefail
+
+# ⚠️ Deliberately NOT `set -e`, and this part is NOT prophylactic -- it is a live
+# hazard. `grep -c` exits 1 when the count is 0, and count 0 is ZERO WARNINGS,
+# i.e. the PASSING case. Measured: `set -euo pipefail` aborts this script on the
+# two grep -c lines below precisely when a run succeeds. Anyone who reads the
+# pipeline-status section in tests/repros/README.md and reaches for the standard
+# hardening will break this script; write counts as `$(grep -c X f || true)`
+# first if you ever add it.
+
+# EXIT CONTRACT -- assert the LINE, not just the code:
+#   0  both runs completed, branch emits no more warnings than baseline
+#   1  REGRESSION      -> "!! REGRESSION: ..."       (stdout)
+#   2  SETUP FAILURE   -> "!! SETUP FAILURE: ..."    (stdout)
+#   3  HARNESS DID NOT COMPLETE -> "!! HARNESS ..."  (stdout)
+# 1 is reserved strictly for a real regression, so a red meaning "this machine
+# was busy" can never be read as "your change broke something". All verdict
+# lines go to STDOUT: they are the result, not a diagnostic, and a caller
+# capturing only stdout must still see WHY it failed.
+#
+# Defined here, above its first use: as a function called via `|| setup_fail`,
+# a definition further down silently becomes a 127 that `||` swallows, and the
+# script runs on past the precondition it was supposed to stop at.
+setup_fail() { echo "!! SETUP FAILURE: $*"; exit 2; }
+
 HERE=$(cd "$(dirname "$0")" && pwd)
-BRANCH=${1:?usage: run.sh <prefs.js> [baseline-prefs.js]}
-BASE=${2:-}
+BRANCH=${1:?usage: run.sh <prefs.js> [baseline-prefs.js | --baseline-rev <sha>]}
+
+# Resolve while the caller's cwd is still ours: harness.js needs an absolute
+# path (a module URI resolves relative paths against the harness's own dir) and
+# everything below runs after a `cd`.
+abspath() { case "$1" in /*) printf '%s\n' "$1" ;; *) printf '%s\n' "$PWD/$1" ;; esac; }
+BRANCH=$(abspath "$BRANCH")
+command -v gjs            >/dev/null 2>&1 || setup_fail "gjs not installed"
+command -v gtk4-broadwayd >/dev/null 2>&1 || setup_fail "gtk4-broadwayd not installed"
+[ -f "$BRANCH" ] || setup_fail "no such file: $BRANCH"
+
+BASE=""
+BASE_REV=""
+if [ "${2:-}" = "--baseline-rev" ]; then
+    BASE_REV=${3:?--baseline-rev needs a git revision}
+elif [ -n "${2:-}" ]; then
+    BASE=$(abspath "$2")
+    [ -f "$BASE" ] || setup_fail "no such baseline file: $BASE"
+fi
+
 EXT=$(dirname "$BRANCH")
 
 RUN="$HERE/run-$$"
 BWPID=""
-cleanup() { [ -n "$BWPID" ] && kill "$BWPID" 2>/dev/null; rm -rf "$RUN"; }
+OURSOCK=""
+
+# A killed gtk4-broadwayd LEAVES ITS SOCKET FILE BEHIND. Treating "file exists"
+# as "display occupied" meant every run permanently burned a display number --
+# 62 stale sockets had accumulated here, against a probe window only 26 wide, so
+# the rig got monotonically more likely to fail the longer it was used. That is
+# the real flake, and it is why it showed up during a repeated hunt.
+# broadwayd rebinds over a stale file happily (measured), so the only correct
+# question is whether something is LISTENING.
+sock_live() { timeout 1 python3 -c \
+    "import socket,sys; socket.socket(socket.AF_UNIX).connect(sys.argv[1])" "$1" 2>/dev/null; }
+# Keep $RUN on any non-zero exit so broadwayd.log survives for exactly the case
+# where someone needs it; clean up only on success. A red that deletes its own
+# evidence is the red people learn to skim.
+cleanup() {
+    _rc=$?
+    [ -n "$BWPID" ] && kill "$BWPID" 2>/dev/null
+    [ -n "$OURSOCK" ] && rm -f "$OURSOCK"     # do not leak a display number
+    if [ "$_rc" -eq 0 ]; then rm -rf "$RUN"
+    else echo "run dir kept for diagnosis: $RUN"; fi
+}
 trap cleanup EXIT
 mkdir -p "$RUN/home/.config/speech-to-cli" "$RUN/fakeext/schemas"
 
-glib-compile-schemas --targetdir "$RUN/fakeext/schemas" "$EXT/schemas/" || exit 1
-cp "$EXT/metadata.json" "$RUN/fakeext/" || exit 1
+# --baseline-rev: extract into the run dir, so no caller-supplied path is
+# written to and nothing survives the run.
+if [ -n "$BASE_REV" ]; then
+    BASE="$RUN/baseline-prefs.js"
+    git -C "$EXT" show "$BASE_REV:prefs.js" > "$BASE" 2>/dev/null \
+        || setup_fail "could not extract prefs.js at '$BASE_REV' from $EXT"
+    echo "BASELINE from git rev $BASE_REV"
+fi
+
+glib-compile-schemas --targetdir "$RUN/fakeext/schemas" "$EXT/schemas/" \
+    || setup_fail "glib-compile-schemas failed for $EXT/schemas/"
+cp "$EXT/metadata.json" "$RUN/fakeext/" || setup_fail "no metadata.json in $EXT"
 
 # ── Rig-owned fixture ────────────────────────────────────────────────────────
 # Pinned keys only. Device ids are derived from THIS machine's live wpctl so the
@@ -92,14 +174,22 @@ DISP=""
 start=$(( 20 + ($$ % 60) ))
 for n in $(seq $start $((start + 25))); do
     sock="/run/user/$(id -u)/broadway$((n + 1)).socket"   # display :N -> socket N+1
-    [ -S "$sock" ] && continue
+    sock_live "$sock" && continue                          # genuinely in use
     gtk4-broadwayd ":$n" >"$RUN/broadwayd.log" 2>&1 &
     BWPID=$!
-    for _ in $(seq 1 400); do [ -S "$sock" ] && break; done
-    if [ -S "$sock" ]; then DISP=":$n"; break; fi
+    # Wait in WALL-CLOCK, not iterations. The previous bound was 400 shell
+    # iterations, measured at 5 ms -- against a socket that takes 4 ms to
+    # appear on an idle machine. A 1 ms margin, so any concurrent load made
+    # this give up, kill a perfectly good broadwayd, walk all 26 displays and
+    # report "no free broadway display". That was the seq-3 flake.
+    # 5 s is ~1000x the measured 4 ms bind and still returns the instant the
+    # socket appears.
+    _deadline=$(( $(date +%s) + 5 ))
+    while ! sock_live "$sock" && [ "$(date +%s)" -lt "$_deadline" ]; do sleep 0.05; done
+    if sock_live "$sock"; then DISP=":$n"; OURSOCK="$sock"; break; fi
     kill "$BWPID" 2>/dev/null; BWPID=""
 done
-[ -n "$DISP" ] || { echo "no free broadway display; see $RUN/broadwayd.log" >&2; exit 1; }
+[ -n "$DISP" ] || setup_fail "no free broadway display in :$start..:$((start+25)); see $RUN/broadwayd.log"
 echo "DISPLAY broadway $DISP (per-PID), run dir $RUN"
 
 # A run that CRASHED also produces "no new warnings". Require the harness to
@@ -115,15 +205,15 @@ run() {   # run <prefs.js> <stderr-file>
     echo "$out"
     case "$out" in
         *EXIT_CLEAN*) return 0 ;;
-        *) echo "!! harness DID NOT COMPLETE for $1 -- stderr below, comparison is meaningless" >&2
-           cat "$2" >&2; return 1 ;;
+        *) echo "!! HARNESS DID NOT COMPLETE for $1 -- comparison is meaningless"
+           cat "$2" >&2; return 3 ;;
     esac
 }
 
 if [ -n "$BASE" ]; then
-    echo "=== BASELINE $BASE ==="; run "$BASE" "$RUN/base.stderr" || exit 1
+    echo "=== BASELINE $BASE ==="; run "$BASE" "$RUN/base.stderr" || exit 3
 fi
-echo "=== BRANCH $BRANCH ==="; run "$BRANCH" "$RUN/branch.stderr" || exit 1
+echo "=== BRANCH $BRANCH ==="; run "$BRANCH" "$RUN/branch.stderr" || exit 3
 echo "--- stderr ---"; cat "$RUN/branch.stderr"
 rc=0
 if [ -n "$BASE" ]; then
@@ -138,7 +228,7 @@ if [ -n "$BASE" ]; then
     # EXIT CONTRACT: the diff exiting non-zero is NOT failure -- a fix is
     # SUPPOSED to change stderr. Only a regression or an incomplete run fails.
     if [ "$br" -gt "$bl" ]; then
-        echo "!! REGRESSION: branch emits more warnings than baseline ($br > $bl)" >&2
+        echo "!! REGRESSION: branch emits more warnings than baseline ($br > $bl)"
         rc=1
     fi
 fi

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -20,10 +20,24 @@
 # audio-level throttles, pipe back-pressure) and overlapping runs make their
 # measurements unreliable.
 set -u
+# pipefail so a pipeline's status reflects the interesting command, not just the
+# last one. Prophylactic here -- no pipeline in this file has its status consumed
+# today -- and set uniformly across all five runners so the next one added cannot
+# inherit `... | grep X | tail -1`, which returns 0 when the grep matched nothing.
+#
+# ⚠️ NOT `set -e`, deliberately: `grep -c` exits 1 on a zero count, and a zero
+# count is the PASSING case for a warning counter. `set -euo pipefail` aborts on
+# success. If you add -e, write every count as `$(grep -c X f || true)` first.
+set -o pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
 SVC="${1:-$REPO/gnome-speaks-service.py}"
 [ -f "$SVC" ] || { echo "no such service file: $SVC" >&2; exit 2; }
+# Resolve while the caller's cwd is still ours. The check above validates HERE,
+# but every suite runs via `cd "$HERE/$suite"` and resolves GS_SVC_PATH THERE --
+# so a relative path passes validation and then fails every suite with
+# FileNotFoundError naming a path inside the suite directory.
+case "$SVC" in /*) ;; *) SVC="$PWD/$SVC" ;; esac
 export GS_SVC_PATH="$SVC"
 rc=0
 

--- a/tests/repros/subtitle-token/run_all.sh
+++ b/tests/repros/subtitle-token/run_all.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Usage: ./run_all.sh /path/to/gnome-speaks-service.py
 set -u
+# pipefail so a pipeline's status reflects the interesting command, not just the
+# last one. Prophylactic here -- no pipeline in this file has its status consumed
+# today -- and set uniformly across all five runners so the next one added cannot
+# inherit `... | grep X | tail -1`, which returns 0 when the grep matched nothing.
+#
+# ⚠️ NOT `set -e`, deliberately: `grep -c` exits 1 on a zero count, and a zero
+# count is the PASSING case for a warning counter. `set -euo pipefail` aborts on
+# success. If you add -e, write every count as `$(grep -c X f || true)` first.
+set -o pipefail
 # Default to the service in THIS checkout: tests/repros/<suite>/ -> repo root.
 # A hardcoded absolute path is both a public-repo leak and a broken contract --
 # it silently tests some other tree than the one the caller is standing in.


### PR DESCRIPTION
Rebased onto `ff1a905`; `git merge-base --is-ancestor origin/main HEAD` passes. **Hold until lucid-dead-recorder calls the flake hunt done** — this now touches `run_all.sh`, and merging mid-hunt swaps their instrument.

## The flake is CONFIRMED, and it was two bugs, both mine

**1. A stale socket permanently burned a display number — the dominant cause, and nobody had guessed it.** A killed `gtk4-broadwayd` **leaves its socket file behind**, and the probe treated *file exists* as *display occupied*. So every run consumed one of the 26 slots in its probe window, permanently. **62 stale sockets had accumulated on this machine, all from this rig.**

That makes the failure **monotonic** — the more the rig is used, the likelier the red — which is exactly why it appeared in a repeated hunt rather than in normal use. broadwayd rebinds over a stale file happily (measured), so the only correct question is whether something is **listening**. `sock_live()` now asks that by connecting, and each run removes its own socket on exit. (The 61 leaked sockets have been cleaned up.)

**2. The readiness bound counted iterations, not time.**

```
old bound:  400 shell iterations  = 5 ms   (measured)
bind time:  socket appears        = 4 ms   (measured, idle)
under 8 concurrent starts:          5-7 ms - 7 of 8 over the old bound
```

A 1 ms margin, so any contention made the probe kill a healthy broadwayd and walk the whole window. Now a **5 s wall-clock deadline** — ~1000x the measured bind — returning the instant the socket answers.

## Exit codes, so a red says something

| code | meaning | line (stdout) |
|---|---|---|
| 0 | completed, no regression | — |
| 1 | **regression only** | `!! REGRESSION: branch emits more warnings than baseline (5 > 0)` |
| 2 | setup failure | `!! SETUP FAILURE: ...` |
| 3 | harness did not complete | `!! HARNESS DID NOT COMPLETE for ...` |

`1` is now strictly a real regression, so *"this machine was busy"* can never read as *"your change broke something"*.

**All verdict lines moved to stdout.** The `REGRESSION` line was on **stderr**, which is why a control capturing stdout saw `rc=1` with no reason and could not tell a contract failure from a crash. A machine-readable verdict on stderr is a bug, not a convention.

`$RUN` is **kept on any non-zero exit** with its path printed, so `broadwayd.log` survives for the one case that needs it; removed on success. A red that deletes its own evidence is the red people learn to skim.

## `setup_fail` was defined below its first use

As a function called via `|| setup_fail`, a later definition is a **127 that `||` swallows** — so a failed precondition did not stop the script; it ran on and failed elsewhere, reporting the wrong cause. That is why the first exit-code test showed 2 and 3 crossed. Fixed and re-tested.

## `GS_SVC_PATH` must be absolute — fixed, not just documented

```
RELATIVE -> FileNotFoundError: '.../tests/repros/service-audit/gnome-speaks-service.py'
ABSOLUTE -> RESULT: 0/12 attempts ...   (suite runs)
```

The trap: `run_all.sh` validates with `[ -f "$SVC" ]` in the **caller's** cwd, while every suite resolves it after `cd "$HERE/<suite>"`. **Validated here, used there** — the same shape as the rig's own relative-path bug. `run_all.sh` now resolves its argument; the README documents the contract for anyone exporting the var by hand for a single suite.

## Also

- `harness.js` requires an **absolute** path (exit 2) rather than guessing. Resolving inside the harness would have been *worse than failing*: gjs runs after a `cd`, so a caller-relative path would have silently resolved elsewhere and **tested the wrong file**. `run.sh` resolves while it still knows the caller's cwd.
- `--baseline-rev <sha>` extracts into the managed run dir, replacing a `git show ... > <placeholder>` recipe where substituting `.` overwrites your working `prefs.js`.
- `set -o pipefail` in all five runners, **labelled honestly as prophylactic**: none has a pipeline whose status is consumed today. Deliberately **not** `set -e` — `grep -c` exits 1 on a zero count, and a zero count is the *passing* case, so `-e` aborts precisely when a run succeeds. The README warns at the point of temptation, with `|| true` as the fix.

## Verification

| check | result |
|---|---|
| all four exit codes + their stdout lines | correct |
| run dir kept on failure / removed on success | correct |
| sockets leaked | 0 |
| runner's exact prefs-rig invocation, new `run.sh` | `st=0`, reason grep -> `EXIT_CLEAN` |
| full `run_all.sh` with a **relative** argument | 44 checks, 0 red, `FileNotFoundError` 0 |

**Scope note on that last row:** the 44-check run was made against the *pre-rewrite* `run.sh`. Since then `run.sh` changed substantially, and I have deliberately **not** re-run the full runner, because doing so contaminates the in-flight flake hunt. The post-rewrite `run.sh` is verified by the four exit-path tests and by replicating the runner's exact invocation in isolation (3 s, no contention).

A setup failure now yields `st=2` with a **blank reason** under the runner's current `EXIT_CLEAN|REGRESSION` grep — that is lucid's half of the fix, and the line is present and greppable for it.
