### PR TITLE
fix(ibus): text committed into IBus's fake context is typed via the fallback instead of vanishing (#109)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,14 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
   only `stop()` cancels the session token and only the token may gate the transcript. A library
   result is not a cancellation check either: `stt_fixed()` calls `is_cancelled()` exactly once and
   then POSTs to Azure with a 30 s timeout, so a stop during the upload is simply never seen.
+- **IBus's `fake` client is "no text field", not a target**: ibus-daemon focuses its pseudo-client `fake` when NO
+  input context has focus -- which is exactly what a pointer tap on badge chrome produces (the tap gives the shell
+  stage key focus; the window's context loses IBus focus). A `commit_text` into it vanishes: on 2026-09-07 a
+  recognised transcript was lost that way with no toast (#109). `acquire()` therefore treats `client == "fake"` as a
+  refusal with reason `no_target`, `commit()` types that utterance through the ydotool fallback (never for
+  `secure` -- a password field gets nothing from any backend, including after a mid-session focus move), and the
+  extension hands stage key focus back to the window before acting on a pointer tap (`_releaseKeyFocusFromPointer`).
+  Keyboard activation keeps focus (a11y).
 - **`commit_text("\n")` is not the Enter key**: it inserts a newline *character*, so a shell never
   runs the command. `press_enter()` is a distinct seam method for this reason and delegates to a
   key-event backend even when IBus is active (spec §5.4, "non-text targets"). Never collapse it

--- a/extension.js
+++ b/extension.js
@@ -655,6 +655,12 @@ export default class GnomeSpeaksExtension extends Extension {
                 return Clutter.EVENT_PROPAGATE;
 
             if (!wasDragging) {
+                // A pointer tap must not leave the badge holding stage key
+                // focus: while a shell actor has it, no window's text field is
+                // focused, IBus falls to its "fake" context, and an IBus commit
+                // for THIS very utterance vanishes (#109). Keyboard activation
+                // keeps focus (a11y); the pointer path hands it back first.
+                this._releaseKeyFocusFromPointer();
                 this._onBadgeClicked();
             }
             return Clutter.EVENT_STOP;
@@ -942,6 +948,10 @@ export default class GnomeSpeaksExtension extends Extension {
             // St.Button reports button 0 for keyboard activation — the only
             // honest signal of "this came from the keyboard", which the
             // Chronicle needs so it only steals focus when a keyboard asked.
+            // A pointer tap also hands stage key focus back to the user's
+            // window before acting, so an IBus commit has a real target (#109).
+            if (button !== 0)
+                this._releaseKeyFocusFromPointer();
             onActivate(button === 0);
         });
         return pill;
@@ -2097,6 +2107,20 @@ export default class GnomeSpeaksExtension extends Extension {
             duration: 200,
             mode: Clutter.AnimationMode.EASE_OUT_QUAD,
         });
+    }
+
+    // Drop stage key focus a pointer click gave to badge chrome. Mutter then
+    // refocuses the window that had it, and the window's input context becomes
+    // IBus's focus again -- the place a dictated commit has to land. Keyboard
+    // users never reach this: their focus is the point (a11y).
+    _releaseKeyFocusFromPointer() {
+        try {
+            let focus = global.stage.get_key_focus();
+            if (focus && this._badge && (focus === this._badge || this._badge.contains(focus)))
+                global.stage.set_key_focus(null);
+        } catch (e) {
+            console.debug(`[GNOME Speaks] release key focus: ${e.message}`);
+        }
     }
 
     _onBadgeClicked() {

--- a/ibus_injector.py
+++ b/ibus_injector.py
@@ -65,6 +65,9 @@ ENGINE_LAYOUT = "default"
 
 # ── timings ──────────────────────────────────────────────────────────────
 FOCUS_WAIT = 0.4          # how long acquire() waits for the daemon's FocusIn
+# ibus-daemon focuses this pseudo-client when NO input context has focus --
+# e.g. right after a pointer tap on shell chrome. A commit into it vanishes.
+FAKE_CLIENT = "fake"
 CONTENT_TYPE_GRACE = 0.05  # ...then for SetContentType to settle behind it
 COALESCE_DELAY = 0.12     # back-to-back finals merge into one commit
 SESSION_MAX_SECONDS = 120  # watchdog: no session may outlive this
@@ -342,6 +345,7 @@ if HAS_IBUS:
             self.hints = 0
             self.focused = False
             self.saw_content_type = False
+            self.client = ""
             self._preediting = False
 
         # -- key events ---------------------------------------------------
@@ -356,6 +360,7 @@ if HAS_IBUS:
 
         def do_focus_in_id(self, object_path, client):
             self.focused = True
+            self.client = client or ""
             log.debug("IBus focus in (client=%s)", client)
 
         def do_focus_out(self):
@@ -363,12 +368,17 @@ if HAS_IBUS:
 
         def do_focus_out_id(self, object_path):
             self.focused = False
+            self.client = ""
             # Anything provisional dies with the focus it belonged to -- and
             # so does what we knew about the field: the next FocusIn may come
             # from a client that never sends SetContentType.
             self.saw_content_type = False
             self.clear_preedit()
             log.debug("IBus focus out")
+
+        def has_target(self):
+            """Focused on a REAL input context (not ibus-daemon\'s fake one)."""
+            return bool(self.focused and self.client != FAKE_CLIENT)
 
         def do_reset(self):
             self.clear_preedit()
@@ -473,6 +483,10 @@ class IbusInjector(Injector):
         self._prior = None
         self._active = False
         self._coalescer = _Coalescer()
+        # Why the last acquire() said no: None | "secure" | "no_target" |
+        # "unavailable". commit() falls back to ydotool for every reason but
+        # "secure" (a password field must get NOTHING, from any backend).
+        self._refusal = None
         self._flush_timer = None
         self._watchdog = None
 
@@ -566,10 +580,12 @@ class IbusInjector(Injector):
         into perfectly normal windows.
         """
         if not self.available():
+            self._refusal = "unavailable"
             return False
         with self._lock:
             if self._active:
                 return not self._is_secure()
+            self._refusal = None
             try:
                 prior = self._bus.get_global_engine()
                 prior_name = prior.get_name() if prior else None
@@ -600,11 +616,13 @@ class IbusInjector(Injector):
             try:
                 if not self._bus.set_global_engine(ENGINE_NAME):
                     log.warning("IBus refused SetGlobalEngine; not typing")
+                    self._refusal = "unavailable"
                     clear_prior_engine()
                     self._prior = None
                     return False
             except Exception:
                 log.warning("IBus SetGlobalEngine failed", exc_info=True)
+                self._refusal = "unavailable"
                 clear_prior_engine()
                 self._prior = None
                 return False
@@ -623,8 +641,20 @@ class IbusInjector(Injector):
 
         if self._is_secure():
             log.info("IBus target is a password field; refusing to type")
+            self._refusal = "secure"
             self.cancel()
             return False
+        eng = self._engine
+        if eng is not None and eng.focused and getattr(eng, "client", "") == FAKE_CLIENT:
+            # No input context has focus (a pointer tap on shell chrome does
+            # this). A commit here lands nowhere and is lost silently -- so
+            # hand the whole utterance to the keystroke backend instead (#109).
+            log.info("IBus focus is the daemon's fake context (no text field "
+                     "focused); typing this utterance via the fallback backend")
+            self._refusal = "no_target"
+            self.cancel()
+            return False
+        self._refusal = None
         return True
 
     def _is_secure(self):
@@ -632,11 +662,17 @@ class IbusInjector(Injector):
         return bool(eng is not None and eng.is_secure())
 
     def _ensure_session(self):
+        if self._refusal == "no_target":
+            return False  # decided for this utterance; end() clears it
         if self._active:
             # Re-read the purpose every time: SetContentType can arrive late,
             # and focus can move into a password field mid-session.
             if self._is_secure():
                 log.info("IBus focus moved into a password field; discarding")
+                # "secure" outranks every fallback: the keystroke backend must
+                # not type what IBus just refused (the verifier's mid-session
+                # password case caught exactly that).
+                self._refusal = "secure"
                 self.cancel()
                 return False
             return True
@@ -645,6 +681,7 @@ class IbusInjector(Injector):
     def end(self):
         """Finish cleanly: flush what is buffered, then hand the IME back."""
         with self._lock:
+            self._refusal = None
             self._cancel_timers()
             if self._active:
                 self._flush(allowed=True)
@@ -759,11 +796,23 @@ class IbusInjector(Injector):
         if not text:
             return False
         if not self._ensure_session():
-            return False
+            return self._fallback_text(text)
         with self._lock:
             self._coalescer.push(text)
             self._arm_flush()
         return True
+
+    def _fallback_text(self, text):
+        """Type through the keystroke backend when IBus has no usable target.
+
+        Never for a password field: "secure" means nothing may be typed by
+        any backend. Everything else -- fake context, daemon unavailable,
+        swap refused -- keeps the seam's promise of falling back to ydotool,
+        never to nothing.
+        """
+        if self._refusal == "secure" or self._fallback is None:
+            return False
+        return bool(self._fallback.commit(text))
 
     def type_text(self, text):
         # TEXT path: goes through the same coalesced commit so the

--- a/tests/repros/injector-seam/repro_fake_context_fallback.py
+++ b/tests/repros/injector-seam/repro_fake_context_fallback.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""repro: IBus focus on the daemon's FAKE context means "no text field" -- the
+utterance must type through the fallback backend, not vanish (#109).
+
+2026-09-07 11:08: a badge tap gave shell chrome stage key focus, ibus-daemon
+focused its fake pseudo-client, and the recognised transcript was committed
+into it and lost. Nothing fell back, nothing was typed, no toast.
+
+  F1  focus in client="fake": commit() routes the text to the fallback,
+      the engine receives NO commit, the IME is handed back (cancel)
+  F2  the decision holds for the whole utterance: later partial/commit calls
+      do not re-acquire (no second SetGlobalEngine) and still go to fallback
+  F3  end() clears it: the next utterance with a real client commits via IBus
+  F4  a real client (e.g. "gnome-terminal-server") commits via IBus, fallback
+      untouched
+  F5  a PASSWORD field: neither backend gets the text (secure beats fallback)
+
+Run:  GS_SVC_PATH=<gnome-speaks-service.py> python3 repro_fake_context_fallback.py
+Exit 0 = all hold; 1 = a verdict failed; 2 = setup failure.
+"""
+import atexit
+import importlib
+import os
+import shutil
+import sys
+import time
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_PATH = os.environ.get("GS_SVC_PATH", os.path.join(REPO_ROOT, "gnome-speaks-service.py"))
+WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+RUNTIME = os.path.join(SCRATCH_ROOT, f"ibus-fake-context-{os.getpid()}", "runtime")
+os.makedirs(RUNTIME, exist_ok=True)
+os.environ["XDG_RUNTIME_DIR"] = RUNTIME          # never the real breadcrumb
+atexit.register(shutil.rmtree, os.path.dirname(RUNTIME), True)
+sys.path.insert(0, WT)
+FAILS = []
+
+
+def check(label, cond, detail=""):
+    print(f"  {'OK  ' if cond else 'FAIL'} ({label}) {detail}")
+    if not cond:
+        FAILS.append(label)
+
+
+class FakeEngineDesc:
+    def __init__(self, name):
+        self._name = name
+
+    def get_name(self):
+        return self._name
+
+
+class FakeBus:
+    def __init__(self, prior="xkb:us::eng"):
+        self.current = prior
+        self.swaps = []
+
+    def is_connected(self):
+        return True
+
+    def get_global_engine(self):
+        return FakeEngineDesc(self.current) if self.current else None
+
+    def set_global_engine(self, name):
+        self.swaps.append(name)
+        self.current = name
+        return True
+
+
+class FakeEngine:
+    def __init__(self, client, purpose=0):
+        self.purpose = purpose
+        self.hints = 0
+        self.focused = True
+        self.client = client
+        self.saw_content_type = purpose != 0
+        self.commits = []
+        self.preedits = []
+
+    def is_secure(self):
+        return self.purpose in ib._SECURE_PURPOSES
+
+    def set_preedit(self, text):
+        self.preedits.append(text)
+
+    def clear_preedit(self):
+        pass
+
+    def commit(self, text):
+        self.commits.append(text)
+        return True
+
+
+class FakeFallback:
+    name = "ydotool"
+
+    def __init__(self):
+        self.commits = []
+        self.enters = 0
+
+    def prepare(self):
+        pass
+
+    def recover(self):
+        pass
+
+    def commit(self, text):
+        self.commits.append(text)
+        return True
+
+    def press_enter(self):
+        self.enters += 1
+        return True
+
+
+def wired(client, purpose=0):
+    inj = ib.IbusInjector(fallback=FakeFallback())
+    inj._bus = FakeBus()
+    inj._engine = FakeEngine(client, purpose)
+    inj._registered = True
+    return inj
+
+
+def flush(inj):
+    # the coalescer commits on a timer; force it the way a session end does
+    with inj._lock:
+        inj._flush(allowed=True)
+
+
+def main():
+    global ib
+    try:
+        ib = importlib.import_module("ibus_injector")
+    except Exception as exc:
+        print(f"!! SETUP FAILURE: cannot import ibus_injector from {WT}: {exc}")
+        return 2
+    ib.FOCUS_WAIT = 0.01
+    ib.CONTENT_TYPE_GRACE = 0.0
+    prior_crumb = os.path.join(RUNTIME, "gnome-speaks", "prior-engine")
+
+    # F1 — fake context
+    inj = wired("fake")
+    ok = inj.commit("hello from the badge tap")
+    flush(inj)
+    fb = inj._fallback.commits
+    check("F1", ok and fb == ["hello from the badge tap"] and inj._engine.commits == []
+          and inj._bus.current == "xkb:us::eng" and not inj._active,
+          f"fallback={fb} engine={inj._engine.commits} global={inj._bus.current!r} active={inj._active}")
+
+    # F2 — sticky for the utterance
+    swaps_before = len(inj._bus.swaps)
+    inj.set_preedit("hello from")
+    inj.commit("second part")
+    flush(inj)
+    check("F2", len(inj._bus.swaps) == swaps_before and inj._fallback.commits[-1] == "second part"
+          and inj._engine.commits == [],
+          f"swaps {swaps_before}->{len(inj._bus.swaps)} fallback={inj._fallback.commits} engine={inj._engine.commits}")
+
+    # F3 — end() clears; next utterance with a real client uses IBus
+    inj.end()
+    inj._engine = FakeEngine("gnome-terminal-server")
+    inj.commit("real target now")
+    flush(inj)
+    check("F3", inj._engine.commits == ["real target now"] and inj._fallback.commits == ["hello from the badge tap", "second part"],
+          f"engine={inj._engine.commits} fallback={inj._fallback.commits}")
+    inj.end()
+
+    # F4 — a real client from the start
+    inj = wired("gnome-terminal-server")
+    inj.commit("plain dictation")
+    flush(inj)
+    check("F4", inj._engine.commits == ["plain dictation"] and inj._fallback.commits == [],
+          f"engine={inj._engine.commits} fallback={inj._fallback.commits}")
+    inj.end()
+
+    # F5 — password field: nothing anywhere
+    inj = wired("gnome-terminal-server", purpose=8)   # IBUS_INPUT_PURPOSE_PASSWORD
+    ok = inj.commit("hunter2")
+    flush(inj)
+    check("F5", not ok and inj._engine.commits == [] and inj._fallback.commits == [],
+          f"ok={ok} engine={inj._engine.commits} fallback={inj._fallback.commits}")
+    inj.end()
+
+    if FAILS:
+        print(f"FAIL: {len(FAILS)} verdict(s) -- text committed into IBus's fake context is lost")
+        return 1
+    print("PASS: a fake-context focus types via the fallback; real targets commit via IBus; passwords get nothing")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/injector-seam/verify_ibus_injector.py
+++ b/tests/repros/injector-seam/verify_ibus_injector.py
@@ -154,6 +154,13 @@ class FakeFallback:
         self.enters = 0
         self.recovers = 0
         self.prepared = 0
+        # Text handed to the keystroke backend when IBus has no usable target
+        # (#109): the seam promises ydotool for every failure but a password.
+        self.commits = []
+
+    def commit(self, text):
+        self.commits.append(text)
+        return True
 
     def prepare(self):
         self.prepared += 1

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -125,7 +125,7 @@ run dead-recorder  repro_e_single_shot_turn_end.py repro_f_text_survives_yank.py
                    repro_i_healthy_loop.py
 run pin-lifecycle  repro_pin_lifecycle.py repro_compound_pin_x_deadmic.py \
                    repro_compound_reply_pin.py
-run injector-seam  verify_injector_seam.py verify_ibus_injector.py repro_fallback_retry.py
+run injector-seam  verify_injector_seam.py verify_ibus_injector.py repro_fallback_retry.py repro_fake_context_fallback.py
 run version-cache  verify_version_cache.py repro_a_fork_storm.py
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #109. Root cause of the badge half of #107 (2026-09-07 morning).

Service log 11:08:27: `Transcription (vad): Yeah, but let's do it in person.` → `IBus focus in (client=fake)` → `State processing -> idle`. The transcript was committed into ibus-daemon's **fake** pseudo-client — the one it focuses when **no** input context has focus, which is exactly what a pointer tap on badge chrome produces (the tap gives the shell stage key focus). The commit landed nowhere; nothing fell back; no toast.

**Backend** (`ibus_injector.py`): the engine records the focused client; `acquire()` treats `client == "fake"` as a refusal with reason `no_target` and hands the IME back at once; `commit()` types that utterance through the ydotool fallback (memoised for the utterance so partials do not re-swap the engine; `end()` clears it). **`secure` outranks every fallback**, including a mid-session focus move into a password field — the existing IBus verifier caught my first draft typing that through ydotool, and now asserts the fallback path explicitly.

**Extension** (`extension.js`): pointer taps on the badge and the pills release stage key focus before acting, so the window's input context is IBus's focus again; keyboard activation keeps focus (a11y). Activates at next login on Wayland.

**Verification:** `tests/repros/injector-seam/repro_fake_context_fallback.py` F1–F5 (F1 red on 8a1dfeb, all green here); `verify_ibus_injector.py` ALL PASSED; wake gate green; full `tests/repros/run_all.sh` → 48 checks, 48 pass; `node --check`; leak scan 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)