### PR TITLE
fix: a badge tap in loop mode goes idle — the VAD recorder now honours the stop (#110)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
 |------|-------------|
 | Type (default) | STT -> typed at cursor via ydotool |
 | AI | STT -> LLM -> TTS (streaming sentence-level) |
-| Loop | Auto-restart listening after each utterance |
+| Loop | Auto-restart listening after each utterance. A badge tap while listening ENDS the utterance (text kept), stops the loop for this run and goes idle (#110, JP's choice (a)); the Loop pill / "cast loop" turns the mode off. Every restart guard checks `_stop_event`, and the batch (VAD) recorder honours it via `stt(stop_when=…)` -- before that a tap in offline/loop mode did nothing until VAD silence or 30 s |
 | Terminal | Lowercase, no punctuation, lexical output |
 | Talk | D-Bus API for external apps (blocking call) |
 | Half/Full Duplex | Auto-detected speaker vs headphone routing |
@@ -141,6 +141,11 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
   wire — #42 took the last two reads out of `_run_subtitle_progress` — so
   `grep -n "_cancel_event" gnome-speaks-service.py` returning only that class and prose is a cheap
   standing check that no new verdict is being read off the wire.
+- **The batch (VAD) recorder only ever watched the CANCEL wire**: `stop_listening()` deliberately leaves the wire
+  alone (it would kill the WS), so in vad mode a stop had no effect until VAD silence or `max_seconds` -- the
+  "stuck listening" of 2026-09-07 (#110). speech-to-cli's `stt(stop_when=…)` / `record_with_vad(stop_when=…)` is
+  the FINISH-EARLY-AND-KEEP predicate; the service passes `self._stop_event.is_set`. `_STT_HAS_STOP_WHEN` guards
+  an older speech-to-cli. Fixed-length recording (`stt_fixed`) still cannot be cut short (WAV header).
 - **`stop()` and `stop_listening()` both set `_stop_event` and mean opposite things**:
   `stop_listening()` is the dictation hotkey — end the utterance, **keep** the text.  `stop()` is the
   panic stop (D-Bus Stop, `POST /stop`, "cast stop", every user-speech preemption) — **abandon** it.

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -104,6 +104,9 @@ from stt import (  # noqa: E402
     _check_end_word, _strip_end_word,
 )
 import speech_tts  # noqa: E402
+import inspect as _inspect  # noqa: E402
+# Older speech-to-cli has no stop_when on stt(); detect once, never guess.
+_STT_HAS_STOP_WHEN = "stop_when" in _inspect.signature(stt_dispatch).parameters
 
 if HAS_VAD:
     import webrtcvad  # noqa: E402
@@ -2377,7 +2380,14 @@ class GnomeSpeaksService:
                 GLib.idle_add(self._emit_transcription_ready, "")
                 self._idle_after_stt()
                 return
-            result = stt_dispatch(mode=mode)
+            # stop_when: the dictation hotkey / a loop-mode badge tap sets
+            # _stop_event, and the batch (VAD) recorder must FINISH on it --
+            # keep the words, return -- not run on until silence or 30 s. The
+            # cancel wire is deliberately not used here: that abandons (#110).
+            if _STT_HAS_STOP_WHEN:
+                result = stt_dispatch(mode=mode, stop_when=self._stop_event.is_set)
+            else:
+                result = stt_dispatch(mode=mode)
             self._deliver_stt_result(result, mode, cancel_token)
         except Exception as exc:
             log.exception("Batch STT (%s) failed: %s", mode, exc)

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -111,7 +111,7 @@ run() {   # run <suite> <script>...
 }
 
 run service-audit  repro_c1_dispatch_gate.py repro_c2_hold.py repro_c3_config.py \
-                   repro_c4_timer.py repro_c5_ydotoold_unit.py repro_c6_speech_backend.py smoke_queue_ops.py verify_queue_invariants.py
+                   repro_c4_timer.py repro_c5_ydotoold_unit.py repro_c6_speech_backend.py repro_c7_loop_tap_stops_vad.py smoke_queue_ops.py verify_queue_invariants.py
 run chronicle-perf repro_chronicle_stall.py verify_archive.py \
                    verify_chronicle_contract.py verify_endpoints.py
 run cancel-tokens  repro_a_outcome_mislabel.py repro_b_transcript_after_stop.py \

--- a/tests/repros/service-audit/repro_c7_loop_tap_stops_vad.py
+++ b/tests/repros/service-audit/repro_c7_loop_tap_stops_vad.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""repro: a stop while the batch (VAD) recorder is running FINISHES it early
+and keeps the frames (#110 -- "the badge was stuck in listening mode").
+
+stop_listening() sets the service's _stop_event and deliberately not the
+cancel wire; the VAD recorder used to watch only the wire, so in offline /
+loop mode a tap did nothing until VAD silence or 30 s.
+
+  V1  speech-to-cli stt() accepts stop_when (the service detects it)
+  V2  record_with_vad(stop_when) returns EARLY with the frames captured so far
+      (fake recorder that never goes silent)
+  V3  without stop_when the same recorder runs to max_seconds (control: the
+      predicate is what ends it, not the fake)
+  V4  the service passes stop_when=_stop_event.is_set to stt_dispatch
+
+Needs the speech-to-cli that carries stop_when (SPEECH_ENGINE_PATH).
+Run:  GS_SVC_PATH=<gnome-speaks-service.py> python3 repro_c7_loop_tap_stops_vad.py
+Exit 0 = all hold; 1 = a verdict failed; 2 = setup failure.
+"""
+import atexit
+import importlib
+import importlib.util
+import inspect
+import io
+import os
+import shutil
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_PATH = os.environ.get("GS_SVC_PATH", os.path.join(REPO_ROOT, "gnome-speaks-service.py"))
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+_STATE = os.path.join(SCRATCH_ROOT, f"service-audit-looptap-{os.getpid()}", "state")
+os.makedirs(_STATE, exist_ok=True)
+atexit.register(shutil.rmtree, os.path.dirname(_STATE), True)
+os.environ["XDG_STATE_HOME"] = _STATE
+os.environ.setdefault("SPEECH_ENGINE_PATH", os.path.expanduser("~/Projects/speech-to-cli"))
+FAILS = []
+
+
+def check(label, cond, detail=""):
+    print(f"  {'OK  ' if cond else 'FAIL'} ({label}) {detail}")
+    if not cond:
+        FAILS.append(label)
+
+
+class FakeRecorder:
+    """A recorder whose stdout yields loud frames forever -- VAD never sees silence."""
+    def __init__(self, frame_bytes):
+        self.reads = 0
+        self._fb = frame_bytes
+        self.stdout = self
+
+    def read(self, n):
+        self.reads += 1
+        # alternating high-amplitude samples: energy well above any threshold
+        return (b"\x00\x40\x00\xc0" * (self._fb // 4))[:n]
+
+
+def main():
+    sys.path.insert(0, os.path.dirname(SVC_PATH))
+    spec = importlib.util.spec_from_file_location("gsvc_looptap", SVC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["gsvc_looptap"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        print(f"!! SETUP FAILURE: cannot load service: {exc}")
+        return 2
+    mod.CONFIG_PATH = os.path.join(_STATE, "config.json")
+    stt = importlib.import_module("stt")
+    audio = importlib.import_module("audio")
+    state = importlib.import_module("state")
+
+    has = "stop_when" in inspect.signature(stt.stt).parameters
+    check("V1", has and getattr(mod, "_STT_HAS_STOP_WHEN", False) == has,
+          f"stt(stop_when) supported={has}; service detected={getattr(mod, '_STT_HAS_STOP_WHEN', None)}")
+    if not has:
+        print("FAIL: 1 verdict(s) -- speech-to-cli has no stop_when; a stop cannot end a VAD recording")
+        return 1
+
+    # Make the recorder deterministic and fast: no real VAD, tiny frames.
+    state.HAS_VAD = False
+    state.FRAME_BYTES = 64
+    state.FRAME_MS = 20
+    real_cal = audio.calibrate_noise
+    audio.calibrate_noise = lambda proc: (1.0, [])
+    try:
+        rec = FakeRecorder(state.FRAME_BYTES)
+        stop_at = {"n": 5}
+        frames, _ = audio.record_with_vad(rec, max_seconds=30, stop_when=lambda: rec.reads >= stop_at["n"])
+        check("V2", 3 <= len(frames) <= 6, f"stopped early with {len(frames)} frames after {rec.reads} reads")
+
+        rec2 = FakeRecorder(state.FRAME_BYTES)
+        frames2, _ = audio.record_with_vad(rec2, max_seconds=2)   # 2 s / 20 ms = 100 frames
+        check("V3", len(frames2) >= 90, f"no predicate: ran to max_seconds -> {len(frames2)} frames")
+    finally:
+        audio.calibrate_noise = real_cal
+
+    # V4: the service passes its stop event through
+    seen = {}
+    def fake_dispatch(**kw):
+        seen.update(kw)
+        return {"text": ""}
+    mod.stt_dispatch = fake_dispatch
+    src = inspect.getsource(mod).count("stop_when=self._stop_event.is_set")
+    check("V4", src == 1, f"service passes stop_when=self._stop_event.is_set at {src} site(s)")
+
+    if FAILS:
+        print(f"FAIL: {len(FAILS)} verdict(s) -- a stop does not end a running VAD recording")
+        return 1
+    print("PASS: a stop finishes the VAD recording early and keeps the frames; the service wires it")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #110. Companion: techempower-org/speech-to-cli "stt(stop_when=…)" (must land first).

JP's choice (a): a tap while listening ends the utterance (text kept), stops the loop for this run and goes idle; the Loop pill / "cast loop" turns the mode off.

Every loop-restart guard already honoured `_stop_event`. What did not was the recorder: `stop_listening()` deliberately leaves the cancel wire alone (it would kill the streaming WebSocket), and speech-to-cli's `record_with_vad()` watched only that wire — so in the offline/batch path a tap did nothing until VAD silence or 30 s per cycle. That is the "stuck in listening mode" of 2026-09-07 once the transcripts had also vanished into IBus's fake context (#109).

The service now passes `stop_when=self._stop_event.is_set` to `stt()`; `_STT_HAS_STOP_WHEN` (inspected once at import) keeps an older speech-to-cli working.

**Verification:** `tests/repros/service-audit/repro_c7_loop_tap_stops_vad.py` V1–V4 (V1 red on main/old library; V2 a never-silent fake recorder stops at frame 5 on the predicate; V3 control runs to max_seconds without it; V4 the wiring). Full `tests/repros/run_all.sh` against the companion → 49 checks, 49 pass; wake gate green; leak 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In Loop mode, tapping the badge while listening now ends the utterance while keeping the captured text, stops the loop for that run, and returns to idle.
  * Tapping the Loop pill or saying “cast loop” now turns Loop mode off.

* **Bug Fixes**
  * Stopping a Loop-mode recording no longer waits for silence or the maximum recording timeout before taking effect.

* **Documentation**
  * Updated Loop mode guidance and troubleshooting notes to describe stopping behavior and recording limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->