### PR TITLE
fix: surface batch/offline STT errors instead of reporting silence (#130)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -2409,6 +2409,22 @@ class GnomeSpeaksService:
             _schedule_warmup()
             return
 
+        # stt_vad()/stt_fixed() report a TOTAL failure -- Azure unreachable and
+        # the Wyoming fallback failed too, or the recorder died -- as
+        # {"error": ...} with no "text" key at all. Reading only "text" turned
+        # that into "No speech detected" and a silent idle (#130); with
+        # speech_backend=local every streaming dictation is routed here, so
+        # this is the primary offline path, not a corner. Toast it like the
+        # worker's own exception path does.
+        error = result.get("error")
+        if error:
+            log.error("Batch STT (%s) failed: %s", mode, error)
+            GLib.idle_add(self._emit_error, f"STT failed: {error}")
+            GLib.idle_add(self._emit_transcription_ready, "")
+            self._idle_after_stt()
+            _schedule_warmup()
+            return
+
         user_text = result.get("text", "")
 
         self._set_state("processing")

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -64,7 +64,7 @@ tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
 
 | suite | issue / PR | baseline | expected there |
 |---|---|---|---|
-| `service-audit` | #18–#20 | `7899ccb` | derived (`merge^1`), not re-run |
+| `service-audit` | #18–#20, #110, #130 | `7899ccb` | derived (`merge^1`), not re-run; c8 verified against `025df92` (E1 fails) |
 | `chronicle-perf` | #22 / #27 | `6a1ecae` | derived (`merge^1`), not re-run |
 | `injector-seam` | #24 | `ea47ff1` | derived (`merge^1`), not re-run |
 | `cancel-tokens` | #21 / #33 | `66edc79` | **verified** — 4 of 5 fail |

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -111,7 +111,8 @@ run() {   # run <suite> <script>...
 }
 
 run service-audit  repro_c1_dispatch_gate.py repro_c2_hold.py repro_c3_config.py \
-                   repro_c4_timer.py repro_c5_ydotoold_unit.py repro_c6_speech_backend.py repro_c7_loop_tap_stops_vad.py smoke_queue_ops.py verify_queue_invariants.py
+                   repro_c4_timer.py repro_c5_ydotoold_unit.py repro_c6_speech_backend.py repro_c7_loop_tap_stops_vad.py \
+                   repro_c8_batch_error_toast.py smoke_queue_ops.py verify_queue_invariants.py
 run chronicle-perf repro_chronicle_stall.py verify_archive.py \
                    verify_chronicle_contract.py verify_endpoints.py
 run cancel-tokens  repro_a_outcome_mislabel.py repro_b_transcript_after_stop.py \

--- a/tests/repros/service-audit/repro_c8_batch_error_toast.py
+++ b/tests/repros/service-audit/repro_c8_batch_error_toast.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""repro: a batch/offline STT result of {"error": ...} reaches the user (#130).
+
+speech-to-cli's stt_vad()/stt_fixed() return {"error": "Azure STT unreachable
+(...); offline fallback failed"} -- no "text" key -- when Azure is down AND the
+Wyoming fallback fails. _deliver_stt_result read only result["text"], so a
+total STT failure logged "No speech detected", emitted TranscriptionReady("")
+and idled with NO toast. With speech_backend=local every streaming dictation is
+routed to this batch path, so the swallow was on the PRIMARY offline path.
+
+  E1  an error dict emits exactly one Error signal naming the failure
+  E2  ... and still emits TranscriptionReady("") and returns to idle
+  E3  ... and never types or clipboards anything
+  E4  control: a text-present result types the text and emits NO Error
+  E5  control: an empty-text result (genuine silence) emits NO Error
+
+Run:  GS_SVC_PATH=<gnome-speaks-service.py> python3 repro_c8_batch_error_toast.py
+Exit 0 = all hold; 1 = a verdict failed; 2 = setup failure.
+"""
+import sys
+
+import harness
+
+FAILS = []
+
+
+def check(label, cond, detail=""):
+    print(f"  {'OK  ' if cond else 'FAIL'} ({label}) {detail}")
+    if not cond:
+        FAILS.append(label)
+
+
+def deliver(mod, svc, result):
+    """Run one result through _deliver_stt_result; return (idle_calls, typed)."""
+    idle_calls, typed = [], []
+
+    class _Inj:
+        name = "fake"
+        def commit(self, text): typed.append(text)
+        def paste(self, text): typed.append(text)
+        def end(self): pass
+    mod.get_injector = lambda: _Inj()
+    mod.clipboard_write = lambda text: typed.append(text) or True
+
+    def rec_idle_add(fn, *args, **kw):
+        idle_calls.append((getattr(fn, "__name__", str(fn)), args))
+        return 0
+    real_idle_add = mod.GLib.idle_add
+    mod.GLib.idle_add = rec_idle_add
+    try:
+        svc._set_state("listening")
+        tok = svc._cancels.issue("stt")
+        assert svc._cancels.begin(tok)
+        try:
+            svc._deliver_stt_result(result, "vad", tok)
+        finally:
+            svc._cancels.retire(tok)
+    finally:
+        mod.GLib.idle_add = real_idle_add
+    return idle_calls, typed
+
+
+def main():
+    try:
+        mod, _events = harness.load()
+        svc = harness.make_service(mod)
+    except Exception as exc:
+        print(f"!! SETUP FAILURE: cannot load service: {exc}")
+        return 2
+    svc._save_config_flag = lambda *a, **k: None
+    svc._reload_config_flags = lambda *a, **k: None
+    svc._wake_gate_blocks = lambda: False
+    mod.CONFIG["dictation_mode"] = True
+    mod.CONFIG["conversation_mode"] = False
+    mod.CONFIG["continuous_dictation"] = False
+
+    msg = "Azure STT unreachable (ConnectionError); offline fallback failed"
+    calls, typed = deliver(mod, svc, {"error": msg})
+    errors = [a[0] for n, a in calls if n == "_emit_error"]
+    ready = [a[0] for n, a in calls if n == "_emit_transcription_ready"]
+    check("E1", len(errors) == 1 and msg in errors[0],
+          f"Error signals={errors!r}")
+    check("E2", ready == [""] and svc._state == "idle",
+          f"TranscriptionReady={ready!r} state={svc._state}")
+    check("E3", typed == [], f"typed={typed!r}")
+
+    calls, typed = deliver(mod, svc, {"text": "hello there"})
+    errors = [a[0] for n, a in calls if n == "_emit_error"]
+    check("E4", typed == ["hello there"] and errors == [],
+          f"typed={typed!r} errors={errors!r}")
+
+    calls, typed = deliver(mod, svc, {"text": "", "status": "NoAudio"})
+    errors = [a[0] for n, a in calls if n == "_emit_error"]
+    ready = [a[0] for n, a in calls if n == "_emit_transcription_ready"]
+    check("E5", errors == [] and ready == [""] and typed == [],
+          f"errors={errors!r} ready={ready!r}")
+
+    if FAILS:
+        print(f"FAIL: {len(FAILS)} verdict(s) -- a batch STT error dict is swallowed as silence")
+        return 1
+    print("PASS: a batch STT error reaches the user as an Error signal; text and silence unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #130

`_deliver_stt_result` only read `result['text']`; speech-to-cli's `stt_vad()`/`stt_fixed()` return `{'error': ...}` (no text key) when Azure is unreachable AND Wyoming fails. The service reported 'No speech detected' and idled silently. With `speech_backend=local` every streaming dictation routes to this batch path, so this was the primary offline path.

**Fix:** check `result.get('error')` after the cancel check; emit `Error("STT failed: …")` (same wording as the worker's exception path), then `TranscriptionReady('')` + idle as before.

**Repro:** `tests/repros/service-audit/repro_c8_batch_error_toast.py` — E1 fails on `025df92` (0 Error signals), passes with the fix; text-present and genuine-silence controls hold on both sides. Wired into `run_all.sh`.

`tests/repros/run_all.sh`: 50 checks, 50 pass, ALL SUITES GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)