### PR TITLE
fix: restart the unit that owns the live ydotoold (#102)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -745,6 +745,46 @@ def _is_ydotoold_running():
 _ydotool_reset_lock = threading.Lock()
 
 
+_YDOTOOLD_UNIT_CANDIDATES = ("ydotool.service", "ydotoold.service")
+
+
+def _ydotoold_unit(proc_root="/proc"):
+    """(scope, unit) of the systemd unit that owns the LIVE ydotoold, or None.
+
+    Two units can exist on one machine -- the packaged user unit
+    `ydotool.service` (/usr/bin/ydotoold) and fix-ydotool.sh's `ydotoold.service`
+    (/usr/local/bin/ydotoold) -- and only one of them can hold the socket.
+    Restarting the other one starts a second daemon that exits with "Another
+    ydotoold is running with the same socket", trips the start limit, and
+    never clears a stuck key (#102). So ask the kernel which unit owns the
+    process: /proc/<pid>/exe (the executable, never a name pattern -- a cmdline
+    scan matches its own shell) and /proc/<pid>/cgroup for the unit.
+    scope is "user" or "system".
+    """
+    try:
+        pids = [d for d in os.listdir(proc_root) if d.isdigit()]
+    except OSError:
+        return None
+    for pid in pids:
+        try:
+            exe = os.readlink(os.path.join(proc_root, pid, "exe"))
+        except OSError:
+            continue
+        if os.path.basename(exe) != "ydotoold":
+            continue
+        try:
+            with open(os.path.join(proc_root, pid, "cgroup")) as fh:
+                cg = fh.read()
+        except OSError:
+            continue
+        m = re.search(r"/([^/\s]+\.service)\s*$", cg, re.M)
+        if not m:
+            continue
+        scope = "user" if "/user.slice/" in cg or "user@" in cg else "system"
+        return scope, m.group(1)
+    return None
+
+
 def _reset_ydotoold():
     """Restart ydotoold to clear any stuck key state on its virtual device.
 
@@ -753,6 +793,11 @@ def _reset_ydotoold():
     compositor then suppresses that key from all physical keyboards. Restarting
     the daemon destroys the old virtual device and creates a clean one.
 
+    Restarts the unit that OWNS the live daemon (see _ydotoold_unit); with no
+    daemon running, starts the first known unit that exists. Never restarts a
+    unit by an assumed name -- that is how the reset became a no-op that left
+    a failed unit behind (#102).
+
     Uses a lock to prevent two threads from restarting simultaneously.
     """
     if not _YDOTOOL_V1:
@@ -760,14 +805,34 @@ def _reset_ydotoold():
     if not _ydotool_reset_lock.acquire(blocking=False):
         return  # another thread is already restarting
     try:
-        subprocess.run(
-            ["systemctl", "--user", "restart", "ydotoold"],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            timeout=5,
-        )
+        owner = _ydotoold_unit()
+        if owner is not None:
+            scope, unit = owner
+            if scope != "user":
+                log.warning("ydotoold runs as system unit %s; cannot restart it "
+                            "without privileges -- stuck keys need `sudo systemctl "
+                            "restart %s`", unit, unit)
+                return
+            cmd = ["systemctl", "--user", "restart", unit]
+        else:
+            # No daemon at all: start (not restart) the first candidate that exists.
+            unit = None
+            for cand in _YDOTOOLD_UNIT_CANDIDATES:
+                probe = subprocess.run(
+                    ["systemctl", "--user", "cat", cand],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=5)
+                if probe.returncode == 0:
+                    unit = cand
+                    break
+            if unit is None:
+                log.warning("No ydotoold running and no known unit to start")
+                return
+            cmd = ["systemctl", "--user", "start", unit]
+        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                       timeout=5)
         # Give ydotoold time to create the new virtual device
         time.sleep(0.1)
-        log.info("Reset ydotoold to clear stuck key state")
+        log.info("Reset ydotoold (%s) to clear stuck key state", unit)
     except Exception as e:
         log.warning("Failed to restart ydotoold: %s", e)
     finally:

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -111,7 +111,7 @@ run() {   # run <suite> <script>...
 }
 
 run service-audit  repro_c1_dispatch_gate.py repro_c2_hold.py repro_c3_config.py \
-                   repro_c4_timer.py smoke_queue_ops.py verify_queue_invariants.py
+                   repro_c4_timer.py repro_c5_ydotoold_unit.py smoke_queue_ops.py verify_queue_invariants.py
 run chronicle-perf repro_chronicle_stall.py verify_archive.py \
                    verify_chronicle_contract.py verify_endpoints.py
 run cancel-tokens  repro_a_outcome_mislabel.py repro_b_transcript_after_stop.py \

