### PR TITLE
fix: a red in the repro runner always says why (#59 follow-up)

### DIFF
--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -129,7 +129,28 @@ Both forms have bitten this tree, and the **silent** one is the dangerous half:
   least someone notices, usually when they gate CI on it.
 
 Same root cause: taking a pipeline's exit status as the answer to a question it
-never answered. `$?` after a pipe reads the LAST command, not the interesting
+never answered. `$?` after a pipe reads the LAST command, not the
+interesting one — that form once reported two red suites as green here.
+
+**It came back, in the one branch I hand-rolled instead of using my own fix.**
+After `summarise()` was written to capture-and-test, the prefs-rig branch of
+`run_all.sh` kept a private `grep -E 'EXIT_CLEAN|REGRESSION' | tail -1`. Neither
+pattern matches what the rig prints when it cannot *start*, so when prefs-rig
+became the one check that actually flaked, the runner reported `rc=1` followed
+by nothing at all — a red that named no reason, in the file whose job is to
+make a red legible. The fix existed three lines above the bug.
+
+Two rules came out of that, and both are asserted by control rather than
+assumed:
+
+* **`^!!` is matched first.** Suites emit `!! SETUP FAILURE` / `!! REGRESSION` /
+  `!! HARNESS DID NOT COMPLETE` for what a reader must not miss, and a run can
+  limp as far as a `[PASS]` line and *then* fail setup. If the case lines won,
+  that run would report the pass.
+* **A non-zero rc never prints a blank diagnostic.** The last-resort fallback
+  was `tail -1`, which returns empty on empty input — so "always prints a
+  diagnostic" was only *mostly* true until an explicit
+  `!! NO OUTPUT from <suite> (rc=N)` closed it. `$?` after a pipe reads the LAST command, not the interesting
 one — that form once reported two red suites as green here.
 
 ⚠️ **And do not "fix" this by reaching for `set -euo pipefail`, which is the

--- a/tests/repros/prefs-rig/run.sh
+++ b/tests/repros/prefs-rig/run.sh
@@ -187,7 +187,10 @@ for n in $(seq $start $((start + 25))); do
     _deadline=$(( $(date +%s) + 5 ))
     while ! sock_live "$sock" && [ "$(date +%s)" -lt "$_deadline" ]; do sleep 0.05; done
     if sock_live "$sock"; then DISP=":$n"; OURSOCK="$sock"; break; fi
-    kill "$BWPID" 2>/dev/null; BWPID=""
+    # Remove the socket of an ABANDONED attempt too. OURSOCK is set only for
+    # the display we keep (line 99), so this path left one file behind per
+    # attempt that started broadwayd but never went live.
+    kill "$BWPID" 2>/dev/null; rm -f "$sock"; BWPID=""
 done
 [ -n "$DISP" ] || setup_fail "no free broadway display in :$start..:$((start+25)); see $RUN/broadwayd.log"
 echo "DISPLAY broadway $DISP (per-PID), run dir $RUN"

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -50,21 +50,62 @@ rc=0
 # exits 0 on empty input, so the first pattern always "succeeds" and every
 # summary comes out blank -- the same pipeline-exit-status trap that makes a
 # script ending in `diff` return 1 on success.
-summarise() {
+#
+# EXIT_CLEAN is prefs-rig's own "the run completed" marker and belongs with
+# the other roll-up verdicts; without it that line falls through to the
+# generic tail -1 and reports the stderr-delta line instead of the verdict.
+#
+# `^!!` is FIRST on purpose. A suite emits `!! SETUP FAILURE` / `!! REGRESSION`
+# / `!! HARNESS DID NOT COMPLETE` for the things a reader must not miss, and a
+# run can limp as far as a `[PASS]` line and THEN fail setup -- if the case
+# lines won, that run would report the pass.
+summarise() {   # summarise <output> <label> <rc>
     _s_out=""
-    for _s_pat in '^\[(PASS|FAIL)\]' '^(PASS|FAIL|RESULT):' '^(all checks passed|FAILURES:|ALL )'; do
+    for _s_pat in '^!!' '^\[(PASS|FAIL)\]' '^(PASS|FAIL|RESULT):' \
+                  '^(all checks passed|FAILURES:|ALL |EXIT_CLEAN)'; do
         _s_out=$(printf '%s\n' "$1" | grep -E "$_s_pat" | tail -1)
         if [ -n "$_s_out" ]; then printf '%s\n' "$_s_out"; return; fi
     done
-    printf '%s\n' "$1" | tail -1
+    _s_out=$(printf '%s\n' "$1" | tail -1)
+    if [ -n "$_s_out" ]; then printf '%s\n' "$_s_out"; return; fi
+    # THE INVARIANT: a non-zero rc must never print a blank diagnostic. The
+    # fallback above is `tail -1`, which returns EMPTY on empty input -- so
+    # without this line "always prints a diagnostic" was only mostly true, and
+    # a red with nothing after it is the red people learn to skim.
+    printf '!! NO OUTPUT from %s (rc=%s)\n' "$2" "$3"
 }
-line() { printf '%-16s %-34s rc=%s  %s\n' "$1" "$2" "$3" "$(summarise "$4" | cut -c1-80)"; }
+
+# Exit codes are a contract, and the summary counts them separately so "green"
+# means exactly one thing: 0 clean · 1 the defect is present · 2 SETUP FAILURE
+# (the check could not run, so it reports neither a pass nor a bug) · 3 the
+# harness did not complete. 2 and 3 still fail the gate -- a gate that goes
+# green on a check that never executed is measuring the absence of the test --
+# but they are labelled and counted apart from a real red.
+n_pass=0; n_fail=0; n_setup=0; n_incomplete=0
+tally() {
+    case "$1" in
+        0) n_pass=$((n_pass + 1)) ;;
+        2) n_setup=$((n_setup + 1)); rc=1 ;;
+        3) n_incomplete=$((n_incomplete + 1)); rc=1 ;;
+        *) n_fail=$((n_fail + 1)); rc=1 ;;
+    esac
+}
+line() {
+    case "$3" in
+        0) _l_tag="" ;;
+        2) _l_tag="  [SETUP FAILURE]" ;;
+        3) _l_tag="  [HARNESS INCOMPLETE]" ;;
+        *) _l_tag="" ;;
+    esac
+    tally "$3"
+    printf '%-16s %-34s rc=%s%s  %s\n' "$1" "$2" "$3" "$_l_tag" \
+        "$(summarise "$4" "$1/$2" "$3" | cut -c1-80)"
+}
 
 run() {   # run <suite> <script>...
     suite="$1"; shift
     for f in "$@"; do
         out=$(cd "$HERE/$suite" && timeout 300 python3 "$f" 2>/dev/null); st=$?
-        [ $st -ne 0 ] && rc=1
         line "$suite" "$f" "$st" "$out"
     done
 }
