### PR TITLE
fix: poll config.json from the main loop so prefs edits apply live (#124)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -1994,10 +1994,20 @@ class GnomeSpeaksService:
         "debug",
     )
 
+    # How often the main loop polls CONFIG_PATH's mtime (#124). A stat every
+    # 2 s is the whole cost; the parse only runs when the file changed.
+    CONFIG_WATCH_SECONDS = 2
+
     def _reload_config_flags(self):
         """Re-read boolean mode flags from config file so prefs changes take effect.
 
         Skips JSON parse if file mtime is unchanged since last read.
+
+        Two callers: the non-quick hotkey path in start_listening(), and the
+        main-loop poll started by _start_config_watch() (#124). The poll is
+        what makes prefs.js's "most settings apply live" true -- before it, a
+        speech_backend / wake_word / chronicle flip sat on disk until the next
+        NON-quick hotkey press, and wake-opened and loop sessions are quick.
         """
         try:
             mtime = os.path.getmtime(CONFIG_PATH)
@@ -2014,6 +2024,20 @@ class GnomeSpeaksService:
                     CONFIG[key] = disk[key]
         except Exception as exc:
             log.debug("Config reload skipped: %s", exc)
+
+    def _start_config_watch(self):
+        """Poll CONFIG_PATH from the main loop so prefs changes land without a
+        hotkey press (#124). Returns the GLib source id.
+
+        A timer, not a Gio.FileMonitor: prefs.js and _save_config_flag both
+        publish by rename, but a monitor still fires per event and a parse
+        that fails mid-write would not be retried until the next one. The
+        mtime gate in _reload_config_flags already makes polling free.
+        """
+        def _tick():
+            self._reload_config_flags()
+            return GLib.SOURCE_CONTINUE
+        return GLib.timeout_add_seconds(self.CONFIG_WATCH_SECONDS, _tick)
 
     def _save_config_flag(self, key, value):
         """Write a single flag back to the config file so prefs stays in sync.
@@ -5770,6 +5794,10 @@ def main():
 
     # Start inactivity timer
     service._reset_inactivity_timer()
+
+    # Apply prefs.js edits to config.json while idle (#124). Without this the
+    # only reload was a side effect of the non-quick dictation hotkey.
+    service._start_config_watch()
 
     # Start HTTP REST API server (optional — gracefully skip if port in use)
     http_server = None

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -64,7 +64,7 @@ tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
 
 | suite | issue / PR | baseline | expected there |
 |---|---|---|---|
-| `service-audit` | #18–#20, #110, #130 | `7899ccb` | derived (`merge^1`), not re-run; c8 verified against `025df92` (E1 fails) |
+| `service-audit` | #18–#20, #110, #124 (c8 config-watch), #130 | `7899ccb` | derived (`merge^1`), not re-run; c8 batch-error-toast verified against `025df92` (E1 fails) |
 | `chronicle-perf` | #22 / #27 | `6a1ecae` | derived (`merge^1`), not re-run |
 | `injector-seam` | #24 | `ea47ff1` | derived (`merge^1`), not re-run |
 | `cancel-tokens` | #21 / #33 | `66edc79` | **verified** — 4 of 5 fail |

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -112,7 +112,8 @@ run() {   # run <suite> <script>...
 
 run service-audit  repro_c1_dispatch_gate.py repro_c2_hold.py repro_c3_config.py \
                    repro_c4_timer.py repro_c5_ydotoold_unit.py repro_c6_speech_backend.py repro_c7_loop_tap_stops_vad.py \
-                   repro_c8_batch_error_toast.py smoke_queue_ops.py verify_queue_invariants.py
+                   repro_c8_batch_error_toast.py repro_c8_config_watch.py \
+                   smoke_queue_ops.py verify_queue_invariants.py
 run chronicle-perf repro_chronicle_stall.py verify_archive.py \
                    verify_chronicle_contract.py verify_endpoints.py
 run cancel-tokens  repro_a_outcome_mislabel.py repro_b_transcript_after_stop.py \

--- a/tests/repros/service-audit/repro_c8_config_watch.py
+++ b/tests/repros/service-audit/repro_c8_config_watch.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""C8: a prefs.js edit to config.json applies WITHOUT a hotkey press (#124).
+
+Before: _reload_config_flags() had exactly one caller, start_listening() when
+not quick. prefs.js promised "Most settings apply live", but a flip of
+speech_backend (wyoming.prefer_local reads state.CONFIG, so agent POST /speak
+and GET /status kept the old backend), wake_word (the watcher polls CONFIG) or
+chronicle did nothing until the next NON-quick hotkey press -- and wake-opened
+and loop sessions are quick=True, so they never reloaded at all.
+
+  C8a  _start_config_watch exists and returns a GLib source id
+  C8b  writing speech_backend/wake_word/chronicle to CONFIG_PATH flips CONFIG
+       from the main loop alone -- start_listening is stubbed to FAIL if called
+  C8c  the live consequence: wyoming.skip_reason() follows the flip
+  C8d  an unchanged file is not re-parsed (the mtime gate still holds)
+
+Exit 0 = all hold; 1 = a verdict failed; 2 = setup failure.
+"""
+import builtins
+import json
+import os
+import sys
+import time
+
+import harness
+
+FAILS = []
+
+
+def check(label, cond, detail=""):
+    print(f"  {'OK  ' if cond else 'FAIL'} ({label}) {detail}")
+    if not cond:
+        FAILS.append(label)
+
+
+def main():
+    mod, _events = harness.load(fake_tts_seconds=0.1)
+    GLib = mod.GLib
+    svc = harness.make_service(mod)
+
+    # The bug is that reload rides on this call. It must not be needed.
+    def _no_hotkey(*a, **k):
+        raise AssertionError("start_listening() was called -- reload must not depend on it")
+    svc.start_listening = _no_hotkey
+
+    # Prefs-shaped starting point: all three flags in their pinned state.
+    if (mod.CONFIG.get("speech_backend", "azure") == "local"
+            or mod.CONFIG.get("wake_word") is not False
+            or mod.CONFIG.get("chronicle") is not False):
+        print("!! SETUP FAILURE: CONFIG pins did not take")
+        return 2
+    wy = mod.wyoming_mod
+    mod.CONFIG["wyoming_host"] = "127.0.0.1"   # prefer_local needs a target
+    wy.mark_azure_up(); wy.mark_local_up()
+
+    start = getattr(svc, "_start_config_watch", None)
+    if start is None:
+        check("C8a", False, "GnomeSpeaksService has no _start_config_watch")
+        print("FAIL: 1 verdict(s) -- config reload is still a side effect of the hotkey")
+        return 1
+    source_id = start()
+    check("C8a", isinstance(source_id, int) and source_id > 0, f"source id {source_id}")
+
+    # What prefs.js does: merge-on-write of the same file, published by rename.
+    with open(mod.CONFIG_PATH) as f:
+        disk = json.load(f)
+    disk.update({"speech_backend": "local", "wake_word": True, "chronicle": True})
+    tmp = mod.CONFIG_PATH + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(disk, f)
+    os.replace(tmp, mod.CONFIG_PATH)
+    # Bump mtime past any filesystem granularity so the gate cannot mask the write.
+    st = os.stat(mod.CONFIG_PATH)
+    os.utime(mod.CONFIG_PATH, ns=(st.st_atime_ns, st.st_mtime_ns + 2_000_000_000))
+
+    # Spin the main loop only -- no D-Bus, no hotkey, no start_listening.
+    loop = GLib.MainLoop()
+    interval = getattr(svc, "CONFIG_WATCH_SECONDS", 2)
+    deadline = time.monotonic() + interval * 3 + 1
+
+    def _poll():
+        flipped = (mod.CONFIG.get("speech_backend") == "local"
+                   and mod.CONFIG.get("wake_word") is True
+                   and mod.CONFIG.get("chronicle") is True)
+        if flipped or time.monotonic() > deadline:
+            loop.quit()
+            return GLib.SOURCE_REMOVE
+        return GLib.SOURCE_CONTINUE
+    GLib.timeout_add(50, _poll)
+    t0 = time.monotonic()
+    loop.run()
+    took = time.monotonic() - t0
+    check("C8b", mod.CONFIG.get("speech_backend") == "local"
+          and mod.CONFIG.get("wake_word") is True
+          and mod.CONFIG.get("chronicle") is True,
+          f"after {took:.1f}s: speech_backend={mod.CONFIG.get('speech_backend')!r} "
+          f"wake_word={mod.CONFIG.get('wake_word')!r} chronicle={mod.CONFIG.get('chronicle')!r}")
+    check("C8c", wy.skip_azure() and wy.skip_reason() == "prefer_local",
+          f"skip_azure={wy.skip_azure()} reason={wy.skip_reason()}")
+
+    # Mtime gate: an unchanged file must not be parsed again.
+    cached = svc._config_mtime
+    opened = []
+    orig = builtins.open
+
+    def spy(path, *a, **k):
+        if path == mod.CONFIG_PATH:
+            opened.append(path)
+        return orig(path, *a, **k)
+    builtins.open = spy
+    try:
+        svc._reload_config_flags()
+    finally:
+        builtins.open = orig
+    check("C8d", not opened and svc._config_mtime == cached,
+          f"re-opens of an unchanged config: {len(opened)}")
+
+    GLib.source_remove(source_id)
+    # The watcher thread reads CONFIG['wake_word'] every 0.5 s; put it back
+    # before exit so it never tries to open a mic from a test.
+    mod.CONFIG["wake_word"] = False
+
+    if FAILS:
+        print(f"FAIL: {len(FAILS)} verdict(s) -- config reload is still a side effect of the hotkey")
+        return 1
+    print("PASS: prefs edits to config.json apply from the main loop without a hotkey press")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #124

`_reload_config_flags()` had one caller (non-quick `start_listening()`), so prefs flips of `speech_backend`, `wake_word` and `chronicle` sat on disk until the next non-quick hotkey press; wake-opened and loop sessions never reloaded. This adds a 2 s main-loop poll of the already mtime-gated reload, started in `main()`.

Repro: `tests/repros/service-audit/repro_c8_config_watch.py` -- red on `main`, green here. `tests/repros/run_all.sh`: 50/50 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configuration changes now apply automatically while the service is idle, without requiring a dictation hotkey press.
  - Updates to speech backend, wake word, and related settings are detected through the running service.

- **Tests**
  - Added coverage to verify live configuration updates, unchanged-file handling, and related setting behavior.
  - Expanded the service audit suite and clarified its verification notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->