### PR TITLE
fix: sync menu switches without re-firing their toggled handlers (#98)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,12 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
 - **`addTopChrome` and `affectsInputRegion`**: GNOME 49+ tracks input regions from reactive actors automatically and **rejects** the param. It defaulted to `true` on 46-48, so omitting it is behavior-identical everywhere -- never re-add it.
 - **St renders only ONE box-shadow**: comma-separated shadow lists log `Ignoring excess values` per rule and the extra layers never draw. Keep one shadow per rule and get depth from gradients instead.
 - **`log()` is deprecated in GJS**: use `console.log/warn/error/debug`. Service-absent paths should log at `debug` so a solo-extension install (EGO users with no service) stays quiet.
+- **`PopupSwitchMenuItem.setToggleState()` FIRES `toggled` on GNOME 50** (it is `this.set({state})`, and the
+  item forwards its switch's `notify::state` as `toggled`), so a programmatic sync runs the same handler a
+  click does. Syncing a menu switch from the D-Bus reply of the toggle it mirrors is an infinite loop at
+  round-trip speed (#98: conversation mode flipped every ~5 ms, the badge flew offscreen). Every
+  programmatic switch write goes through `_setSwitchQuietly()`, and every `toggled` handler returns early
+  while `_quietSwitch` is set -- never call `setToggleState` directly.
 - **`PopupSubMenu.open()` refuses an EMPTY submenu** (`popupMenu.js` guards on `isEmpty()`): populating a submenu from its own `open-state-changed` deadlocks -- the event never fires, the row is dead. Seed a placeholder at build time and refresh from the PARENT menu's open instead (the Chronicle submenu bug, cff6745).
 - **Subtitles are conversation-mode only**: both user-voice subtitle paths early-return on `!this._conversationMode` (in dictation the text is already at the cursor). `subtitles_user` / `subtitles_tts` gate the two directions independently *on top of* the `live_subtitles` master; `live_subtitles` is dual-written to GSettings `live-subtitles` because the overlay gates on the GSettings layer.
 - **Orca's Spiel switch moved**: `orca.settings.speechSystemOverride` **no longer exists** in Orca 50 -- an `orca-customizations.py` setting it does nothing silently. Use the relocatable GSettings schema: `gsettings set "org.gnome.Orca.Speech:/org/gnome/orca/default/speech/" speech-server-factory spiel` (values: `speechdispatcherfactory` | `spiel`; the `:path` suffix is mandatory). libspiel is still unpackaged on Ubuntu 26.04 -- source build + `~/.config/environment.d/` typelib path.

--- a/extension.js
+++ b/extension.js
@@ -551,6 +551,7 @@ export default class GnomeSpeaksExtension extends Extension {
 
         // Pills — hidden in idle, shown when active
         this._conversationMode = false;
+        this._quietSwitch = false;
         this._continuousMode = false;
         this._terminalMode = false;
 
@@ -829,6 +830,24 @@ export default class GnomeSpeaksExtension extends Extension {
             isHD ? 'gnome-speaks-quality-hd' : 'gnome-speaks-quality-fast');
     }
 
+    // Set a PopupSwitchMenuItem's state WITHOUT running its 'toggled'
+    // handler. On GNOME 50 setToggleState() is `this.set({state})`, and the
+    // item forwards its switch's notify::state as 'toggled' -- so a
+    // programmatic sync fires the same handler a click does. Syncing the
+    // menu switch from a D-Bus reply therefore re-invoked the toggle, which
+    // flipped the mode back, which re-synced the switch ... one flip per
+    // round trip (~5 ms) until the badge had animated itself off the screen
+    // (#98). The emission is synchronous inside set(), so a flag suffices.
+    _setSwitchQuietly(item, state) {
+        if (!item || item.state === state) return;
+        this._quietSwitch = true;
+        try {
+            item.setToggleState(state);
+        } finally {
+            this._quietSwitch = false;
+        }
+    }
+
     _toggleMode() {
         if (!this._proxy) {
             // Local toggle for testing without service
@@ -841,9 +860,8 @@ export default class GnomeSpeaksExtension extends Extension {
             let enabled = result[0];
             this._conversationMode = enabled;
             this._updateModePill();
-            // Sync the panel menu toggle (without re-triggering its callback)
-            if (this._menuConversationToggle)
-                this._menuConversationToggle.setToggleState(enabled);
+            // Sync the panel menu switch quietly -- see _setSwitchQuietly.
+            this._setSwitchQuietly(this._menuConversationToggle, enabled);
         });
     }
 
@@ -946,8 +964,7 @@ export default class GnomeSpeaksExtension extends Extension {
             if (this._destroyed || error) return;
             this._continuousMode = result[0];
             this._updateContinuousPill();
-            if (this._menuContinuousToggle)
-                this._menuContinuousToggle.setToggleState(this._continuousMode);
+            this._setSwitchQuietly(this._menuContinuousToggle, this._continuousMode);
         });
     }
 
@@ -1393,20 +1410,21 @@ export default class GnomeSpeaksExtension extends Extension {
 
         this._menuConversationToggle = new PopupMenu.PopupSwitchMenuItem('AI Conversation', false);
         this._menuConversationToggle.connect('toggled', (item, state) => {
-            if (!this._proxy) return;
+            if (this._quietSwitch || !this._proxy) return;
             this._proxy.ToggleConversationModeRemote((result, error) => {
                 if (this._destroyed || error) return;
                 let enabled = result[0];
                 this._conversationMode = enabled;
                 this._updateModePill();
                 if (enabled !== state)
-                    item.setToggleState(enabled);
+                    this._setSwitchQuietly(item, enabled);
             });
         });
         menu.addMenuItem(this._menuConversationToggle);
 
         this._menuContinuousToggle = new PopupMenu.PopupSwitchMenuItem('Continuous Dictation', false);
         this._menuContinuousToggle.connect('toggled', () => {
+            if (this._quietSwitch) return;
             this._callMethod('ToggleContinuousDictation');
         });
         menu.addMenuItem(this._menuContinuousToggle);
@@ -1455,6 +1473,7 @@ export default class GnomeSpeaksExtension extends Extension {
 
         this._menuBadgeToggle = new PopupMenu.PopupSwitchMenuItem('Show Badge', this._badgeVisible);
         this._menuBadgeToggle.connect('toggled', (item, state) => {
+            if (this._quietSwitch) return;
             this._badgeVisible = state;
             if (this._badge) {
                 if (state) {
@@ -1822,8 +1841,7 @@ export default class GnomeSpeaksExtension extends Extension {
             if (!error && result) {
                 this._conversationMode = result[0];
                 this._updateModePill();
-                if (this._menuConversationToggle)
-                    this._menuConversationToggle.setToggleState(this._conversationMode);
+                this._setSwitchQuietly(this._menuConversationToggle, this._conversationMode);
             }
         });
         this._proxy.GetContinuousDictationRemote((result, error) => {
@@ -1831,8 +1849,7 @@ export default class GnomeSpeaksExtension extends Extension {
             if (!error && result) {
                 this._continuousMode = result[0];
                 this._updateContinuousPill();
-                if (this._menuContinuousToggle)
-                    this._menuContinuousToggle.setToggleState(this._continuousMode);
+                this._setSwitchQuietly(this._menuContinuousToggle, this._continuousMode);
             }
         });
         this._proxy.GetTerminalModeRemote((result, error) => {
@@ -1926,8 +1943,7 @@ export default class GnomeSpeaksExtension extends Extension {
                     if (!error && result) {
                         this._conversationMode = result[0];
                         this._updateModePill();
-                        if (this._menuConversationToggle)
-                            this._menuConversationToggle.setToggleState(this._conversationMode);
+                        this._setSwitchQuietly(this._menuConversationToggle, this._conversationMode);
                     }
                 });
             }
@@ -2557,8 +2573,7 @@ export default class GnomeSpeaksExtension extends Extension {
 
         let hideItem = this._createMenuItem('Hide Badge', () => {
             this._badgeVisible = false;
-            if (this._menuBadgeToggle)
-                this._menuBadgeToggle.setToggleState(false);
+            this._setSwitchQuietly(this._menuBadgeToggle, false);
             this._badge.ease({
                 opacity: 0, duration: 200, mode: Clutter.AnimationMode.EASE_OUT_QUAD,
             });


### PR DESCRIPTION
Closes #98.

**Symptom:** activating the AI pill flipped conversation mode True/False every ~5 ms (service log: alternating `Conversation mode:` lines, `Restarting listen for conversation mode change` on each), the badge flew offscreen, and the listener was left cycling afterwards. Pre-existing; not related to the IBus trial.

**Mechanism (verified against GNOME 50.1's `popupMenu.js`, extracted from `libshell-18.so`):** `PopupSwitchMenuItem.setToggleState(state)` is `this.set({state})`, and the item forwards its switch's `notify::state` as `toggled`. A programmatic sync therefore fires the same handler a click does. extension.js synced the panel-menu switch from the D-Bus reply, which re-invoked `ToggleConversationMode`, which flipped the mode back, which re-synced the switch — one flip per round trip. The same sync ran at startup from `GetConversationMode`.

**Fix:** `_setSwitchQuietly(item, state)` sets a re-entrancy flag around `setToggleState` (emission is synchronous inside `set()`), and the three `toggled` handlers (conversation, continuous dictation, badge visibility) return early while it is set. All seven programmatic sync sites go through it.

**Verification:** `node --check` clean; a sandboxed headless GNOME Shell 50.1 (own XDG_DATA_HOME/CONFIG_HOME/RUNTIME_DIR, extension enabled) ran 50 s with zero JS errors or CRITICALs on stderr — but the headless shell emitted no extension-load line I could find in stderr or the journal, so "the extension loaded there" is **not proven**; the evidence is syntax + a guarded, additive change + the mechanism read from the shell source. Live confirmation needs a relogin (Wayland caches extension JS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)