@@ -102,7 +143,7 @@ run version-cache  verify_version_cache.py repro_a_fork_storm.py
 # ---------------------------------------------------------------------------
 for c in A B C D E F G H I; do
     out=$(cd "$HERE/offline-handoff" && timeout 300 python3 repro_offline_handoff.py "$c" 2>/dev/null)
-    st=$?; [ $st -ne 0 ] && rc=1
+    st=$?
     line offline-handoff "case $c" "$st" "$out"
 done
 
@@ -124,9 +165,14 @@ if [ -x "$HERE/prefs-rig/run.sh" ] && command -v gjs >/dev/null 2>&1; then
     ref=$(git -C "$REPO" merge-base origin/main HEAD 2>/dev/null || echo origin/main)
     if git -C "$REPO" show "$ref:prefs.js" > "$base_dir/prefs.js" 2>/dev/null; then
         out=$(cd "$HERE/prefs-rig" && timeout 300 ./run.sh "$REPO/prefs.js" "$base_dir/prefs.js" 2>&1)
-        st=$?; [ $st -ne 0 ] && rc=1
-        printf '%-16s %-34s rc=%s  %s\n' prefs-rig "run.sh (gjs/broadway)" "$st" \
-            "$(printf '%s\n' "$out" | grep -E 'EXIT_CLEAN|REGRESSION' | tail -1 | cut -c1-80)"
+        st=$?
+        # Through line()/summarise() like every other suite. This branch used
+        # to hand-roll `grep -E 'EXIT_CLEAN|REGRESSION' | tail -1`, which
+        # matched neither a setup failure nor anything else the rig says when
+        # it cannot start -- so the one check that actually flaked reported
+        # `rc=1` followed by nothing at all. It was the only branch written by
+        # hand instead of using the fix three lines above it.
+        line prefs-rig "run.sh (gjs/broadway)" "$st" "$out"
     else
         printf '%-16s %-34s SKIP (no %s:prefs.js baseline)\n' prefs-rig "run.sh" "$ref"
     fi