--- a/tests/repros/service-audit/repro_c5_ydotoold_unit.py
+++ b/tests/repros/service-audit/repro_c5_ydotoold_unit.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""repro: the stuck-key reset restarts the unit that OWNS the live ydotoold (#102).
+
+Two units can exist (packaged `ydotool.service`, fix-ydotool.sh's
+`ydotoold.service`); restarting the wrong one spawns a second daemon that dies
+with "Another ydotoold is running with the same socket" and the stuck key is
+never cleared. This builds a fake /proc with one ydotoold owned by
+`ydotool.service` and asserts the reset targets THAT unit.
+
+  U1  fake /proc: ydotoold owned by user unit ydotool.service -> detected
+  U2  reset runs `systemctl --user restart ydotool.service`, not ydotoold
+  U3  daemon owned by a SYSTEM unit -> no systemctl call, one warning
+  U4  no daemon -> `start` (not restart) of the first existing candidate
+
+Run:  GS_SVC_PATH=<gnome-speaks-service.py> python3 repro_c5_ydotoold_unit.py
+Exit 0 = all hold; 1 = a verdict failed; 2 = setup failure.
+"""
+import atexit
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_PATH = os.environ.get("GS_SVC_PATH", os.path.join(REPO_ROOT, "gnome-speaks-service.py"))
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+_STATE = os.path.join(SCRATCH_ROOT, f"service-audit-ydotool-{os.getpid()}", "state")
+os.makedirs(_STATE, exist_ok=True)
+atexit.register(shutil.rmtree, os.path.dirname(_STATE), True)
+os.environ["XDG_STATE_HOME"] = _STATE
+os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+FAILS = []
+
+
+def check(label, cond, detail=""):
+    print(f"  {'OK  ' if cond else 'FAIL'} ({label}) {detail}")
+    if not cond:
+        FAILS.append(label)
+
+
+def load():
+    sys.path.insert(0, os.path.dirname(SVC_PATH))
+    spec = importlib.util.spec_from_file_location("gsvc_ydo", SVC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["gsvc_ydo"] = mod
+    spec.loader.exec_module(mod)
+    mod.CONFIG_PATH = os.path.join(_STATE, "config.json")
+    return mod
+
+
+def fake_proc(unit, scope="user"):
+    root = tempfile.mkdtemp(prefix="proc-", dir=os.path.dirname(_STATE))
+    # a non-ydotoold process, to prove the scan filters by executable
+    os.makedirs(os.path.join(root, "100"))
+    os.symlink("/usr/bin/bash", os.path.join(root, "100", "exe"))
+    open(os.path.join(root, "100", "cgroup"), "w").write("0::/user.slice/user-1000.slice/user@1000.service/app.slice/foo.service\n")
+    if unit:
+        os.makedirs(os.path.join(root, "200"))
+        os.symlink("/usr/bin/ydotoold", os.path.join(root, "200", "exe"))
+        path = (f"0::/user.slice/user-1000.slice/user@1000.service/app.slice/{unit}\n"
+                if scope == "user" else f"0::/system.slice/{unit}\n")
+        open(os.path.join(root, "200", "cgroup"), "w").write(path)
+    return root
+
+
+def main():
+    if not os.path.isfile(SVC_PATH):
+        print(f"!! SETUP FAILURE: no such file: {SVC_PATH}")
+        return 2
+    mod = load()
+    if not hasattr(mod, "_reset_ydotoold"):
+        print("!! SETUP FAILURE: service has no _reset_ydotoold")
+        return 2
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(list(cmd))
+        class R: returncode = 0
+        return R()
+    mod.subprocess.run = fake_run
+    mod.time.sleep = lambda s: None
+    mod._YDOTOOL_V1 = True
+
+    detect = getattr(mod, "_ydotoold_unit", None)
+    proc = fake_proc("ydotool.service")
+    got = detect(proc) if detect else None
+    check("U1", got == ("user", "ydotool.service"), f"detected {got!r}")
+
+    if detect:
+        mod._ydotoold_unit = lambda proc_root="/proc", _p=proc: detect(_p)
+    calls.clear()
+    mod._reset_ydotoold()
+    restarted = [c for c in calls if "restart" in c or "start" in c]
+    check("U2", restarted == [["systemctl", "--user", "restart", "ydotool.service"]],
+          f"systemctl calls: {restarted}")
+
+    if detect:
+        proc_sys = fake_proc("ydotool.service", scope="system")
+        mod._ydotoold_unit = lambda proc_root="/proc", _p=proc_sys: detect(_p)
+        calls.clear()
+        mod._reset_ydotoold()
+        check("U3", calls == [], f"system-owned daemon must not be restarted from user scope: {calls}")
+
+        proc_none = fake_proc(None)
+        mod._ydotoold_unit = lambda proc_root="/proc", _p=proc_none: detect(_p)
+        calls.clear()
+        mod._reset_ydotoold()
+        starts = [c for c in calls if c[:3] == ["systemctl", "--user", "start"]]
+        cats = [c for c in calls if c[:3] == ["systemctl", "--user", "cat"]]
+        check("U4", len(starts) == 1 and starts[0][3] == "ydotool.service" and cats,
+              f"no daemon -> probe {len(cats)} unit(s), start {starts}")
+    else:
+        check("U3", False, "no _ydotoold_unit seam"); check("U4", False, "no _ydotoold_unit seam")
+
+    if FAILS:
+        print(f"FAIL: {len(FAILS)} verdict(s) -- the reset does not target the unit that owns ydotoold")
+        return 1
+    print("PASS: the stuck-key reset restarts the unit that owns the live ydotoold")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #102.

The stuck-key reset ran `systemctl --user restart ydotoold` by name. On this machine the daemon is owned by the packaged user unit `ydotool.service`; the reset therefore started a second daemon that died with "Another ydotoold is running with the same socket", hit the start limit (6 restarts in 12 ms), and left `ydotoold.service` permanently failed — while never actually clearing a stuck key.

**Fix:** `_ydotoold_unit()` asks the kernel which unit owns the live daemon — `/proc/<pid>/exe` for the executable (never a cmdline pattern, which self-matches) and `/proc/<pid>/cgroup` for the unit — and the reset restarts that unit. A system-scope owner is refused with a warning (no privileges); with no daemon at all it *starts* the first known unit that exists.

**Repro:** `tests/repros/service-audit/repro_c5_ydotoold_unit.py` builds a fake /proc; U1–U4 all fail on 93a005c and pass here. Registered in `run_all.sh`.

**Gate:** bare `tests/repros/run_all.sh` on the branch → 46 checks, 46 pass; wake gate green; leak scan 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)