### PR TITLE
fix: "cast stop" casts, and STT punctuation on the trigger word no longer misses (#119)

### DIFF
--- a/spellbook.json
+++ b/spellbook.json
@@ -8,6 +8,8 @@
       "name": "silence",
       "patterns": [
         "silence",
+        "stop",
+        "halt",
         "be silent",
         "quiet"
       ],

--- a/spellbook.py
+++ b/spellbook.py
@@ -43,6 +43,12 @@ DENYLIST = [
 VALID_ACTION_TYPES = ("say", "dbus_self", "http", "shell", "assist", "oracle")
 VALID_GATES = ("instant", "confirm")
 
+# Punctuation STT glues onto a spoken trigger word, or drops between it and
+# the incantation (#119). Sentence-final punctuation plus the dash family;
+# never apostrophes or slashes, which are parts of words.
+_TRIGGER_PUNCT = re.compile(r"[.,!?;:\-\u2013\u2014\u2026]+")
+_LEADING_PUNCT = re.compile(r"^[.,!?;:\-\u2013\u2014\u2026\s]+")
+
 FIZZLE_TEXT = "The spell fizzles."
 UNREACHABLE_TEXT = "The realm is beyond reach."
 
@@ -124,9 +130,17 @@ def match(text, book):
     norm = text.strip().lower()
     norm = re.sub(r"[.,!?;:]+$", "", norm).strip()
     words = norm.split()
-    if not words or words[0] not in book["trigger_words"]:
+    # Azure's DisplayText is punctuated, and an imperative trigger word can
+    # arrive as "cast," / "Cast." / "Invoke..." -- or with a dash after it
+    # ("Cast - skip"). Punctuation glued to the trigger, or standing alone in
+    # front of the incantation, is prosody, not words: strip it, or the whole
+    # utterance is a "miss" and gets typed at the cursor (#119). A hyphenated
+    # word ("cast-iron") loses its hyphen and still misses, as it should.
+    if not words:
         return "miss", None, None
-    incantation = " ".join(words[1:])
+    if _TRIGGER_PUNCT.sub("", words[0]) not in book["trigger_words"]:
+        return "miss", None, None
+    incantation = _LEADING_PUNCT.sub("", " ".join(words[1:]))
     if not incantation:
         return "fizzle", None, ""
     best = None  # (pattern_len, spell, remainder)

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -75,6 +75,7 @@ tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
 | `pin-lifecycle` | #46 ×#57 | `15dd402` | compound X: X1 FAIL, X2 PASS, X3 FAIL |
 | `version-cache` | #53 / #85 | two-sided, below | `577a05f` passes, `7eaeb02` fails |
 | `prefs-rig` | #82 | merge base of the branch | more warnings than baseline = fail |
+| `spellbook` | #119 | `025df92` | **verified** — 8 fail: `cast stop`, `cast halt`, every punctuated trigger (`Cast, stop.`, `Cast - skip`, `Invoke... skip`, …); the denylist, overlay and op-table checks stay green on both sides |
 
 "derived" means the SHA is the merge commit's first parent — the main tip
 immediately before the fix, correct by construction but not re-run. The method

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -129,6 +129,7 @@ run pin-lifecycle  repro_pin_lifecycle.py repro_compound_pin_x_deadmic.py \
                    repro_compound_reply_pin.py
 run injector-seam  verify_injector_seam.py verify_ibus_injector.py repro_fallback_retry.py repro_fake_context_fallback.py
 run version-cache  verify_version_cache.py repro_a_fork_storm.py
+run spellbook      verify_spellbook.py
 
 # ---------------------------------------------------------------------------
 # offline-handoff: ONE PROCESS PER CASE, on purpose.

--- a/tests/repros/spellbook/verify_spellbook.py
+++ b/tests/repros/spellbook/verify_spellbook.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Verify spellbook.py: match(), the denylist floor, overlay merge, op table.
+
+Contract under test (#119):
+  1. match(): "cast stop" is the documented panic stop and must CAST, not
+     fizzle; a trigger word followed by STT punctuation ("Cast, stop." /
+     "Cast. Stop." / "Invoke... skip") or a dictation dash ("Cast - skip")
+     must cast, never MISS -- a miss is typed at the cursor verbatim.
+     Longest pattern wins ("cast stop the loop now" -> loop, remainder "now").
+     No false positive from the normalisation: "cast-iron skillet" and
+     "broadcast stop" stay a miss.
+  2. _validate(): the DENYLIST is a floor (ydotool, \\block\\., wol sleep
+     refuse to load), shell needs a non-empty argv LIST, unknown gate/type,
+     missing name/patterns.
+  3. load_spellbook(): every repo spell loads; a user overlay overrides by
+     name; a BROKEN overlay file never drops the repo spells; a denylisted
+     overlay spell is dropped alone; trigger_words override is lowercased.
+  4. Op table: every dbus_self.op in spellbook.json has an `op == "<op>"`
+     branch in the service's _spell_ctx_dbus -- a typo'd op today is a
+     silent FIZZLE_TEXT at runtime, and nothing else checks the join.
+
+Imports spellbook.py from the tree under test, NOT the service: the service
+pulls in speech-to-cli and JP's live config at import, and nothing here needs
+either. The op-table check reads the service SOURCE as text. Touches no port,
+no D-Bus, no live config; the overlay fixtures live in a per-PID scratch dir.
+
+Baseline: red on 025df92 for the #119 cases (cast stop / Cast, stop. /
+Cast - skip / Invoke... skip); everything else green on both sides.
+"""
+import atexit
+import importlib.util
+import json
+import logging
+import os
+import re
+import shutil
+import sys
+
+# ENV CONTRACT (unified 2026-09-06): GS_SVC_PATH is the ONE input -- the
+# service.py file under test. The worktree dir is DERIVED from its dirname, so
+# spellbook.py and spellbook.json always come from the same tree as the
+# service. GS_WT overrides the dir only if you really mean to mix trees.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+SVC_PATH = os.environ.get("GS_SVC_PATH", SVC_DEFAULT)
+WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
+MOD_PATH = os.path.join(WT, "spellbook.py")
+BOOK_PATH = os.path.join(WT, "spellbook.json")
+
+# Per-PID scratch under the repo's gitignored tmp/ -- never a fixed path, never
+# the /tmp tmpfs. Only ever deleted by the process that created it.
+_SCRATCH = os.path.join(SCRATCH_ROOT, f"spellbook-{os.getpid()}")
+os.makedirs(_SCRATCH, exist_ok=True)
+atexit.register(shutil.rmtree, _SCRATCH, True)
+
+FAILS = []
+
+
+def check(label, cond, detail=""):
+    if cond:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label} {detail}")
+        FAILS.append(label)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("gs_spellbook", MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["gs_spellbook"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def write_fixture(name, obj):
+    path = os.path.join(_SCRATCH, name)
+    with open(path, "w") as f:
+        if isinstance(obj, str):
+            f.write(obj)
+        else:
+            json.dump(obj, f)
+    return path
+
+
+def check_match(sb, book, text, kind, name=None, remainder=None):
+    got_kind, got_spell, got_rem = sb.match(text, book)
+    got_name = got_spell["name"] if got_spell else None
+    ok = got_kind == kind and got_name == name
+    if remainder is not None:
+        ok = ok and got_rem == remainder
+    label = f"match {text!r} -> {kind}"
+    if name:
+        label += f" {name}"
+    if remainder is not None:
+        label += f" rem={remainder!r}"
+    check(label, ok, f"got ({got_kind}, {got_name}, {got_rem!r})")
+
+
+def main():
+    for p in (MOD_PATH, BOOK_PATH, SVC_PATH):
+        if not os.path.isfile(p):
+            print(f"!! SETUP FAILURE: no such file {p}")
+            return 2
+    logging.getLogger("gnome-speaks").setLevel(logging.CRITICAL)
+    sb = load_module()
+    with open(BOOK_PATH) as f:
+        raw = json.load(f)
+    repo_names = [s["name"] for s in raw["spells"]]
+
+    print("-- match(): #119 cases (red on 025df92)")
+    book = sb.load_spellbook(BOOK_PATH, None)
+    check_match(sb, book, "cast stop", "cast", "silence", "")
+    check_match(sb, book, "Cast, stop.", "cast", "silence", "")
+    check_match(sb, book, "Cast. Stop.", "cast", "silence", "")
+    check_match(sb, book, "cast, silence", "cast", "silence", "")
+    check_match(sb, book, "Cast - skip", "cast", "skip", "")
+    check_match(sb, book, "Invoke... skip", "cast", "skip", "")
+    check_match(sb, book, "cast halt", "cast", "silence", "")
+    check("silence spell reaches op stop",
+          book["spells"]["silence"]["action"].get("op") == "stop")
+
+    print("-- match(): regression guards (green on both sides)")
+    check_match(sb, book, "Cast skip!", "cast", "skip", "")
+    check_match(sb, book, "invoke echo", "cast", "echo", "")
+    check_match(sb, book, "cast the loop", "cast", "loop", "")
+    check_match(sb, book, "cast stop the loop", "cast", "loop", "")
+    check_match(sb, book, "cast stop the loop now", "cast", "loop", "now")
+    check_match(sb, book, "cast", "fizzle", None, "")
+    check_match(sb, book, "Cast.", "fizzle", None, "")
+    check_match(sb, book, "cast summon dragons", "fizzle", None,
+                "summon dragons")
+    check_match(sb, book, "hello world", "miss")
+    check_match(sb, book, "", "miss")
+    check_match(sb, book, "cast-iron skillet", "miss")
+    check_match(sb, book, "broadcast stop", "miss")
+    check_match(sb, book, "stop", "miss")
+
+    print("-- _validate(): the denylist floor")
+    base = {"name": "x", "patterns": ["x"],
+            "action": {"type": "say", "text": "hi"}}
+    check("valid say spell loads", sb._validate(base) is None)
+    # The denylist is matched against the JSON-serialized action, so a
+    # phrase pattern (`wol\s+sleep`) sees a shell STRING, not split argv --
+    # these fixtures use the string forms the floor is written for.
+    for argv, pat in (
+            (["ydotool", "key", "1:1"], "ydotool"),
+            (["sh", "-c", "realm wol sleep some-host"], "wol sleep"),
+            (["curl", "http://x/lock.set"], r"\block\."),
+            (["sh", "-c", "loginctl lock-session"], "loginctl lock")):
+        err = sb._validate({**base, "action": {"type": "shell",
+                                               "argv": argv}})
+        check(f"denylist refuses {pat}",
+              err is not None and "denylist" in err, repr(err))
+    err = sb._validate({**base, "action": {
+        "type": "http", "method": "POST",
+        "url": "http://ha/api/services/homeassistant/restart"}})
+    check("denylist refuses homeassistant/restart",
+          err is not None and "denylist" in err, repr(err))
+    check("denylist is case-insensitive",
+          sb._validate({**base, "action": {"type": "shell",
+                                           "argv": ["YDOTOOL"]}})
+          is not None)
+    check("shell argv string rejected",
+          sb._validate({**base, "action": {"type": "shell",
+                                           "argv": "echo hi"}})
+          == "shell action requires a non-empty argv list")
+    check("shell argv empty list rejected",
+          sb._validate({**base, "action": {"type": "shell", "argv": []}})
+          is not None)
+    check("shell argv list accepted",
+          sb._validate({**base, "action": {"type": "shell",
+                                           "argv": ["echo", "hi"]}}) is None)
+    check("unknown action type rejected",
+          sb._validate({**base, "action": {"type": "eval"}})
+          == "unknown action type 'eval'")
+    check("missing action rejected",
+          sb._validate({"name": "x", "patterns": ["x"]}) is not None)
+    check("unknown gate rejected",
+          sb._validate({**base, "gate": "yolo"}) == "unknown gate 'yolo'")
+    check("missing name rejected",
+          sb._validate({"patterns": ["x"], "action": base["action"]})
+          == "missing name")
+    check("missing patterns rejected",
+          sb._validate({"name": "x", "patterns": [],
+                        "action": base["action"]}) == "missing patterns")
+
+    print("-- load_spellbook(): repo + overlay")
+    check(f"all {len(repo_names)} repo spells load",
+          sorted(book["spells"]) == sorted(repo_names),
+          f"loaded {sorted(book['spells'])}")
+    check("repo trigger words are cast/invoke",
+          book["trigger_words"] == ["cast", "invoke"], book["trigger_words"])
+    overlay = write_fixture("overlay.json", {
+        "trigger_words": ["Cast", "SUMMON"],
+        "spells": [
+            {"name": "skip", "patterns": ["onward"],
+             "action": {"type": "say", "text": "overridden"}},
+            {"name": "evil", "patterns": ["evil"],
+             "action": {"type": "shell", "argv": ["ydotool", "type", "x"]}},
+            {"name": "greet", "patterns": ["greet"],
+             "action": {"type": "say", "text": "hail"}},
+        ]})
+    merged = sb.load_spellbook(BOOK_PATH, overlay)
+    check("overlay overrides by name",
+          merged["spells"]["skip"]["patterns"] == ["onward"]
+          and merged["spells"]["skip"]["action"]["type"] == "say")
+    check("overlay adds a new spell", "greet" in merged["spells"])
+    check("denylisted overlay spell dropped alone",
+          "evil" not in merged["spells"]
+          and len(merged["spells"]) == len(repo_names) + 1,
+          sorted(merged["spells"]))
+    check("trigger_words override is lowercased",
+          merged["trigger_words"] == ["cast", "summon"],
+          merged["trigger_words"])
+    check_match(sb, merged, "Summon, greet.", "cast", "greet", "")
+    check_match(sb, merged, "invoke skip", "miss")
+    broken = write_fixture("broken.json", "{not json")
+    kept = sb.load_spellbook(BOOK_PATH, broken)
+    check("broken overlay file never drops repo spells",
+          sorted(kept["spells"]) == sorted(repo_names))
+    check("missing overlay path is fine",
+          sorted(sb.load_spellbook(
+              BOOK_PATH, os.path.join(_SCRATCH, "nope.json"))["spells"])
+          == sorted(repo_names))
+
+    print("-- op table: spellbook.json <-> _spell_ctx_dbus")
+    with open(SVC_PATH) as f:
+        src = f.read()
+    m = re.search(r"def _spell_ctx_dbus\(self, op\):.*?\n    def ", src,
+                  re.S)
+    check("service has _spell_ctx_dbus", m is not None)
+    body = m.group(0) if m else ""
+    ops = sorted({s["action"]["op"] for s in raw["spells"]
+                  if s["action"]["type"] == "dbus_self"})
+    for op in ops:
+        check(f"op {op!r} has a branch", f'op == "{op}"' in body)
+
+    print()
+    if FAILS:
+        print(f"FAILURES: {len(FAILS)}")
+        for f in FAILS:
+            print(f"  - {f}")
+        return 1
+    print("ALL SPELLBOOK CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #119

## What

Two `spellbook.match()` faults, both measured in-process on `025df92`:

1. **`cast stop` fizzled.** No spell carried a bare `stop` pattern, yet CLAUDE.md names "cast stop" as the panic stop. `stop` and `halt` join `silence` (op `stop`). Longest-pattern-wins keeps `cast stop the loop` → `loop` (remainder-preserving: `cast stop the loop now` → `loop`, `now`).
2. **A punctuated trigger word was a MISS — typed at the cursor verbatim.** `match()` stripped punctuation only at the *end* of the utterance, so Azure `format=detailed` DisplayText like `Cast, stop.` / `Cast. Stop.` / `Invoke... skip` left `words[0]` as `"cast,"`, and `Cast - skip` fizzled with remainder `- skip`. `match()` now strips sentence punctuation and the dash family (`- – — …`) from the trigger token and from the head of the incantation. Not a widened net: `cast-iron skillet` and `broadcast stop` still miss, `stop` alone still misses.

## Suite

`tests/repros/spellbook/verify_spellbook.py` — 64 checks, plain script per the repro contract (0/1/2), per-PID scratch under `tmp/repros/`, **imports `spellbook.py` only**: never the service, never `~/.config/speech-to-cli/config.json`. Covers the #119 cases, longest-pattern-wins, the DENYLIST floor, shell `argv` validation, overlay merge (override by name, denylisted overlay spell dropped alone, broken overlay file keeps the repo spells, lowercased `trigger_words`), and the `spellbook.json` ↔ `_spell_ctx_dbus` op table (grep of the service source — a typo'd op is a silent fizzle at runtime today).

Registered in `run_all.sh`; baseline `025df92` pinned in `tests/repros/README.md`.

## Verification

- Branch: `ALL SPELLBOOK CHECKS PASSED` (64/64).
- Extracted `025df92`: **8 fail** — `cast stop`, `cast halt`, and every punctuated-trigger case (incl. the overlay `Summon, greet.`); denylist / overlay / op-table checks green on both sides.
- `tests/repros/run_all.sh` bare: `50 checks: 50 pass, 0 fail` / `ALL SUITES GREEN` (49 before this suite).
- `python3 verify_wake_gate.py`: `all checks passed` (unchanged).
- `py_compile` on `spellbook.py` + the suite; `spellbook.json` parses.

## Noticed, not changed (out of #119's scope)

The DENYLIST is matched against the **JSON-serialized action**, so a phrase pattern like `wol\s+sleep` or `loginctl\s+lock` sees `"wol", "sleep"` for a shell **argv list** and does not fire — only a shell *string* (`["sh","-c","… wol sleep …"]`) or an http URL/body trips it. The suite's fixtures use the string forms deliberately. Whether the floor should also match the joined argv is a small design call I did not want to fold into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The “silence” spell now responds to “stop” and “halt” in addition to existing trigger phrases.
  - Spoken commands remain recognizable when punctuation or dashes are attached to trigger words, such as “Cast, stop.” or “Cast - skip.”

- **Bug Fixes**
  - Improved command matching for speech-to-text output that adds, removes, or joins punctuation around spoken phrases.

- **Tests**
  - Added regression coverage for trigger matching, punctuation handling, validation, denylist behavior, and spellbook consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->