### PR TITLE
fix: retry the IBus backend when ibus-daemon appears after the service (#100)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -995,6 +995,12 @@ _INJECTION_METHODS = ("ydotool", "ibus", "auto")
 _injector = None
 _injector_method = None
 _injector_lock = threading.Lock()
+# When "ibus"/"auto" resolved to the ydotool fallback because the daemon was
+# not reachable (typically: the service started before ibus-daemon at login),
+# remember when, so get_injector() can retry instead of caching the fallback
+# for the whole session (#100). None = the cached backend is the one asked for.
+_injector_fallback_since = None
+_INJECTOR_RETRY_SECONDS = 15.0
 
 
 def _make_injector():
@@ -1042,12 +1048,12 @@ def _make_injector():
 
 def get_injector():
     """The process-wide injection backend (lazy, rebuilt when config changes)."""
-    global _injector, _injector_method
+    global _injector, _injector_method, _injector_fallback_since
     method = str(CONFIG.get("injection_method") or "ydotool").strip().lower()
-    if _injector is not None and method == _injector_method:
+    if _injector is not None and method == _injector_method and not _fallback_retry_due(rearm=False):
         return _injector
     with _injector_lock:
-        if _injector is not None and method == _injector_method:
+        if _injector is not None and method == _injector_method and not _fallback_retry_due(rearm=True):
             return _injector
         previous = _injector
         if previous is not None:
@@ -1058,9 +1064,35 @@ def get_injector():
                 log.debug("Previous injector cancel failed", exc_info=True)
         _injector = _make_injector()
         _injector_method = method
+        wanted_ibus = method in ("ibus", "auto") and IbusInjector is not None
+        if wanted_ibus and getattr(_injector, "name", "") == "ydotool":
+            if _injector_fallback_since is None:
+                _injector_fallback_since = time.monotonic()
+        else:
+            _injector_fallback_since = None
         log.info("Injection backend: %s (injection_method=%s)",
                  _injector.name, method)
         return _injector
+
+
+def _fallback_retry_due(rearm):
+    """True when the cached backend is an unwanted ydotool fallback and the
+    retry interval has passed. Bounded: one retry per interval, never a spin.
+
+    The lock-free fast path in get_injector() asks with rearm=False (a pure
+    read); only the caller holding _injector_lock rearms, so several callers
+    arriving together cost one attempt, and the fast path can never rearm the
+    clock out from under the caller about to rebuild.
+    """
+    global _injector_fallback_since
+    since = _injector_fallback_since
+    if since is None:
+        return False
+    if time.monotonic() - since < _INJECTOR_RETRY_SECONDS:
+        return False
+    if rearm:
+        _injector_fallback_since = time.monotonic()
+    return True
 
 
 class _LiveTyper:

--- a/gnome-speaks.service
+++ b/gnome-speaks.service
@@ -3,6 +3,11 @@ Description=GNOME Speaks - Shared Speech Service (TTS/STT via Azure)
 Documentation=https://github.com/jphein/gnome-speaks
 # Start after the graphical session is ready (audio devices available)
 After=graphical-session.target
+# Order after ibus-daemon when the session has one, so the IBus injection
+# backend finds the daemon at start instead of falling back to ydotool for
+# the whole session (#100). A missing unit is ignored by After=, so this is
+# harmless on sessions without IBus.
+After=org.freedesktop.IBus.session.GNOME.service
 Wants=graphical-session.target
 
 [Service]

--- a/gnome-speaks.service.in
+++ b/gnome-speaks.service.in
@@ -2,6 +2,11 @@
 Description=GNOME Speaks - Shared Speech Service (TTS/STT via Azure)
 Documentation=https://github.com/jphein/gnome-speaks
 After=graphical-session.target
+# Order after ibus-daemon when the session has one, so the IBus injection
+# backend finds the daemon at start instead of falling back to ydotool for
+# the whole session (#100). A missing unit is ignored by After=, so this is
+# harmless on sessions without IBus.
+After=org.freedesktop.IBus.session.GNOME.service
 Wants=graphical-session.target
 
 [Service]

--- a/tests/repros/injector-seam/repro_fallback_retry.py
+++ b/tests/repros/injector-seam/repro_fallback_retry.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""repro: an IBus backend that was unreachable at start is retried later (#100).
+
+At login the service can start before ibus-daemon. _init_typing() then calls
+get_injector() once, the IBus attempt fails, and the ydotool fallback was
+cached for the whole session -- injection_method=ibus silently meant ydotool
+until a restart. The fix retries the build (bounded: once per
+_INJECTOR_RETRY_SECONDS) while the cached backend is an unwanted fallback.
+
+Verdicts (each printed, all must hold):
+  R1  ibus unreachable at first use          -> backend is ydotool (fallback)
+  R2  second call inside the interval        -> NO rebuild attempt (bounded)
+  R3  daemon appears, interval elapsed       -> backend becomes ibus
+  R4  once the wanted backend is cached, no further rebuilds happen
+  R5  injection_method=ydotool never retries (nothing is "unwanted")
+
+Run:  GS_SVC_PATH=<gnome-speaks-service.py> python3 repro_fallback_retry.py
+Exit 0 = all hold; 1 = a verdict failed; 2 = setup failure (never a verdict).
+"""
+import atexit
+import importlib.util
+import os
+import shutil
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_PATH = os.environ.get("GS_SVC_PATH", os.path.join(REPO_ROOT, "gnome-speaks-service.py"))
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+_STATE = os.path.join(SCRATCH_ROOT, f"injector-seam-retry-{os.getpid()}", "state")
+os.makedirs(_STATE, exist_ok=True)
+atexit.register(shutil.rmtree, os.path.dirname(_STATE), True)
+os.environ["XDG_STATE_HOME"] = _STATE
+os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+
+FAILS = []
+
+
+def check(label, cond, detail=""):
+    print(f"  {'OK  ' if cond else 'FAIL'} ({label}) {detail}")
+    if not cond:
+        FAILS.append(label)
+
+
+def load():
+    sys.path.insert(0, os.path.dirname(SVC_PATH))
+    spec = importlib.util.spec_from_file_location("gsvc_retry", SVC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["gsvc_retry"] = mod
+    spec.loader.exec_module(mod)
+    mod.CONFIG.update({"key": "test-key", "wake_word": False, "chronicle": False,
+                       "continuous_dictation": False, "conversation_mode": False,
+                       "terminal_mode": False, "spiel_provider": False, "debug": False,
+                       "wyoming_host": ""})
+    mod.CONFIG_PATH = os.path.join(_STATE, "config.json")
+    return mod
+
+
+class FakeIbus:
+    """Stands in for IbusInjector: reachability is a switch the test flips."""
+    reachable = False
+    builds = 0
+    name = "ibus"
+
+    def __init__(self, fallback=None):
+        FakeIbus.builds += 1
+        self.fallback = fallback
+
+    def available(self):
+        return FakeIbus.reachable
+
+    def cancel(self):
+        pass
+
+    def prepare(self):
+        pass
+
+
+def main():
+    if not os.path.isfile(SVC_PATH):
+        print(f"!! SETUP FAILURE: no such file: {SVC_PATH}")
+        return 2
+    mod = load()
+    if getattr(mod, "IbusInjector", None) is None and not hasattr(mod, "_make_injector"):
+        print("!! SETUP FAILURE: service has no injector seam")
+        return 2
+    mod.IbusInjector = FakeIbus
+    # A controllable clock: the fix (if present) keys its interval off time.monotonic.
+    clock = {"t": 1000.0}
+    real_monotonic = mod.time.monotonic
+    mod.time.monotonic = lambda: clock["t"]
+    try:
+        mod._injector = None
+        mod._injector_method = None
+        mod.CONFIG["injection_method"] = "ibus"
+
+        FakeIbus.reachable = False
+        inj = mod.get_injector()
+        check("R1", getattr(inj, "name", "") == "ydotool",
+              f"first use with ibus unreachable -> {getattr(inj, 'name', '?')}")
+        b1 = FakeIbus.builds
+
+        clock["t"] += 1.0
+        mod.get_injector()
+        check("R2", FakeIbus.builds == b1,
+              f"1 s later: builds {b1} -> {FakeIbus.builds} (must not rebuild inside the interval)")
+
+        FakeIbus.reachable = True
+        interval = float(getattr(mod, "_INJECTOR_RETRY_SECONDS", 15.0))
+        clock["t"] += interval + 1.0
+        inj = mod.get_injector()
+        check("R3", getattr(inj, "name", "") == "ibus",
+              f"daemon up, {interval + 1:.0f} s later -> {getattr(inj, 'name', '?')}")
+        b3 = FakeIbus.builds
+
+        clock["t"] += 10 * interval
+        mod.get_injector()
+        check("R4", FakeIbus.builds == b3,
+              f"wanted backend cached: builds {b3} -> {FakeIbus.builds} (must not rebuild)")
+
+        mod.CONFIG["injection_method"] = "ydotool"
+        inj = mod.get_injector()
+        b5 = FakeIbus.builds
+        clock["t"] += 10 * interval
+        mod.get_injector()
+        check("R5", getattr(inj, "name", "") == "ydotool" and FakeIbus.builds == b5,
+              f"explicit ydotool never retries: builds {b5} -> {FakeIbus.builds}")
+    finally:
+        mod.time.monotonic = real_monotonic
+
+    if FAILS:
+        print(f"FAIL: {len(FAILS)} verdict(s) -- an unreachable IBus at start is cached as ydotool for the whole session")
+        return 1
+    print("PASS: an unwanted ydotool fallback is retried once per interval and replaced when IBus appears")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -125,7 +125,7 @@ run dead-recorder  repro_e_single_shot_turn_end.py repro_f_text_survives_yank.py
                    repro_i_healthy_loop.py
 run pin-lifecycle  repro_pin_lifecycle.py repro_compound_pin_x_deadmic.py \
                    repro_compound_reply_pin.py
-run injector-seam  verify_injector_seam.py verify_ibus_injector.py
+run injector-seam  verify_injector_seam.py verify_ibus_injector.py repro_fallback_retry.py
 run version-cache  verify_version_cache.py repro_a_fork_storm.py
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #100.

At login `gnome-speaks.service` and `org.freedesktop.IBus.session.GNOME.service` start in undefined order. `_init_typing()` builds the injection backend once; if ibus-daemon is not reachable yet, the IBus attempt is marked failed permanently and the ydotool fallback is cached for the session — `injection_method=ibus` silently means ydotool until a restart. Found while checking what a relogin would do to the IBus trial.

**Fix, both ends:** the unit orders `After=org.freedesktop.IBus.session.GNOME.service` (a missing unit is ignored, so harmless without IBus); and `get_injector()` retries the build while the cached backend is an unwanted ydotool fallback, bounded to one attempt per 15 s. The lock-free fast path reads the clock only; the lock holder rearms it (the first draft rearmed outside the lock, which made the inner check say "not due" and never rebuild — caught in review, fixed before commit).

**Repro:** `tests/repros/injector-seam/repro_fallback_retry.py` — R3 (daemon appears after the interval → backend becomes ibus) FAILS on 66e9b87 and PASSES here; R2/R4/R5 pin the bound, the no-rebuild-once-wanted case, and that explicit ydotool never retries. Registered in `run_all.sh`.

**Gate:** bare `tests/repros/run_all.sh` on the branch → 45 checks, 45 pass; wake gate green; leak scan 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)