### PR TITLE
fix(prefs-rig): reap orphaned broadwayds, with a control that can fail (#94)

### DIFF
--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -186,6 +186,43 @@ form has its own short-form failure. If you do add `-e`, write every count as
   merely currently-true — if stub ownership ever moves into the harness, check H
   before trusting it.
 
+## Orphaned broadwayds, and a control that can fail
+
+A hard-killed `run.sh` (SIGKILL from a tool timeout, or an OOM kill) leaves its
+`gtk4-broadwayd` **alive** — the EXIT trap covers TERM and INT, but nothing
+catches KILL. A live orphan is not stale: the liveness probe correctly reads it
+as *occupied* and skips that display forever, so orphans **monotonically
+exhaust** the 26-slot probe window. Same shape as the stale-socket bug, a
+different cause, and it survives that fix.
+
+`run.sh` reaps them before probing. PIDs are resolved **through the socket** —
+socket path → inode from `/proc/net/unix` → the process holding that inode in
+`/proc/<pid>/fd` — and never by matching a process name. A name pattern is how
+a reaper kills its own shell: bracketing the first character protects the
+pattern from matching *itself*, but not from the bare token appearing elsewhere
+in the same command. There is no name here for a pattern to match.
+
+Two restrictions keep it off anything that is not ours: the process must hold
+one of our sockets, **and** its stdout must be a `.../run-<pid>/broadwayd.log`
+that no longer exists. A live run's log exists; a hand-started broadwayd has a
+different stdout. Both are verified, not assumed.
+
+`verify_reaper.sh` is the control, and it is checked **in both directions**:
+
+```
+A. reaper DISABLED  -> rc=2  !! SETUP FAILURE: no free broadway display in :200..:225
+B. reaper ENABLED   -> rc=0  26 orphans reaped
+```
+
+> The candidate control for the sibling socket bug returned `0 -> 0` against
+> **unfixed** code — it would have passed on the bug it was meant to catch, and
+> was dropped for that reason. **A gate that is green on broken code
+> manufactures confidence.** If a control has never been watched to fail, it is
+> not yet a control.
+
+It is not wired into `run_all.sh`: it starts 26 processes and verifies the
+reaper, not the service. Run it when touching the probe or the reaper.
+
 ## prefs-rig is not python
 
 `prefs-rig/` is a GJS/bash rig (`run.sh` → `gjs` + `gtk4-broadwayd`) testing

--- a/tests/repros/prefs-rig/run.sh
+++ b/tests/repros/prefs-rig/run.sh
@@ -171,7 +171,93 @@ PY
 
 # ── Per-PID broadway display ─────────────────────────────────────────────────
 DISP=""
-start=$(( 20 + ($$ % 60) ))
+
+# ---------------------------------------------------------------------------
+# Reap orphaned broadwayds before probing (#94).
+#
+# A hard-killed run.sh (SIGKILL from a tool timeout, or an OOM kill) leaves its
+# broadwayd ALIVE -- the EXIT trap covers TERM and INT, but nothing catches
+# KILL. A live orphan is not stale: sock_live() correctly reads it as
+# "occupied" and skips that display FOREVER, so orphans monotonically exhaust
+# the 26-slot probe window. Same shape as the stale-socket bug, different
+# cause, and it survives that fix.
+#
+# PIDs are resolved THROUGH THE SOCKET -- socket path -> inode from
+# /proc/net/unix -> the process holding that inode in /proc/<pid>/fd -- and
+# never by matching a process name. A name pattern is how a reaper kills its
+# own shell: bracketing the first character protects the pattern from matching
+# itself, but not from the bare token appearing elsewhere in the same command.
+# There is no name here for a pattern to match.
+#
+# Two restrictions keep this from touching anything that is not ours: the
+# process must hold one of OUR sockets, and its stdout must be a
+# .../run-<pid>/broadwayd.log that NO LONGER EXISTS. A live run's log exists,
+# so a live run is never reaped; a broadwayd someone started by hand has a
+# different stdout, so it is never reaped either.
+# ---------------------------------------------------------------------------
+reap_orphaned_broadwayd() {
+    python3 - "$(id -u)" <<'REAPPY'
+import os, sys
+
+rundir = "/run/user/%s" % sys.argv[1]
+inode = {}
+try:
+    with open("/proc/net/unix") as fh:
+        for line in fh:
+            parts = line.split()
+            if len(parts) >= 8 and parts[-1].startswith(rundir + "/broadway"):
+                inode[parts[6]] = parts[-1]
+except OSError:
+    sys.exit(0)
+if not inode:
+    sys.exit(0)
+
+for pid in os.listdir("/proc"):
+    if not pid.isdigit():
+        continue
+    try:
+        fds = os.listdir("/proc/%s/fd" % pid)
+    except OSError:
+        continue                      # gone, or not ours to look at
+    sock = None
+    for fd in fds:
+        try:
+            target = os.readlink("/proc/%s/fd/%s" % (pid, fd))
+        except OSError:
+            continue
+        if target.startswith("socket:[") and target[8:-1] in inode:
+            sock = inode[target[8:-1]]
+            break
+    if sock is None:
+        continue
+    try:
+        out = os.readlink("/proc/%s/fd/1" % pid)
+    except OSError:
+        continue
+    path = out[:-10] if out.endswith(" (deleted)") else out
+    if not path.endswith("/broadwayd.log") or "/run-" not in path:
+        continue                      # not this rig's broadwayd
+    if os.path.exists(path):
+        continue                      # a LIVE run owns this display
+    try:
+        os.kill(int(pid), 15)
+    except OSError:
+        continue
+    try:
+        os.unlink(sock)
+    except OSError:
+        pass
+    print("reaped orphaned broadwayd pid=%s %s" % (pid, sock))
+REAPPY
+}
+
+# GS_REAP_DISABLE is the OTHER half of the test seam: verify_reaper.sh must be
+# able to show the control going RED without the reaper, or it proves nothing.
+[ -n "${GS_REAP_DISABLE:-}" ] || reap_orphaned_broadwayd
+
+# GS_BROADWAY_START is a TEST SEAM: verify_reaper.sh needs a deterministic
+# window to fill with orphans, and the default is derived from $$.
+start=${GS_BROADWAY_START:-$(( 20 + ($$ % 60) ))}
 for n in $(seq $start $((start + 25))); do
     sock="/run/user/$(id -u)/broadway$((n + 1)).socket"   # display :N -> socket N+1
     sock_live "$sock" && continue                          # genuinely in use

--- a/tests/repros/prefs-rig/verify_reaper.sh
+++ b/tests/repros/prefs-rig/verify_reaper.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Control for #94: orphaned broadwayds must not exhaust the probe window.
+#
+#   ./verify_reaper.sh
+#
+# THIS CONTROL CAN FAIL, and that is the whole point of it. The previous
+# candidate control for the sibling socket bug -- two concurrent run.sh, count
+# sockets before and after -- returned 0 -> 0 against UNFIXED code, so it would
+# have passed on the bug it was meant to catch. A gate that is green on broken
+# code manufactures confidence. This one is verified in both directions:
+#
+#   with the reaper     the rig finds a display   -> PASS
+#   reaper disabled     the rig cannot            -> the control goes RED
+#
+# It fills a deterministic 26-display window with LIVE orphans (broadwayd
+# processes whose run-<pid>/broadwayd.log has been deleted), which is what a
+# SIGKILLed run leaves behind. A live orphan is not stale -- sock_live() reads
+# it as "occupied" and skips it forever.
+#
+# Not wired into run_all.sh: it starts 26 processes and is a verification of
+# the reaper, not of the service. Run it when touching the probe or the reaper.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../../.." && pwd)"
+UID_="$(id -u)"
+START=200                      # far outside the default 20..104 window
+N=26                           # the whole probe span
+PIDS=()
+ORPHAN_DIR=$(mktemp -d)
+
+cleanup() {
+    for p in ${PIDS+"${PIDS[@]}"}; do kill "$p" 2>/dev/null; done
+    for n in $(seq $START $((START + N - 1))); do rm -f "/run/user/$UID_/broadway$((n + 1)).socket"; done
+    rm -rf "$ORPHAN_DIR"
+}
+trap cleanup EXIT
+
+make_orphans() {
+    for n in $(seq $START $((START + N - 1))); do
+        d="$ORPHAN_DIR/run-$n"; mkdir -p "$d"
+        gtk4-broadwayd ":$n" >"$d/broadwayd.log" 2>&1 &
+        PIDS+=($!)
+    done
+    sleep 2                                   # let them all bind
+    rm -rf "$ORPHAN_DIR"/run-*                # the run dirs are GONE: orphans
+}
+
+live=0
+for n in $(seq $START $((START + N - 1))); do
+    timeout 1 python3 -c "import socket,sys; socket.socket(socket.AF_UNIX).connect(sys.argv[1])" \
+        "/run/user/$UID_/broadway$((n + 1)).socket" 2>/dev/null && live=$((live + 1))
+done
+[ "$live" -eq 0 ] || { echo "!! SETUP FAILURE: displays :$START..$((START+N-1)) already in use ($live)"; exit 2; }
+
+echo "== creating $N live orphans on :$START..:$((START + N - 1)) =="
+make_orphans
+live=0
+for n in $(seq $START $((START + N - 1))); do
+    timeout 1 python3 -c "import socket,sys; socket.socket(socket.AF_UNIX).connect(sys.argv[1])" \
+        "/run/user/$UID_/broadway$((n + 1)).socket" 2>/dev/null && live=$((live + 1))
+done
+echo "   live orphans holding displays: $live/$N"
+[ "$live" -eq "$N" ] || { echo "!! SETUP FAILURE: only $live/$N orphans bound; cannot test exhaustion"; exit 2; }
+
+BASE=$(mktemp -d)
+git -C "$REPO" show "$(git -C "$REPO" merge-base origin/main HEAD)":prefs.js > "$BASE/prefs.js" 2>/dev/null \
+    || { echo "!! SETUP FAILURE: no baseline prefs.js"; rm -rf "$BASE"; exit 2; }
+
+echo "== A. reaper DISABLED -- the control must go RED here =="
+GS_BROADWAY_START=$START GS_REAP_DISABLE=1 timeout 300 "$HERE/run.sh" "$REPO/prefs.js" "$BASE/prefs.js" >"$ORPHAN_DIR.a" 2>&1
+a=$?
+echo "   rc=$a  $(grep -m1 '^!!' "$ORPHAN_DIR.a" 2>/dev/null || echo '(no !! line)')"
+
+echo "== B. reaper ENABLED -- the rig must find a display =="
+GS_BROADWAY_START=$START timeout 300 "$HERE/run.sh" "$REPO/prefs.js" "$BASE/prefs.js" >"$ORPHAN_DIR.b" 2>&1
+b=$?
+echo "   rc=$b  $(grep -cE '^reaped orphaned broadwayd' "$ORPHAN_DIR.b" 2>/dev/null || echo 0) orphans reaped"
+rm -rf "$BASE"
+
+echo
+if [ "$a" -eq 0 ]; then
+    echo "!! CONTROL IS MEANINGLESS: the rig succeeded with the reaper DISABLED."
+    echo "   A control that cannot fail proves nothing. Fix the control, not the code."
+    rc=1
+elif [ "$b" -ne 0 ]; then
+    echo "!! REAPER DID NOT RECOVER THE WINDOW (rc=$b)"; sed -n '1,20p' "$ORPHAN_DIR.b"
+    rc=1
+else
+    echo "PASS: disabled -> rc=$a (window exhausted); enabled -> rc=0 (orphans reaped)"
+    rc=0
+fi
+rm -f "$ORPHAN_DIR.a" "$ORPHAN_DIR.b"
+exit $rc


### PR DESCRIPTION
Closes #94.

A hard-killed `run.sh` — SIGKILL from a tool timeout, or an OOM kill — leaves its `gtk4-broadwayd` **alive**. The EXIT trap covers TERM and INT (measured), but nothing catches KILL.

**A live orphan is not stale.** `sock_live()` correctly reads it as *occupied* and skips that display forever, so orphans **monotonically exhaust** the 26-slot probe window. Same shape as the stale-socket bug fixed in #93, a different cause, and it survives that fix.

## PIDs are resolved through the socket, never by name

socket path → inode from `/proc/net/unix` → the process holding that inode in `/proc/<pid>/fd`.

A name pattern is how a reaper kills its own shell: bracketing the first character protects the pattern from matching *itself*, but not from the bare token appearing elsewhere in the same command — which happened twice in ten minutes to the person who found this bug. **There is no name here for a pattern to match.**

Two restrictions keep it off anything that is not ours: the process must hold one of our sockets, **and** its stdout must be a `.../run-<pid>/broadwayd.log` that no longer exists.

## The control fails in the disabled direction

```
A. reaper DISABLED  -> rc=2  !! SETUP FAILURE: no free broadway display in :200..:225
B. reaper ENABLED   -> rc=0  26 orphans reaped
```

The candidate control for the sibling socket bug returned `0 -> 0` against **unfixed** code — it would have passed on the bug it was meant to catch, and was dropped rather than shipped. **A gate that is green on broken code manufactures confidence.** `verify_reaper.sh` refuses to report a pass if run A succeeds, because a control that cannot fail proves nothing.

## Safety verified separately, not assumed

```
live run's broadwayd (log exists)          -> SURVIVED
orphan (log deleted)                       -> reaped
hand-started broadwayd (different stdout)  -> UNTOUCHED
```

A reaper that kills live runs would be considerably worse than the bug, so that direction is checked explicitly.

## Notes

- Two test seams, both labelled: `GS_BROADWAY_START` pins the probe window so the control can fill a deterministic 26 displays; `GS_REAP_DISABLE` lets the control demonstrate the red.
- `verify_reaper.sh` is **not** wired into `run_all.sh` — it starts 26 processes and verifies the reaper, not the service. Run it when touching the probe or the reaper.
- The `rm -f "$sock"` one-liner is already on main (`3a43efb`) and is **not** re-applied here.

## Verification

Bare `tests/repros/run_all.sh`: **44 checks, 44 pass, rc=0.** 0 dirty, 0 leftover scratch, 0 broadway sockets, 0 stray run dirs. Leak scan 0 with a planted canary. Ancestry yes. No service-file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)