### PR TITLE
chore: one isolation core for the repro harnesses (#90)

### DIFF
--- a/tests/repros/cancel-tokens/harness.py
+++ b/tests/repros/cancel-tokens/harness.py
@@ -17,13 +17,9 @@ Run any repro with:
     GS_SVC_PATH=<path to a gnome-speaks-service.py> python3 <script>
 exit 0 = clean, exit 1 = bug present.
 """
-import atexit
-import contextlib
-import glob
 import importlib.util
 import json
 import os
-import shutil
 import sys
 import time
 
@@ -78,50 +74,20 @@ SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
 # and it read exactly like a service regression.
 SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
 
+# The shared isolation core (#90). Five harnesses carried a byte-identical copy
+# of it; a correction to the contract had to be made five times.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import isolation  # noqa: E402
+
+
 SVC_PATH = os.environ.get("GS_SVC_PATH", SVC_DEFAULT)
 WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
 
 # get(), never setdefault(): setdefault EXPORTS the path, so any child python
 # this suite spawns would inherit the PARENT's dir and its atexit would delete
 # the still-running parent's scratch out from under it.
-_PINNED = os.environ.get("GS_REPRO_SCRATCH")
-SCRATCH = _PINNED or os.path.join(SCRATCH_ROOT, f"cancel-repros-{os.getpid()}")
-STATE_DIR = os.path.join(SCRATCH, "state")
-os.environ["XDG_STATE_HOME"] = STATE_DIR        # BEFORE the module computes
-                                                # CHRONICLE_PATH from it
-if _PINNED is None:
-    # Only ever reset and remove a directory THIS process created. A dir the
-    # caller pinned belongs to the caller.
-    shutil.rmtree(SCRATCH, ignore_errors=True)  # a verdict must never depend
-    atexit.register(shutil.rmtree, SCRATCH, True)   # on who ran here before
-os.makedirs(STATE_DIR, exist_ok=True)
-
-
-def _sweep_stale_scratch():
-    """Remove scratch dirs whose owning process is gone.
-
-    atexit does NOT run when `timeout` SIGTERMs a run, which is exactly how
-    these are usually killed -- so the PID-keyed dirs accumulate. Only a dir
-    whose PID no longer exists is touched, so a live sibling run is never
-    swept out from under itself.
-    """
-    import re
-    for d in glob.glob(os.path.join(os.path.dirname(SCRATCH), "*-repros-*")):
-        m = re.search(r"-repros-(\d+)$", d)
-        if not m or d == SCRATCH:
-            continue
-        try:
-            os.kill(int(m.group(1)), 0)      # signal 0: liveness probe only
-        except ProcessLookupError:
-            shutil.rmtree(d, ignore_errors=True)
-        except PermissionError:
-            pass                              # someone else's live process
-        except Exception:
-            pass
-
-
-_sweep_stale_scratch()
-os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+SCRATCH, STATE_DIR = isolation.setup_scratch("cancel-repros", SCRATCH_ROOT)
+isolation.sweep_stale_scratch(SCRATCH)
 
 
 class RecordingInjector:
@@ -209,109 +175,16 @@ class RecordingInjector:
 
 # Every key below is pinned because a repro's verdict depends on it. Nothing
 # here may be read from JP's live config -- see the ISOLATION note above.
-CONFIG_PINS = {
-    "key": "test-key",              # speak() bails out early without one
-    "wake_word": False,             # the wake watcher must never open the mic
-    "wake_word_model": "",
-    "wake_word_secure_gate": False, # #55: gates live_typing for the session
-    "continuous_dictation": False,  # is_loop -- picks the whole cycle shape
-    "conversation_mode": False,
-    "dictation_mode": True,
-    "terminal_mode": False,         # use_lexical: rewrites text before asserts
-    "skip_final_paste": False,      # picks finalize() vs paste() in step 9
-    "injection_method": "ydotool",
-    "read_notifications": False,
-    "llm_thinking": False,
-    "spiel_provider": False,        # a second D-Bus name on the session bus
-    "debug": False,                 # else every run appends to /tmp/speech-debug.log
-    "live_subtitles": False,
-    "phrase_list": [],
-    "wyoming_host": "",             # no LAN fallback from a test
-    "chronicle": False,
-}
+CONFIG_PINS = dict(isolation.CONFIG_PINS)
 
-
-
-REAL_STATE = os.path.join(os.path.expanduser("~/.local/state"), "gnome-speaks")
-
-
-
-@contextlib.contextmanager
-def config_scope(mod, **overrides):
-    """Run ONE scenario with its own CONFIG flags, restored afterwards.
-
-    Every load() in a process hands back the SAME dict -- `from state import
-    CONFIG` binds one shared object across the service, audio, stt, speech_tts
-    and wyoming -- so two scenarios in one process silently clobber each
-    other's flags, and the second one's verdict describes the first one's
-    configuration. Snapshot/restore rather than forking, so the repro stays
-    debuggable in one process:
-
-        with harness.config_scope(mod, continuous_dictation=True):
-            ...                      # loop-mode scenario
-        # flags are back to the pinned baseline here
-    
-
-    Three traps a scenario can hit that produce a GREEN run while measuring the
-    WRONG code path -- all three found by lucid-pin-lifecycle, and all three
-    cost an hour each to rediscover:
-
-    1. `_reload_config_flags()` restores conversation_mode=False at
-       start_listening(), so a conversation-mode scenario silently takes the
-       DICTATION path (send_backspaces + paste), the reply path never runs, and
-       the repro still prints a paste and looks like it passed. The CONFIG_PATH
-       redirect in _isolate_config() closes this -- the reload re-reads OUR
-       file and re-applies OUR pins -- but only for flags that are IN
-       CONFIG_PINS. Put a scenario's flags there or in config_scope(), never in
-       a bare CONFIG[...] assignment after load().
-    2. In SINGLE-SHOT, turn_end sets _stop_event and
-       _stream_conversation_worker aborts on it before stream_chat is ever
-       called. Any reply-path scenario needs loop mode, and should assert
-       stream_chat was actually invoked so it cannot pass while testing
-       something else.
-    3. Production calls _conversation_worker SYNCHRONOUSLY from inside
-       _streaming_stt_cycle, so the cycle's `finally` -- and its injector
-       release -- runs after the reply. A scenario that starts the worker on
-       its OWN thread has no such release and will report a stranded backend
-       that production does not have.
-    """
-    saved = dict(mod.CONFIG)
-    mod.CONFIG.update(overrides)
-    try:
-        yield mod.CONFIG
-    finally:
-        mod.CONFIG.clear()
-        mod.CONFIG.update(saved)
+# Re-exported so callers keep working: subtitle_spy delegates its PATH checks
+# to harness.assert_isolated() and adds the "pins actually took" half, and
+# repros call harness.config_scope() directly.
+config_scope = isolation.config_scope
 
 
 def assert_isolated(mod):
-    """Prove the module under test cannot reach JP's live state, BEFORE any
-    scenario runs.
-
-    CHRONICLE_PATH is computed at MODULE IMPORT from $XDG_STATE_HOME, so this
-    only holds if the env var was set before exec_module -- which is easy to
-    break by moving an import. The chronicle archive and the rotated
-    generations are derived from CHRONICLE_PATH at call time, so pinning it
-    pins them too. Raises rather than warns: a repro that has quietly attached
-    itself to the real ledger must not be allowed to report a verdict.
-    """
-    root = os.path.realpath(SCRATCH)
-    checks = {
-        "CHRONICLE_PATH": getattr(mod, "CHRONICLE_PATH", None),
-        "CONFIG_PATH": getattr(mod, "CONFIG_PATH", None),
-        "XDG_STATE_HOME": os.environ.get("XDG_STATE_HOME"),
-    }
-    for name, value in checks.items():
-        if value is None:
-            raise AssertionError(f"{name} is unset -- cannot prove isolation")
-        real = os.path.realpath(value)
-        if not (real == root or real.startswith(root + os.sep)):
-            raise AssertionError(
-                f"{name}={value!r} resolves OUTSIDE the isolated scratch "
-                f"{SCRATCH!r} -- refusing to run")
-        if os.path.realpath(REAL_STATE) in (real, os.path.dirname(real)):
-            raise AssertionError(f"{name} points at JP's live state dir")
-    return True
+    return isolation.assert_isolated(mod, SCRATCH)
 
 
 def _isolate_config(mod):
@@ -348,7 +221,7 @@ def load(fake_tts_seconds=1.0):
     sys.modules["gsvc_under_test"] = mod
     spec.loader.exec_module(mod)  # main() is __main__-guarded; nothing starts
 
-    _isolate_config(mod)   # BEFORE anything reads CONFIG
+    isolation.isolate_config(mod, SCRATCH, CONFIG_PINS)   # BEFORE anything reads CONFIG
     assert_isolated(mod)   # and prove it, before any scenario
 
     mod._schedule_warmup = lambda *a, **k: None

--- a/tests/repros/chronicle-perf/harness.py
+++ b/tests/repros/chronicle-perf/harness.py
@@ -2,13 +2,9 @@
 
 No audio, no network, no mic, no D-Bus, no port 7710, no writes outside /tmp.
 """
-import atexit
-import contextlib
-import glob
 import importlib.util
 import json
 import os
-import shutil
 import sys
 import time
 
@@ -63,158 +59,37 @@ SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
 # and it read exactly like a service regression.
 SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
 
+# The shared isolation core (#90). Five harnesses carried a byte-identical copy
+# of it; a correction to the contract had to be made five times.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import isolation  # noqa: E402
+
+
 SVC_PATH = os.environ.get("GS_SVC_PATH", SVC_DEFAULT)
 WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
 
 # get(), never setdefault(): setdefault EXPORTS the path, so any child python
 # this suite spawns would inherit the PARENT's dir and its atexit would delete
 # the still-running parent's scratch out from under it.
-_PINNED = os.environ.get("GS_REPRO_SCRATCH")
-SCRATCH = _PINNED or os.path.join(SCRATCH_ROOT, f"chronicle-repros-{os.getpid()}")
-STATE_DIR = os.path.join(SCRATCH, "state")
-os.environ["XDG_STATE_HOME"] = STATE_DIR        # BEFORE the module computes
-                                                # CHRONICLE_PATH from it
-if _PINNED is None:
-    # Only ever reset and remove a directory THIS process created. A dir the
-    # caller pinned belongs to the caller.
-    shutil.rmtree(SCRATCH, ignore_errors=True)  # a verdict must never depend
-    atexit.register(shutil.rmtree, SCRATCH, True)   # on who ran here before
-os.makedirs(STATE_DIR, exist_ok=True)
-
-
-def _sweep_stale_scratch():
-    """Remove scratch dirs whose owning process is gone.
-
-    atexit does NOT run when `timeout` SIGTERMs a run, which is exactly how
-    these are usually killed -- so the PID-keyed dirs accumulate. Only a dir
-    whose PID no longer exists is touched, so a live sibling run is never
-    swept out from under itself.
-    """
-    import re
-    for d in glob.glob(os.path.join(os.path.dirname(SCRATCH), "*-repros-*")):
-        m = re.search(r"-repros-(\d+)$", d)
-        if not m or d == SCRATCH:
-            continue
-        try:
-            os.kill(int(m.group(1)), 0)      # signal 0: liveness probe only
-        except ProcessLookupError:
-            shutil.rmtree(d, ignore_errors=True)
-        except PermissionError:
-            pass                              # someone else's live process
-        except Exception:
-            pass
-
-
-_sweep_stale_scratch()
-os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+SCRATCH, STATE_DIR = isolation.setup_scratch("chronicle-repros", SCRATCH_ROOT)
+isolation.sweep_stale_scratch(SCRATCH)
 
 
 
 # Every key below is pinned because a repro's verdict depends on it. Nothing
 # here may be read from JP's live config -- see the ISOLATION note above.
-CONFIG_PINS = {
-    "key": "test-key",              # speak() bails out early without one
-    "wake_word": False,             # the wake watcher must never open the mic
-    "wake_word_model": "",
-    "wake_word_secure_gate": False, # #55: gates live_typing for the session
-    "continuous_dictation": False,  # is_loop -- picks the whole cycle shape
-    "conversation_mode": False,
-    "dictation_mode": True,
-    "terminal_mode": False,         # use_lexical: rewrites text before asserts
-    "skip_final_paste": False,      # picks finalize() vs paste() in step 9
-    "injection_method": "ydotool",
-    "read_notifications": False,
-    "llm_thinking": False,
-    "spiel_provider": False,        # a second D-Bus name on the session bus
-    "debug": False,                 # else every run appends to /tmp/speech-debug.log
-    "live_subtitles": False,
-    "phrase_list": [],
-    "wyoming_host": "",             # no LAN fallback from a test
-    "chronicle": True,
-}
+CONFIG_PINS = dict(isolation.CONFIG_PINS)
 
+CONFIG_PINS["chronicle"] = True   # this suite has the ledger under test
 
-
-REAL_STATE = os.path.join(os.path.expanduser("~/.local/state"), "gnome-speaks")
-
-
-
-@contextlib.contextmanager
-def config_scope(mod, **overrides):
-    """Run ONE scenario with its own CONFIG flags, restored afterwards.
-
-    Every load() in a process hands back the SAME dict -- `from state import
-    CONFIG` binds one shared object across the service, audio, stt, speech_tts
-    and wyoming -- so two scenarios in one process silently clobber each
-    other's flags, and the second one's verdict describes the first one's
-    configuration. Snapshot/restore rather than forking, so the repro stays
-    debuggable in one process:
-
-        with harness.config_scope(mod, continuous_dictation=True):
-            ...                      # loop-mode scenario
-        # flags are back to the pinned baseline here
-    
-
-    Three traps a scenario can hit that produce a GREEN run while measuring the
-    WRONG code path -- all three found by lucid-pin-lifecycle, and all three
-    cost an hour each to rediscover:
-
-    1. `_reload_config_flags()` restores conversation_mode=False at
-       start_listening(), so a conversation-mode scenario silently takes the
-       DICTATION path (send_backspaces + paste), the reply path never runs, and
-       the repro still prints a paste and looks like it passed. The CONFIG_PATH
-       redirect in _isolate_config() closes this -- the reload re-reads OUR
-       file and re-applies OUR pins -- but only for flags that are IN
-       CONFIG_PINS. Put a scenario's flags there or in config_scope(), never in
-       a bare CONFIG[...] assignment after load().
-    2. In SINGLE-SHOT, turn_end sets _stop_event and
-       _stream_conversation_worker aborts on it before stream_chat is ever
-       called. Any reply-path scenario needs loop mode, and should assert
-       stream_chat was actually invoked so it cannot pass while testing
-       something else.
-    3. Production calls _conversation_worker SYNCHRONOUSLY from inside
-       _streaming_stt_cycle, so the cycle's `finally` -- and its injector
-       release -- runs after the reply. A scenario that starts the worker on
-       its OWN thread has no such release and will report a stranded backend
-       that production does not have.
-    """
-    saved = dict(mod.CONFIG)
-    mod.CONFIG.update(overrides)
-    try:
-        yield mod.CONFIG
-    finally:
-        mod.CONFIG.clear()
-        mod.CONFIG.update(saved)
+# Re-exported so callers keep working: subtitle_spy delegates its PATH checks
+# to harness.assert_isolated() and adds the "pins actually took" half, and
+# repros call harness.config_scope() directly.
+config_scope = isolation.config_scope
 
 
 def assert_isolated(mod):
-    """Prove the module under test cannot reach JP's live state, BEFORE any
-    scenario runs.
-
-    CHRONICLE_PATH is computed at MODULE IMPORT from $XDG_STATE_HOME, so this
-    only holds if the env var was set before exec_module -- which is easy to
-    break by moving an import. The chronicle archive and the rotated
-    generations are derived from CHRONICLE_PATH at call time, so pinning it
-    pins them too. Raises rather than warns: a repro that has quietly attached
-    itself to the real ledger must not be allowed to report a verdict.
-    """
-    root = os.path.realpath(SCRATCH)
-    checks = {
-        "CHRONICLE_PATH": getattr(mod, "CHRONICLE_PATH", None),
-        "CONFIG_PATH": getattr(mod, "CONFIG_PATH", None),
-        "XDG_STATE_HOME": os.environ.get("XDG_STATE_HOME"),
-    }
-    for name, value in checks.items():
-        if value is None:
-            raise AssertionError(f"{name} is unset -- cannot prove isolation")
-        real = os.path.realpath(value)
-        if not (real == root or real.startswith(root + os.sep)):
-            raise AssertionError(
-                f"{name}={value!r} resolves OUTSIDE the isolated scratch "
-                f"{SCRATCH!r} -- refusing to run")
-        if os.path.realpath(REAL_STATE) in (real, os.path.dirname(real)):
-            raise AssertionError(f"{name} points at JP's live state dir")
-    return True
+    return isolation.assert_isolated(mod, SCRATCH)
 
 
 def _isolate_config(mod):
@@ -250,7 +125,7 @@ def load(fake_tts_seconds=1.0):
     sys.modules["gsvc_under_test"] = mod
     spec.loader.exec_module(mod)  # main() is __main__-guarded; nothing starts
 
-    _isolate_config(mod)   # BEFORE anything reads CONFIG
+    isolation.isolate_config(mod, SCRATCH, CONFIG_PINS)   # BEFORE anything reads CONFIG
     assert_isolated(mod)   # and prove it, before any scenario
 
     # --- neutralize every side effect before any instance exists ---

--- a/tests/repros/dead-recorder/harness.py
+++ b/tests/repros/dead-recorder/harness.py
@@ -17,13 +17,9 @@ Run any repro with:
     GS_SVC_PATH=<path to a gnome-speaks-service.py> python3 <script>
 exit 0 = clean, exit 1 = bug present.
 """
-import atexit
-import contextlib
-import glob
 import importlib.util
 import json
 import os
-import shutil
 import sys
 import time
 
@@ -78,50 +74,20 @@ SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
 # and it read exactly like a service regression.
 SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
 
+# The shared isolation core (#90). Five harnesses carried a byte-identical copy
+# of it; a correction to the contract had to be made five times.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import isolation  # noqa: E402
+
+
 SVC_PATH = os.environ.get("GS_SVC_PATH", SVC_DEFAULT)
 WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
 
 # get(), never setdefault(): setdefault EXPORTS the path, so any child python
 # this suite spawns would inherit the PARENT's dir and its atexit would delete
 # the still-running parent's scratch out from under it.
-_PINNED = os.environ.get("GS_REPRO_SCRATCH")
-SCRATCH = _PINNED or os.path.join(SCRATCH_ROOT, f"deadrec-repros-{os.getpid()}")
-STATE_DIR = os.path.join(SCRATCH, "state")
-os.environ["XDG_STATE_HOME"] = STATE_DIR        # BEFORE the module computes
-                                                # CHRONICLE_PATH from it
-if _PINNED is None:
-    # Only ever reset and remove a directory THIS process created. A dir the
-    # caller pinned belongs to the caller.
-    shutil.rmtree(SCRATCH, ignore_errors=True)  # a verdict must never depend
-    atexit.register(shutil.rmtree, SCRATCH, True)   # on who ran here before
-os.makedirs(STATE_DIR, exist_ok=True)
-
-
-def _sweep_stale_scratch():
-    """Remove scratch dirs whose owning process is gone.
-
-    atexit does NOT run when `timeout` SIGTERMs a run, which is exactly how
-    these are usually killed -- so the PID-keyed dirs accumulate. Only a dir
-    whose PID no longer exists is touched, so a live sibling run is never
-    swept out from under itself.
-    """
-    import re
-    for d in glob.glob(os.path.join(os.path.dirname(SCRATCH), "*-repros-*")):
-        m = re.search(r"-repros-(\d+)$", d)
-        if not m or d == SCRATCH:
-            continue
-        try:
-            os.kill(int(m.group(1)), 0)      # signal 0: liveness probe only
-        except ProcessLookupError:
-            shutil.rmtree(d, ignore_errors=True)
-        except PermissionError:
-            pass                              # someone else's live process
-        except Exception:
-            pass
-
-
-_sweep_stale_scratch()
-os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+SCRATCH, STATE_DIR = isolation.setup_scratch("deadrec-repros", SCRATCH_ROOT)
+isolation.sweep_stale_scratch(SCRATCH)
 
 
 class RecordingInjector:
@@ -207,109 +173,16 @@ class RecordingInjector:
 
 # Every key below is pinned because a repro's verdict depends on it. Nothing
 # here may be read from JP's live config -- see the ISOLATION note above.
-CONFIG_PINS = {
-    "key": "test-key",              # speak() bails out early without one
-    "wake_word": False,             # the wake watcher must never open the mic
-    "wake_word_model": "",
-    "wake_word_secure_gate": False, # #55: gates live_typing for the session
-    "continuous_dictation": False,  # is_loop -- picks the whole cycle shape
-    "conversation_mode": False,
-    "dictation_mode": True,
-    "terminal_mode": False,         # use_lexical: rewrites text before asserts
-    "skip_final_paste": False,      # picks finalize() vs paste() in step 9
-    "injection_method": "ydotool",
-    "read_notifications": False,
-    "llm_thinking": False,
-    "spiel_provider": False,        # a second D-Bus name on the session bus
-    "debug": False,                 # else every run appends to /tmp/speech-debug.log
-    "live_subtitles": False,
-    "phrase_list": [],
-    "wyoming_host": "",             # no LAN fallback from a test
-    "chronicle": False,
-}
+CONFIG_PINS = dict(isolation.CONFIG_PINS)
 
-
-
-REAL_STATE = os.path.join(os.path.expanduser("~/.local/state"), "gnome-speaks")
-
-
-
-@contextlib.contextmanager
-def config_scope(mod, **overrides):
-    """Run ONE scenario with its own CONFIG flags, restored afterwards.
-
-    Every load() in a process hands back the SAME dict -- `from state import
-    CONFIG` binds one shared object across the service, audio, stt, speech_tts
-    and wyoming -- so two scenarios in one process silently clobber each
-    other's flags, and the second one's verdict describes the first one's
-    configuration. Snapshot/restore rather than forking, so the repro stays
-    debuggable in one process:
-
-        with harness.config_scope(mod, continuous_dictation=True):
-            ...                      # loop-mode scenario
-        # flags are back to the pinned baseline here
-    
-
-    Three traps a scenario can hit that produce a GREEN run while measuring the
-    WRONG code path -- all three found by lucid-pin-lifecycle, and all three
-    cost an hour each to rediscover:
-
-    1. `_reload_config_flags()` restores conversation_mode=False at
-       start_listening(), so a conversation-mode scenario silently takes the
-       DICTATION path (send_backspaces + paste), the reply path never runs, and
-       the repro still prints a paste and looks like it passed. The CONFIG_PATH
-       redirect in _isolate_config() closes this -- the reload re-reads OUR
-       file and re-applies OUR pins -- but only for flags that are IN
-       CONFIG_PINS. Put a scenario's flags there or in config_scope(), never in
-       a bare CONFIG[...] assignment after load().
-    2. In SINGLE-SHOT, turn_end sets _stop_event and
-       _stream_conversation_worker aborts on it before stream_chat is ever
-       called. Any reply-path scenario needs loop mode, and should assert
-       stream_chat was actually invoked so it cannot pass while testing
-       something else.
-    3. Production calls _conversation_worker SYNCHRONOUSLY from inside
-       _streaming_stt_cycle, so the cycle's `finally` -- and its injector
-       release -- runs after the reply. A scenario that starts the worker on
-       its OWN thread has no such release and will report a stranded backend
-       that production does not have.
-    """
-    saved = dict(mod.CONFIG)
-    mod.CONFIG.update(overrides)
-    try:
-        yield mod.CONFIG
-    finally:
-        mod.CONFIG.clear()
-        mod.CONFIG.update(saved)
+# Re-exported so callers keep working: subtitle_spy delegates its PATH checks
+# to harness.assert_isolated() and adds the "pins actually took" half, and
+# repros call harness.config_scope() directly.
+config_scope = isolation.config_scope
 
 
 def assert_isolated(mod):
-    """Prove the module under test cannot reach JP's live state, BEFORE any
-    scenario runs.
-
-    CHRONICLE_PATH is computed at MODULE IMPORT from $XDG_STATE_HOME, so this
-    only holds if the env var was set before exec_module -- which is easy to
-    break by moving an import. The chronicle archive and the rotated
-    generations are derived from CHRONICLE_PATH at call time, so pinning it
-    pins them too. Raises rather than warns: a repro that has quietly attached
-    itself to the real ledger must not be allowed to report a verdict.
-    """
-    root = os.path.realpath(SCRATCH)
-    checks = {
-        "CHRONICLE_PATH": getattr(mod, "CHRONICLE_PATH", None),
-        "CONFIG_PATH": getattr(mod, "CONFIG_PATH", None),
-        "XDG_STATE_HOME": os.environ.get("XDG_STATE_HOME"),
-    }
-    for name, value in checks.items():
-        if value is None:
-            raise AssertionError(f"{name} is unset -- cannot prove isolation")
-        real = os.path.realpath(value)
-        if not (real == root or real.startswith(root + os.sep)):
-            raise AssertionError(
-                f"{name}={value!r} resolves OUTSIDE the isolated scratch "
-                f"{SCRATCH!r} -- refusing to run")
-        if os.path.realpath(REAL_STATE) in (real, os.path.dirname(real)):
-            raise AssertionError(f"{name} points at JP's live state dir")
-    return True
+    return isolation.assert_isolated(mod, SCRATCH)
 
 
 def _isolate_config(mod):
@@ -346,7 +219,7 @@ def load(fake_tts_seconds=1.0):
     sys.modules["gsvc_under_test"] = mod
     spec.loader.exec_module(mod)  # main() is __main__-guarded; nothing starts
 
-    _isolate_config(mod)   # BEFORE anything reads CONFIG
+    isolation.isolate_config(mod, SCRATCH, CONFIG_PINS)   # BEFORE anything reads CONFIG
     assert_isolated(mod)   # and prove it, before any scenario
 
     # Pin the delivery path: this file is loaded from JP's real config.json,

--- a/tests/repros/isolation.py
+++ b/tests/repros/isolation.py
@@ -1,0 +1,211 @@
+"""Shared isolation core for the repro harnesses (#90).
+
+Five harnesses carried a byte-identical copy of this (three of them literally
+byte-identical; chronicle-perf differed by ONE character, the `chronicle` pin).
+That was the right shape in scratch, where every suite had to be self-contained
+and copyable, and the wrong shape in a versioned tree: a correction to the
+isolation contract had to be made five times, and copies drift.
+
+Two external inputs used to decide these repros' verdicts, and both produced
+results that read as product regressions. Everything here exists for one of
+them.
+
+1. JP's LIVE ~/.config/speech-to-cli/config.json. state.load_config() reads it
+   at import, so CONFIG started as ~47 live desktop keys. Worse,
+   _reload_config_flags() RE-READS that file mid-run and overwrites CONFIG for
+   every key in _SYNC_FLAGS, so a pin applied after load() is silently
+   clobbered unless the repro also stubs that method; and _save_config_flag()
+   WRITES it.
+2. Another agent running the same suite. Every scratch path used to be a fixed
+   absolute directory, so two processes shared one chronicle file. MEASURED:
+   two concurrent runs of verify_chronicle_contract.py both fail with
+   'equivalence [...]' mismatches; each alone passes.
+
+NOT moved in here, deliberately:
+
+  * subtitle_spy.assert_isolated() delegates its PATH checks to the harness's
+    and adds the other half -- that the CONFIG pins actually TOOK. A path can
+    be redirected correctly while a pin is silently missing, and terminal_mode
+    really is True on the developer desktop. Both halves are needed and they
+    answer different questions.
+  * prefs-rig is GJS/bash and shares none of this. It must never be imported
+    by a python collector, and its exit contract is its own.
+"""
+import atexit
+import contextlib
+import glob
+import json
+import os
+import re
+import shutil
+
+# Every key here is pinned because some repro's verdict depends on it. Nothing
+# may be read from the live config -- see the module docstring.
+CONFIG_PINS = {
+    "key": "test-key",              # speak() bails out early without one
+    "wake_word": False,             # the wake watcher must never open the mic
+    "wake_word_model": "",
+    "wake_word_secure_gate": False, # #55: gates live_typing for the session
+    "continuous_dictation": False,  # is_loop -- picks the whole cycle shape
+    "conversation_mode": False,
+    "dictation_mode": True,
+    "terminal_mode": False,         # use_lexical: rewrites text before asserts
+    "skip_final_paste": False,      # picks finalize() vs paste() in step 9
+    "injection_method": "ydotool",
+    "read_notifications": False,
+    "llm_thinking": False,
+    "spiel_provider": False,        # a second D-Bus name on the session bus
+    "debug": False,                 # else every run appends to /tmp/speech-debug.log
+    "live_subtitles": False,
+    "phrase_list": [],
+    "wyoming_host": "",             # no LAN fallback from a test
+    "chronicle": False,             # chronicle-perf overrides this to True
+}
+
+REAL_STATE = os.path.join(os.path.expanduser("~/.local/state"), "gnome-speaks")
+
+
+def setup_scratch(prefix, scratch_root):
+    """Choose this run's scratch dir and point XDG_STATE_HOME at it.
+
+    MUST be called at harness import, before the service module is exec'd:
+    CHRONICLE_PATH is computed at MODULE IMPORT from $XDG_STATE_HOME, so this
+    is one moved import away from silently attaching a repro to the real
+    ledger.
+
+    GS_REPRO_SCRATCH is read with get(), never setdefault -- setdefault EXPORTS
+    the path, so a child process would inherit the PARENT's dir and its atexit
+    would delete the still-running parent's scratch. Reset and cleanup are
+    therefore gated on this process having CHOSEN the directory: a caller-pinned
+    path belongs to the caller.
+
+    `prefix` is the suite's historical directory prefix and is deliberately not
+    derived: version-cache uses "version-cache", which does not match the
+    "*-repros-*" sweep glob below and so has never been swept. Deriving it
+    would silently change that.
+
+    Returns (scratch, state_dir).
+    """
+    pinned = os.environ.get("GS_REPRO_SCRATCH")
+    scratch = pinned or os.path.join(scratch_root, f"{prefix}-{os.getpid()}")
+    state_dir = os.path.join(scratch, "state")
+    os.environ["XDG_STATE_HOME"] = state_dir
+    if pinned is None:
+        # A verdict must never depend on who ran here before.
+        shutil.rmtree(scratch, ignore_errors=True)
+        atexit.register(shutil.rmtree, scratch, True)
+    os.makedirs(state_dir, exist_ok=True)
+    os.environ.setdefault("SPEECH_ENGINE_PATH",
+                          os.path.expanduser("~/Projects/speech-to-cli"))
+    return scratch, state_dir
+
+
+def sweep_stale_scratch(scratch):
+    """Remove sibling scratch dirs whose owning process is gone.
+
+    atexit does NOT run when `timeout` SIGTERMs a run, which is how these are
+    usually killed, so PID-keyed dirs accumulate. Only a dir whose PID no
+    longer exists is touched, so a live sibling run is never swept out from
+    under itself -- a leftover directory is not evidence of a leak until its
+    PID has been checked dead.
+    """
+    for d in glob.glob(os.path.join(os.path.dirname(scratch), "*-repros-*")):
+        m = re.search(r"-repros-(\d+)$", d)
+        if not m or d == scratch:
+            continue
+        try:
+            os.kill(int(m.group(1)), 0)      # signal 0: liveness probe only
+        except ProcessLookupError:
+            shutil.rmtree(d, ignore_errors=True)
+        except PermissionError:
+            pass                              # someone else's live process
+        except Exception:
+            pass
+
+
+def isolate_config(mod, scratch, pins=None):
+    """Rebuild CONFIG from the service's OWN defaults plus `pins`.
+
+    CONFIG is mutated IN PLACE: `from state import CONFIG` means the service,
+    audio, stt, speech_tts and wyoming all hold the same dict object, so
+    rebinding mod.CONFIG would isolate the service module and miss every other
+    one. CONFIG_PATH is repointed at a file holding the same values, so
+    _reload_config_flags() re-reading it mid-run is a no-op that re-applies our
+    pins, and _save_config_flag() can never touch the real file.
+    """
+    pins = CONFIG_PINS if pins is None else pins
+    real_defaults = mod.state.DEFAULTS_PATH
+    try:
+        mod.state.DEFAULTS_PATH = os.path.join(scratch, "absent-config.json")
+        baseline = mod.state.load_config()
+    finally:
+        mod.state.DEFAULTS_PATH = real_defaults
+    baseline.update(pins)
+    path = os.path.join(scratch, "config.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(baseline, f)
+    mod.CONFIG_PATH = path
+    mod.CONFIG.clear()
+    mod.CONFIG.update(baseline)
+    return baseline
+
+
+def assert_isolated(mod, scratch):
+    """Prove the module cannot reach the live state, BEFORE any scenario.
+
+    Raises rather than warns: a repro that has quietly attached itself to the
+    real ledger must not be allowed to report a verdict.
+    """
+    root = os.path.realpath(scratch)
+    checks = {
+        "CHRONICLE_PATH": getattr(mod, "CHRONICLE_PATH", None),
+        "CONFIG_PATH": getattr(mod, "CONFIG_PATH", None),
+        "XDG_STATE_HOME": os.environ.get("XDG_STATE_HOME"),
+    }
+    for name, value in checks.items():
+        if value is None:
+            raise AssertionError(f"{name} is unset -- cannot prove isolation")
+        real = os.path.realpath(value)
+        if not (real == root or real.startswith(root + os.sep)):
+            raise AssertionError(
+                f"{name}={value!r} resolves OUTSIDE the isolated scratch "
+                f"{scratch!r} -- refusing to run")
+        if os.path.realpath(REAL_STATE) in (real, os.path.dirname(real)):
+            raise AssertionError(f"{name} points at the live state dir")
+    return True
+
+
+@contextlib.contextmanager
+def config_scope(mod, **overrides):
+    """Run ONE scenario with its own CONFIG flags, restored afterwards.
+
+    Every load() in a process hands back the SAME dict, so two scenarios in one
+    process silently clobber each other's flags and the second one's verdict
+    describes the first one's configuration.
+
+    Three traps a scenario can hit that produce a GREEN run while measuring the
+    WRONG code path -- all three found by lucid-pin-lifecycle:
+
+    1. `_reload_config_flags()` restores conversation_mode=False at
+       start_listening(), so a conversation-mode scenario silently takes the
+       DICTATION path, the reply path never runs, and the repro still prints a
+       paste and looks like it passed. The CONFIG_PATH redirect closes this,
+       but only for flags that are IN the pins. Put a scenario's flags here or
+       in CONFIG_PINS, never in a bare CONFIG[...] assignment after load().
+    2. In SINGLE-SHOT, turn_end sets _stop_event and
+       _stream_conversation_worker aborts on it before stream_chat is ever
+       called. Any reply-path scenario needs loop mode, and should assert
+       stream_chat was actually invoked.
+    3. Production calls _conversation_worker SYNCHRONOUSLY from inside
+       _streaming_stt_cycle, so the cycle's `finally` -- and its injector
+       release -- runs after the reply. A scenario that starts the worker on
+       its OWN thread has no such release and will report a stranded backend
+       that production does not have.
+    """
+    saved = dict(mod.CONFIG)
+    mod.CONFIG.update(overrides)
+    try:
+        yield mod.CONFIG
+    finally:
+        mod.CONFIG.clear()
+        mod.CONFIG.update(saved)

--- a/tests/repros/service-audit/harness.py
+++ b/tests/repros/service-audit/harness.py
@@ -2,13 +2,9 @@
 
 No audio, no network, no mic, no D-Bus, no port 7710, no writes outside /tmp.
 """
-import atexit
-import contextlib
-import glob
 import importlib.util
 import json
 import os
-import shutil
 import sys
 import time
 
@@ -63,158 +59,35 @@ SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
 # and it read exactly like a service regression.
 SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
 
+# The shared isolation core (#90). Five harnesses carried a byte-identical copy
+# of it; a correction to the contract had to be made five times.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import isolation  # noqa: E402
+
+
 SVC_PATH = os.environ.get("GS_SVC_PATH", SVC_DEFAULT)
 WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
 
 # get(), never setdefault(): setdefault EXPORTS the path, so any child python
 # this suite spawns would inherit the PARENT's dir and its atexit would delete
 # the still-running parent's scratch out from under it.
-_PINNED = os.environ.get("GS_REPRO_SCRATCH")
-SCRATCH = _PINNED or os.path.join(SCRATCH_ROOT, f"audit-repros-{os.getpid()}")
-STATE_DIR = os.path.join(SCRATCH, "state")
-os.environ["XDG_STATE_HOME"] = STATE_DIR        # BEFORE the module computes
-                                                # CHRONICLE_PATH from it
-if _PINNED is None:
-    # Only ever reset and remove a directory THIS process created. A dir the
-    # caller pinned belongs to the caller.
-    shutil.rmtree(SCRATCH, ignore_errors=True)  # a verdict must never depend
-    atexit.register(shutil.rmtree, SCRATCH, True)   # on who ran here before
-os.makedirs(STATE_DIR, exist_ok=True)
-
-
-def _sweep_stale_scratch():
-    """Remove scratch dirs whose owning process is gone.
-
-    atexit does NOT run when `timeout` SIGTERMs a run, which is exactly how
-    these are usually killed -- so the PID-keyed dirs accumulate. Only a dir
-    whose PID no longer exists is touched, so a live sibling run is never
-    swept out from under itself.
-    """
-    import re
-    for d in glob.glob(os.path.join(os.path.dirname(SCRATCH), "*-repros-*")):
-        m = re.search(r"-repros-(\d+)$", d)
-        if not m or d == SCRATCH:
-            continue
-        try:
-            os.kill(int(m.group(1)), 0)      # signal 0: liveness probe only
-        except ProcessLookupError:
-            shutil.rmtree(d, ignore_errors=True)
-        except PermissionError:
-            pass                              # someone else's live process
-        except Exception:
-            pass
-
-
-_sweep_stale_scratch()
-os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+SCRATCH, STATE_DIR = isolation.setup_scratch("audit-repros", SCRATCH_ROOT)
+isolation.sweep_stale_scratch(SCRATCH)
 
 
 
 # Every key below is pinned because a repro's verdict depends on it. Nothing
 # here may be read from JP's live config -- see the ISOLATION note above.
-CONFIG_PINS = {
-    "key": "test-key",              # speak() bails out early without one
-    "wake_word": False,             # the wake watcher must never open the mic
-    "wake_word_model": "",
-    "wake_word_secure_gate": False, # #55: gates live_typing for the session
-    "continuous_dictation": False,  # is_loop -- picks the whole cycle shape
-    "conversation_mode": False,
-    "dictation_mode": True,
-    "terminal_mode": False,         # use_lexical: rewrites text before asserts
-    "skip_final_paste": False,      # picks finalize() vs paste() in step 9
-    "injection_method": "ydotool",
-    "read_notifications": False,
-    "llm_thinking": False,
-    "spiel_provider": False,        # a second D-Bus name on the session bus
-    "debug": False,                 # else every run appends to /tmp/speech-debug.log
-    "live_subtitles": False,
-    "phrase_list": [],
-    "wyoming_host": "",             # no LAN fallback from a test
-    "chronicle": False,
-}
+CONFIG_PINS = dict(isolation.CONFIG_PINS)
 
-
-
-REAL_STATE = os.path.join(os.path.expanduser("~/.local/state"), "gnome-speaks")
-
-
-
-@contextlib.contextmanager
-def config_scope(mod, **overrides):
-    """Run ONE scenario with its own CONFIG flags, restored afterwards.
-
-    Every load() in a process hands back the SAME dict -- `from state import
-    CONFIG` binds one shared object across the service, audio, stt, speech_tts
-    and wyoming -- so two scenarios in one process silently clobber each
-    other's flags, and the second one's verdict describes the first one's
-    configuration. Snapshot/restore rather than forking, so the repro stays
-    debuggable in one process:
-
-        with harness.config_scope(mod, continuous_dictation=True):
-            ...                      # loop-mode scenario
-        # flags are back to the pinned baseline here
-    
-
-    Three traps a scenario can hit that produce a GREEN run while measuring the
-    WRONG code path -- all three found by lucid-pin-lifecycle, and all three
-    cost an hour each to rediscover:
-
-    1. `_reload_config_flags()` restores conversation_mode=False at
-       start_listening(), so a conversation-mode scenario silently takes the
-       DICTATION path (send_backspaces + paste), the reply path never runs, and
-       the repro still prints a paste and looks like it passed. The CONFIG_PATH
-       redirect in _isolate_config() closes this -- the reload re-reads OUR
-       file and re-applies OUR pins -- but only for flags that are IN
-       CONFIG_PINS. Put a scenario's flags there or in config_scope(), never in
-       a bare CONFIG[...] assignment after load().
-    2. In SINGLE-SHOT, turn_end sets _stop_event and
-       _stream_conversation_worker aborts on it before stream_chat is ever
-       called. Any reply-path scenario needs loop mode, and should assert
-       stream_chat was actually invoked so it cannot pass while testing
-       something else.
-    3. Production calls _conversation_worker SYNCHRONOUSLY from inside
-       _streaming_stt_cycle, so the cycle's `finally` -- and its injector
-       release -- runs after the reply. A scenario that starts the worker on
-       its OWN thread has no such release and will report a stranded backend
-       that production does not have.
-    """
-    saved = dict(mod.CONFIG)
-    mod.CONFIG.update(overrides)
-    try:
-        yield mod.CONFIG
-    finally:
-        mod.CONFIG.clear()
-        mod.CONFIG.update(saved)
+# Re-exported so callers keep working: subtitle_spy delegates its PATH checks
+# to harness.assert_isolated() and adds the "pins actually took" half, and
+# repros call harness.config_scope() directly.
+config_scope = isolation.config_scope
 
 
 def assert_isolated(mod):
-    """Prove the module under test cannot reach JP's live state, BEFORE any
-    scenario runs.
-
-    CHRONICLE_PATH is computed at MODULE IMPORT from $XDG_STATE_HOME, so this
-    only holds if the env var was set before exec_module -- which is easy to
-    break by moving an import. The chronicle archive and the rotated
-    generations are derived from CHRONICLE_PATH at call time, so pinning it
-    pins them too. Raises rather than warns: a repro that has quietly attached
-    itself to the real ledger must not be allowed to report a verdict.
-    """
-    root = os.path.realpath(SCRATCH)
-    checks = {
-        "CHRONICLE_PATH": getattr(mod, "CHRONICLE_PATH", None),
-        "CONFIG_PATH": getattr(mod, "CONFIG_PATH", None),
-        "XDG_STATE_HOME": os.environ.get("XDG_STATE_HOME"),
-    }
-    for name, value in checks.items():
-        if value is None:
-            raise AssertionError(f"{name} is unset -- cannot prove isolation")
-        real = os.path.realpath(value)
-        if not (real == root or real.startswith(root + os.sep)):
-            raise AssertionError(
-                f"{name}={value!r} resolves OUTSIDE the isolated scratch "
-                f"{SCRATCH!r} -- refusing to run")
-        if os.path.realpath(REAL_STATE) in (real, os.path.dirname(real)):
-            raise AssertionError(f"{name} points at JP's live state dir")
-    return True
+    return isolation.assert_isolated(mod, SCRATCH)
 
 
 def _isolate_config(mod):
@@ -250,7 +123,7 @@ def load(fake_tts_seconds=1.0):
     sys.modules["gsvc_under_test"] = mod
     spec.loader.exec_module(mod)  # main() is __main__-guarded; nothing starts
 
-    _isolate_config(mod)   # BEFORE anything reads CONFIG
+    isolation.isolate_config(mod, SCRATCH, CONFIG_PINS)   # BEFORE anything reads CONFIG
     assert_isolated(mod)   # and prove it, before any scenario
 
     # --- neutralize every side effect before any instance exists ---

--- a/tests/repros/version-cache/harness.py
+++ b/tests/repros/version-cache/harness.py
@@ -11,12 +11,8 @@ Run any repro with:
     GS_SVC_PATH=<path to a gnome-speaks-service.py> python3 <script>
 exit 0 = clean, exit 1 = bug present.
 """
-import atexit
-import contextlib
 import importlib.util
-import json
 import os
-import shutil
 import sys
 
 # ENV CONTRACT: GS_SVC_PATH is the ONE input -- the service.py under test.
@@ -35,6 +31,11 @@ SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
 # and it read exactly like a service regression.
 SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
 
+# The shared isolation core (#90).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import isolation  # noqa: E402
+
+
 SVC_PATH = os.environ.get(
     "GS_SVC_PATH",
     SVC_DEFAULT)
@@ -48,20 +49,13 @@ WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
 # inherited by it -- whereupon the child's atexit would delete the still-running
 # parent's directory.  So the child gets its own, and we only clean up a
 # directory we chose ourselves; a caller-pinned path is left alone.
-_OWNED = "GS_REPRO_SCRATCH" not in os.environ
-SCRATCH = os.environ.get("GS_REPRO_SCRATCH",
-                         os.path.join(SCRATCH_ROOT, "version-cache-%d" % os.getpid()))
-STATE_DIR = os.path.join(SCRATCH, "state")
-os.environ["XDG_STATE_HOME"] = STATE_DIR
-os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
-if _OWNED:
-    # Reset at start as well as exit: a verdict must never depend on who ran
-    # here before. Gated on _OWNED for the reason above -- and because rmtree
-    # at start on a SHARED path is what made the chronicle suite destroy a peer
-    # agent's live directory (see that suite's ISOLATION note).
-    shutil.rmtree(SCRATCH, ignore_errors=True)
-    atexit.register(shutil.rmtree, SCRATCH, True)   # disposable byproduct, not state
-os.makedirs(STATE_DIR, exist_ok=True)
+# NOTE the prefix: "version-cache", not "<x>-repros". It does not match the
+# "*-repros-*" sweep glob, so this suite has never been swept and still is
+# not -- deriving the prefix would have changed that silently. This suite
+# SPAWNS a child (dump_payload.py), which is why the shared helper reads
+# GS_REPRO_SCRATCH with get() and never setdefault: an exported path would
+# be inherited and the child's atexit would delete the running parent's dir.
+SCRATCH, STATE_DIR = isolation.setup_scratch("version-cache", SCRATCH_ROOT)
 
 
 class _CompletedProcess:
@@ -111,80 +105,13 @@ class CountingSubprocess:
 
 
 
-CONFIG_PINS = {
-    "key": "test-key", "wake_word": False, "wake_word_model": "",
-    "wake_word_secure_gate": False, "chronicle": False,
-    "continuous_dictation": False, "conversation_mode": False,
-    "dictation_mode": True, "terminal_mode": False, "skip_final_paste": False,
-    "injection_method": "ydotool", "read_notifications": False,
-    "llm_thinking": False, "spiel_provider": False, "debug": False,
-    "live_subtitles": False, "phrase_list": [], "wyoming_host": "",
-}
+CONFIG_PINS = dict(isolation.CONFIG_PINS)
 
-REAL_STATE = os.path.join(os.path.expanduser("~/.local/state"), "gnome-speaks")
-
-
-def _isolate_config(mod):
-    """Rebuild CONFIG from the service's OWN defaults plus CONFIG_PINS.
-
-    CONFIG arrived holding JP's LIVE ~/.config/speech-to-cli/config.json (~47
-    keys), and _reload_config_flags() re-reads that file MID-RUN for every
-    _SYNC_FLAGS key, so pinning a couple of keys after load() was never
-    enough. Mutated IN PLACE: `from state import CONFIG` means audio, stt,
-    speech_tts and wyoming share the one dict object, so rebinding mod.CONFIG
-    would isolate the service module and miss all of them. CONFIG_PATH is
-    repointed at a file holding the same values, so the mid-run re-read
-    becomes a no-op and _save_config_flag() can never touch the real file.
-    """
-    real_defaults = mod.state.DEFAULTS_PATH
-    try:
-        mod.state.DEFAULTS_PATH = os.path.join(SCRATCH, "absent-config.json")
-        baseline = mod.state.load_config()
-    finally:
-        mod.state.DEFAULTS_PATH = real_defaults
-    baseline.update(CONFIG_PINS)
-    path = os.path.join(SCRATCH, "config.json")
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(baseline, f)
-    mod.CONFIG_PATH = path
-    mod.CONFIG.clear()
-    mod.CONFIG.update(baseline)
-    return baseline
-
-
-@contextlib.contextmanager
-def config_scope(mod, **overrides):
-    """Run ONE scenario with its own CONFIG flags, restored afterwards."""
-    saved = dict(mod.CONFIG)
-    mod.CONFIG.update(overrides)
-    try:
-        yield mod.CONFIG
-    finally:
-        mod.CONFIG.clear()
-        mod.CONFIG.update(saved)
+config_scope = isolation.config_scope
 
 
 def assert_isolated(mod):
-    """Prove the module cannot reach JP's live state, BEFORE any scenario.
-
-    CHRONICLE_PATH is computed at MODULE IMPORT from $XDG_STATE_HOME, so this
-    only holds if the env var was set before exec_module -- one moved import
-    away from breaking. Raises rather than warns: a repro that has quietly
-    attached itself to the real ledger must not report a verdict.
-    """
-    root = os.path.realpath(SCRATCH)
-    for name in ("CHRONICLE_PATH", "CONFIG_PATH"):
-        value = getattr(mod, name, None)
-        if value is None:
-            raise AssertionError(f"{name} is unset -- cannot prove isolation")
-        real = os.path.realpath(value)
-        if not (real == root or real.startswith(root + os.sep)):
-            raise AssertionError(
-                f"{name}={value!r} resolves OUTSIDE the isolated scratch "
-                f"{SCRATCH!r} -- refusing to run")
-        if os.path.realpath(REAL_STATE) in (real, os.path.dirname(real)):
-            raise AssertionError(f"{name} points at JP's live state dir")
-    return True
+    return isolation.assert_isolated(mod, SCRATCH)
 
 
 def load():
@@ -195,7 +122,7 @@ def load():
     sys.modules["gsvc_under_test"] = mod
     spec.loader.exec_module(mod)  # main() is __main__-guarded; nothing starts
 
-    _isolate_config(mod)   # BEFORE anything reads CONFIG
+    isolation.isolate_config(mod, SCRATCH, CONFIG_PINS)   # BEFORE anything reads CONFIG
     assert_isolated(mod)   # and prove it, before any scenario
     mod._schedule_warmup = lambda *a, **k: None
     mod._refresh_audio_detection = lambda *a, **k: None


### PR DESCRIPTION
Closes #90.

Five harnesses carried a copy of the same ~90-line isolation block. **Three were byte-identical; chronicle-perf differed by one character** (the `chronicle` pin); version-cache was a shorter variant.

```
cancel-tokens   isolation region 5784 chars  md5 ccf2988ae856
dead-recorder   isolation region 5784 chars  md5 ccf2988ae856
service-audit   isolation region 5784 chars  md5 ccf2988ae856
chronicle-perf  isolation region 5783 chars  md5 433f4d696123   <- one char
version-cache   isolation region 3149 chars  md5 ffff637e0ef6
```

That was the right shape in scratch, where each suite had to be self-contained and copyable, and the wrong shape in a versioned tree: a correction to the isolation contract had to be made five times, and copies drift.

`tests/repros/isolation.py` now holds `setup_scratch()`, `sweep_stale_scratch()`, `isolate_config()`, `assert_isolated()`, `config_scope()` and `CONFIG_PINS`. Each harness keeps its full public surface — repros and `subtitle_spy` import `SCRATCH`, `config_scope`, `assert_isolated`, `load`, `make_service`, `wait_for` and friends **by name**, so those had to survive as module attributes.

Net: **−658 lines across the harnesses, +79 there, +211 in one shared file.**

## Two differences preserved deliberately, not tidied away

- **chronicle-perf overrides `chronicle` to `True`.** That single character is the entire reason its copy was not byte-identical to the other three, and folding it into the shared default would have silently disabled the ledger in the one suite that tests it.
- **version-cache keeps the prefix `version-cache`, not `<x>-repros`.** It does not match the `*-repros-*` sweep glob, so that suite has never been swept — and still is not. Deriving the prefix from the suite name, which is the obvious tidy-up, would have changed that behaviour invisibly.

## Both splits intact, and checked rather than assumed

- **`subtitle_spy.assert_isolated()` still delegates its path checks to the harness and keeps its own half** — proving the CONFIG pins actually *took*. A path can be redirected correctly while a pin is silently missing. Negative control: with `terminal_mode` forced `True` and every path correct, it still raises `SystemExit(2)` naming the pin:
  ```
  - CONFIG['terminal_mode'] is True, expected False
  ok  broken pin caught -> SystemExit(2), paths were fine
  ```
- **prefs-rig imports none of this.** `isolation.py` mentions it only to say it must never be imported by a python collector.

## Acceptance

Bare `tests/repros/run_all.sh` before and after, verdicts diffed check-for-check:

```
IDENTICAL — all 44 verdicts unchanged
44 checks: 44 pass, 0 fail   rc=0
0 leftover scratch, 0 dirty files
```

Leak scan 0 with a planted canary proving the scanner could see. Ancestry gate yes. No service-file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)