### PR TITLE
fix: give the HTTP API a JSON failure envelope (#128)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -4985,6 +4985,7 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
 
     def _send_json(self, data, status=200):
         body = json.dumps(data).encode("utf-8")
+        self._replied = True   # headers go out below; _dispatch must not add a 500
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self._set_cors_headers()
@@ -5001,7 +5002,36 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
         self._set_cors_headers()
         self.end_headers()
 
+    # Every request gets a JSON answer, including the ones that blow up (#128).
+    # BaseHTTPRequestHandler lets an exception escape do_GET/do_POST straight
+    # into socketserver, which prints a traceback and closes the socket with
+    # NO response -- agents saw curl's "Empty reply from server" instead of an
+    # error they could parse, and the only trace was a stack dump in the
+    # journal. The envelope is the contract: a handler that raises is a bug,
+    # but the caller still gets {"ok": false, "error": ...} and a 500.
+    _replied = False
+
+    def _dispatch(self, handler):
+        self._replied = False   # per request: one handler instance may serve several
+        try:
+            handler()
+        except Exception as exc:  # noqa: BLE001 -- the envelope IS the point
+            log.exception("HTTP %s %s failed", self.command, self.path)
+            if self._replied:
+                return  # headers already on the wire; nothing sane to add
+            try:
+                self._send_error_json(
+                    500, f"internal error: {type(exc).__name__}: {exc}")
+            except OSError:
+                pass  # client already gone
+
     def do_GET(self):
+        self._dispatch(self._route_get)
+
+    def do_POST(self):
+        self._dispatch(self._route_post)
+
+    def _route_get(self):
         path = self.path.split("?")[0]
         if path == "/api/version":
             self._handle_version()
@@ -5016,7 +5046,7 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
         else:
             self._send_error_json(404, f"Unknown endpoint: {path}")
 
-    def do_POST(self):
+    def _route_post(self):
         path = self.path.split("?")[0]
         if path == "/speak":
             self._handle_speak()
@@ -5038,16 +5068,29 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
     # -- Request body parsing ----------------------------------------------
 
     def _read_json_body(self):
-        """Read and parse JSON request body. Returns dict or None on error."""
-        content_length = int(self.headers.get("Content-Length", 0))
+        """Read and parse JSON request body. Returns dict or None on error.
+
+        Every handler does `body.get(...)` on the result, so a body that parses
+        but is not an object (a bare list, string, number) is a 400 here, not
+        an AttributeError three lines later.
+        """
+        try:
+            content_length = int(self.headers.get("Content-Length", 0))
+        except ValueError:
+            self._send_error_json(400, "Invalid Content-Length header")
+            return None
         if content_length == 0:
             return {}
         try:
             raw = self.rfile.read(content_length)
-            return json.loads(raw)
+            body = json.loads(raw)
         except (json.JSONDecodeError, ValueError) as exc:
             self._send_error_json(400, f"Invalid JSON: {exc}")
             return None
+        if not isinstance(body, dict):
+            self._send_error_json(400, "JSON body must be an object")
+            return None
+        return body
 
     # -- Endpoint handlers -------------------------------------------------
 
@@ -5056,7 +5099,7 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
         if body is None:
             return  # error already sent
         text = body.get("text", "")
-        if not text or not text.strip():
+        if not isinstance(text, str) or not text.strip():
             self._send_error_json(400, "Missing or empty 'text' field")
             return
 
@@ -5163,7 +5206,7 @@ class SpeechHTTPHandler(http.server.BaseHTTPRequestHandler):
         if body is None:
             return
         text = body.get("text", "")
-        if not text or not text.strip():
+        if not isinstance(text, str) or not text.strip():
             self._send_error_json(400, "Missing or empty 'text' field")
             return
         handled = self.service._try_cast(text)

--- a/tests/repros/chronicle-perf/verify_http_envelope.py
+++ b/tests/repros/chronicle-perf/verify_http_envelope.py
@@ -1,0 +1,136 @@
+"""#128: every HTTP request gets a JSON answer, even the ones that blow up.
+
+Before the fix, do_GET/do_POST dispatched into _handle_* with no try/except,
+so an escaping exception made socketserver print a traceback and close the
+socket with NO response -- curl reported "Empty reply from server" and an
+agent had nothing to parse. Four inputs reached that path from the outside:
+
+  - `Content-Length: abc`          int() sat outside _read_json_body's try
+  - a JSON body that is a list     body.get -> AttributeError
+  - {"text": 5}                    .strip() -> AttributeError
+  - any non-queue.Full raise inside enqueue_speech (forced here)
+
+Bound on port 0 like verify_endpoints.py -- never 7710, the live service
+owns that. Exit 0 = every case answered JSON with the right status; 1 = at
+least one still drops the connection or answers the wrong code.
+"""
+import http.client
+import http.server
+import json
+import threading
+
+import harness
+
+mod, events = harness.load(0.05)
+svc = harness.make_service(mod)
+fails = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {'ok  ' if ok else 'FAIL'} {name}{'' if ok else '  <- ' + detail}")
+    if not ok:
+        fails.append(name)
+
+
+mod.SpeechHTTPHandler.service = svc
+srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), mod.SpeechHTTPHandler)
+port = srv.server_address[1]
+assert port != 7710
+threading.Thread(target=srv.serve_forever, daemon=True).start()
+
+
+def raw_post(path, body, headers):
+    """Returns (status, parsed_json) or (None, repr(exc)) on a dropped socket.
+
+    Headers are passed through verbatim so a malformed Content-Length reaches
+    the server instead of being corrected by http.client.
+    """
+    c = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+    try:
+        c.putrequest("POST", path, skip_accept_encoding=True)
+        for k, v in headers.items():
+            c.putheader(k, v)
+        c.endheaders()
+        if body:
+            c.send(body)
+        r = c.getresponse()
+        data = r.read()
+        try:
+            return r.status, json.loads(data)
+        except ValueError:
+            return r.status, {"_raw": data[:80].decode("latin-1")}
+    except (http.client.HTTPException, OSError) as exc:
+        return None, repr(exc)
+    finally:
+        c.close()
+
+
+def post(path, payload):
+    body = json.dumps(payload).encode()
+    return raw_post(path, body, {"Content-Type": "application/json",
+                                 "Content-Length": str(len(body))})
+
+
+def envelope(name, result, status):
+    st, body = result
+    check(f"{name} -> {status}", st == status, f"got {st} {body}")
+    check(f"{name} is a JSON error envelope",
+          isinstance(body, dict) and body.get("ok") is False
+          and isinstance(body.get("error"), str), f"{body}")
+
+
+# ---- 400s: malformed input must be rejected, not crashed on ----------
+envelope("Content-Length: abc",
+         raw_post("/speak", b"", {"Content-Type": "application/json",
+                                  "Content-Length": "abc"}), 400)
+envelope("JSON list body", post("/speak", ["hello"]), 400)
+envelope("JSON string body", post("/skip", "hello"), 400)
+envelope('{"text": 5} on /speak', post("/speak", {"text": 5}), 400)
+envelope('{"text": 5} on /cast', post("/cast", {"text": 5}), 400)
+envelope('{"text": null} on /speak', post("/speak", {"text": None}), 400)
+
+# ---- 500: a handler that raises still answers -------------------------
+def boom(*a, **k):
+    raise RuntimeError("forced by verify_http_envelope")
+
+
+real_enqueue = svc.enqueue_speech
+svc.enqueue_speech = boom
+try:
+    envelope("enqueue_speech raising RuntimeError",
+             post("/speak", {"text": "hello"}), 500)
+finally:
+    svc.enqueue_speech = real_enqueue
+
+# GET side goes through the same envelope
+real_status = mod.SpeechHTTPHandler._handle_status
+mod.SpeechHTTPHandler._handle_status = boom
+try:
+    c = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+    try:
+        c.request("GET", "/status")
+        r = c.getresponse()
+        res = (r.status, json.loads(r.read()))
+    except (http.client.HTTPException, OSError, ValueError) as exc:
+        res = (None, repr(exc))
+    finally:
+        c.close()
+    envelope("GET /status handler raising", res, 500)
+finally:
+    mod.SpeechHTTPHandler._handle_status = real_status
+
+# ---- control: the healthy path is untouched ---------------------------
+st, body = post("/speak", {"text": "control utterance"})
+check("healthy POST /speak still 200", st == 200 and body.get("ok") is True,
+      f"{st} {body}")
+st, body = post("/skip", {})
+check("bodyless-equivalent POST /skip still 200", st == 200, f"{st} {body}")
+svc._drain_tts_queue()
+svc.stop(drain_queue=False)
+srv.shutdown()
+
+print()
+if fails:
+    print("FAILURES:", ", ".join(fails))
+    raise SystemExit(1)
+print("all checks passed")

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -113,7 +113,7 @@ run() {   # run <suite> <script>...
 run service-audit  repro_c1_dispatch_gate.py repro_c2_hold.py repro_c3_config.py \
                    repro_c4_timer.py repro_c5_ydotoold_unit.py repro_c6_speech_backend.py repro_c7_loop_tap_stops_vad.py smoke_queue_ops.py verify_queue_invariants.py
 run chronicle-perf repro_chronicle_stall.py verify_archive.py \
-                   verify_chronicle_contract.py verify_endpoints.py
+                   verify_chronicle_contract.py verify_endpoints.py verify_http_envelope.py
 run cancel-tokens  repro_a_outcome_mislabel.py repro_b_transcript_after_stop.py \
                    repro_c_streaming_after_stop.py repro_d_mic_disconnect.py \
                    verify_cancel_invariants.py


### PR DESCRIPTION
Closes #128

`do_GET`/`do_POST` dispatched into `_handle_*` with no try/except, so an escaping exception made socketserver print a traceback and close the socket with **no response** — agents got `Empty reply from server` instead of JSON.

**Fix (`SpeechHTTPHandler`):**
- `_dispatch` wraps both routers: `log.exception` + JSON 500 `{"ok": false, "error": ...}` unless the handler already sent headers (`_replied`, reset per request).
- `_read_json_body`: non-integer `Content-Length` and non-object JSON bodies are 400s, not crashes.
- `/speak`, `/cast`: a non-string `text` is a 400 instead of an `AttributeError` on `.strip()`.

**Repro:** `tests/repros/chronicle-perf/verify_http_envelope.py` — binds port 0 like `verify_endpoints.py`, drives all four escaping inputs plus a forced raise inside `enqueue_speech` (POST) and `_handle_status` (GET), with a healthy-path control. Wired into `run_all.sh`.

**Verification:**
- Against `main`: 14 of 18 checks fail with `RemoteDisconnected`; controls pass.
- Against this branch: all pass.
- `tests/repros/run_all.sh`: 50/50, ALL SUITES GREEN (incl. prefs-rig).
- `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)