@@ -136,5 +182,10 @@ else
 fi
 
 echo
+n_total=$((n_pass + n_fail + n_setup + n_incomplete))
+_sum="$n_total checks: $n_pass pass, $n_fail fail"
+[ "$n_setup" -gt 0 ] && _sum="$_sum, $n_setup SETUP FAILURE"
+[ "$n_incomplete" -gt 0 ] && _sum="$_sum, $n_incomplete HARNESS INCOMPLETE"
+echo "$_sum"
 [ $rc -eq 0 ] && echo "ALL SUITES GREEN" || echo "SOME SUITES FAILED"
 exit $rc


### PR DESCRIPTION
Follow-up to #59, from the flake hunt.

The hunt found **exactly one varying check in nine runs** — `prefs-rig`, 1 red — and the red printed `rc=1` followed by **nothing at all**. The runner whose job is to make a red legible had produced the "red people learn to skim".

## Cause

After `summarise()` was written to capture output and test it for *content*, the prefs-rig branch kept a private `grep -E 'EXIT_CLEAN|REGRESSION' | tail -1`. Neither pattern matches what the rig prints when it cannot **start**, so the one check that actually flaked reported nothing.

It was the only branch hand-rolled instead of using the fix three lines above it — the same pipeline-exit-status trap the README already documents, in the file that documents it.

## Changes

- **prefs-rig goes through `line()`/`summarise()`** like every other suite.
- **`^!!` is matched first.** Suites emit `!! SETUP FAILURE` / `!! REGRESSION` / `!! HARNESS DID NOT COMPLETE` for what a reader must not miss, and a run can limp as far as a `[PASS]` line and *then* fail setup. If the case lines won, that run would report the pass.
- **A non-zero rc never prints a blank diagnostic.** The last-resort fallback was `tail -1`, which returns empty on empty input — so "always prints a diagnostic" was only *mostly* true until `!! NO OUTPUT from <suite> (rc=N)` closed it.
- **Exit codes counted separately**, so "green" means exactly one thing: `44 checks: 42 pass, 0 fail, 1 SETUP FAILURE, 1 HARNESS INCOMPLETE`. `2` and `3` still fail the gate — a gate that goes green on a check that never executed is measuring the absence of the test — but they are labelled apart from a real red.
- **`EXIT_CLEAN` joins the roll-up verdicts**; without it prefs-rig's line falls through to the generic fallback and reports the stderr-delta line instead of the verdict.

## Control-asserted, not assumed

Two real suites forced through the real runner:

```
repro_c1  rc=2  [SETUP FAILURE]       !! NO OUTPUT from service-audit/repro_c1_dispatch_gate.py (rc=2)
repro_c2  rc=3  [HARNESS INCOMPLETE]  !! HARNESS DID NOT COMPLETE
44 checks: 42 pass, 0 fail, 1 SETUP FAILURE, 1 HARNESS INCOMPLETE   -> rc=1
```

The `rc=3` stub printed a `PASS:` line **before** its `!!` line — that is what proves the priority rather than assuming it. Both suites restored and verified clean against HEAD afterwards.

## Verification

Bare `tests/repros/run_all.sh`, no env vars: **44 checks, 44 pass, ALL SUITES GREEN, rc=0, 0 dirty files.** Ancestry gate yes. Leak scan 0, with a planted canary proving the scanner could see first.

No service-file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved suite result reporting so setup failures, regressions, and incomplete harness runs are identified consistently.
  - Non-zero exits now always produce a diagnostic instead of blank output.
  - Exit statuses are reliably propagated when any suite fails.

- **Improvements**
  - Added clearer labels for setup failures and incomplete harness runs.
  - Final runner summaries now include separate totals for passes, failures, setup failures, and incomplete runs.

- **Documentation**
  - Expanded guidance on pipeline exit-status handling and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->