### PR TITLE
fix: answer GetAudioInfo off the main loop (#135)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -5589,9 +5589,14 @@ class DBusHandler:
                 result = self.service.get_terminal_mode()
                 invocation.return_value(GLib.Variant("(b)", (result,)))
 
+            # Shells out to wpctl (3 s timeout) on every call, pw-dump when the
+            # sink changed and pw-cli until the EC probe is cached -- the same
+            # probes #50 measured at 3.9 s while PipeWire was still coming up.
+            # The extension calls this at proxy init and on every
+            # bus-name-appeared, i.e. exactly that window, so it goes to the
+            # pool like every other blocking method (#135).
             elif method_name == "GetAudioInfo":
-                result = self.service.get_audio_info()
-                invocation.return_value(GLib.Variant("(s)", (result,)))
+                self._run_async(invocation, "(s)", self.service.get_audio_info)
 
             elif method_name == "SetSTTMode":
                 mode = parameters.unpack()[0]

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -66,6 +66,7 @@ tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
 |---|---|---|---|
 | `service-audit` | #18–#20, #110, #124 (c8 config-watch), #130 | `7899ccb` | derived (`merge^1`), not re-run; c8 batch-error-toast verified against `025df92` (E1 fails) |
 | `chronicle-perf` | #22 / #27 | `6a1ecae` | derived (`merge^1`), not re-run |
+| `chronicle-perf/repro_audio_info_stall` | #135 | `025df92` | **verified** — 319 ms stall, probe on MainThread |
 | `injector-seam` | #24 | `ea47ff1` | derived (`merge^1`), not re-run |
 | `cancel-tokens` | #21 / #33 | `66edc79` | **verified** — 4 of 5 fail |
 | `dead-recorder` | #57, #48 / #72 | `e863b2c` | **verified** — e, f, h fail; g, i pass |

--- a/tests/repros/chronicle-perf/repro_audio_info_stall.py
+++ b/tests/repros/chronicle-perf/repro_audio_info_stall.py
@@ -1,0 +1,128 @@
+"""Issue #135 repro: GetAudioInfo runs the PipeWire probes ON the GLib main loop.
+
+Same instrument as repro_chronicle_stall.py, pointed at the other inline
+method: a 20ms heartbeat runs on a real GLib main loop while
+DBusHandler.handle_method_call("GetAudioInfo") is dispatched exactly as GDBus
+dispatches it. get_audio_info() calls _refresh_audio_detection() (wpctl status,
+3 s timeout; pw-dump when the sink changed) and has_echo_cancel() (pw-cli
+list-objects, 3 s, until cached). Here both are stubbed: the refresh sleeps
+300 ms standing in for a slow probe, the EC check returns at once -- so the
+measurement is the dispatch path, not PipeWire.
+
+The extension issues GetAudioInfo at proxy init and on every bus-name-appeared,
+i.e. at login and after every service restart -- the window where #50 measured
+these probes at 3.9 s. For as long as the call is answered inline the service
+emits no StateChanged/AudioLevel/SubtitleUpdate and StartListening/Stop wait
+behind it.
+
+Hedge, verbatim from the issue: the inline cost at login is INFERRED from
+#50's measurement, not re-measured; on warm PipeWire wpctl is ~12 ms and the
+stall is invisible. This repro therefore asserts on the dispatch shape (does
+a slow probe stall the loop?), not on a live PipeWire timing.
+"""
+import json
+import statistics
+import sys
+import threading
+import time
+
+import harness
+
+PROBE_SECONDS = 0.3
+
+mod, _events = harness.load(0.05)
+from gi.repository import GLib  # noqa: E402
+
+svc = harness.make_service(mod)
+handler = mod.DBusHandler(svc)
+
+# harness.load() already stubs _refresh_audio_detection to a no-op; replace it
+# with a slow one, and pin the EC probe so no pw-cli is spawned either.
+probe_thread = []
+
+
+def slow_refresh(*a, **k):
+    probe_thread.append(threading.current_thread().name)
+    time.sleep(PROBE_SECONDS)
+
+
+mod._refresh_audio_detection = slow_refresh
+mod.has_echo_cancel = lambda *a, **k: False
+
+
+class FakeInvocation:
+    """Stands in for Gio.DBusMethodInvocation."""
+
+    def __init__(self):
+        self.done = threading.Event()
+        self.error = None
+        self.payload = None
+
+    def return_value(self, variant):
+        self.payload = variant
+        self.done.set()
+
+    def return_dbus_error(self, name, msg):
+        self.error = (name, msg)
+        self.done.set()
+
+
+loop = GLib.MainLoop()
+svc._main_loop = loop
+beats = []
+
+
+def heartbeat():
+    beats.append(time.monotonic())
+    return True
+
+
+GLib.timeout_add(20, heartbeat)
+inv = FakeInvocation()
+main_thread = threading.current_thread().name
+
+
+def fire():
+    # Exactly how GDBus dispatches an incoming call: on the main loop.
+    handler.handle_method_call(None, None, mod.OBJECT_PATH, mod.INTERFACE_NAME,
+                              "GetAudioInfo", GLib.Variant("()", ()), inv)
+    return False
+
+
+def finish():
+    if inv.done.wait(timeout=5):
+        GLib.idle_add(loop.quit)
+    return False
+
+
+GLib.timeout_add(300, fire)
+threading.Thread(target=finish, daemon=True).start()
+GLib.timeout_add(6000, lambda: (loop.quit(), False)[-1])
+loop.run()
+
+gaps = [round((b - a) * 1000, 1) for a, b in zip(beats, beats[1:])]
+stall = max(gaps) if gaps else 0.0
+answered = inv.done.is_set()
+info = json.loads(inv.payload.unpack()[0]) if answered and inv.error is None else None
+on_main = bool(probe_thread) and probe_thread[0] == main_thread
+
+print(f"probe: {PROBE_SECONDS * 1000:.0f} ms stand-in, ran on "
+      f"{probe_thread[0] if probe_thread else 'NO THREAD'} "
+      f"(main is {main_thread})")
+print(f"main-loop stall: worst heartbeat gap {stall:.1f} ms "
+      f"(median {statistics.median(gaps):.1f} ms over {len(gaps)} beats)")
+print(f"GetAudioInfo answered={answered} error={inv.error} "
+      f"keys={sorted(info) if info else None}")
+
+if not answered or info is None:
+    print("\n!! SETUP FAILURE: GetAudioInfo never returned a payload")
+    sys.exit(2)
+if set(info) != {"device_type", "echo_cancel", "half_duplex", "description"}:
+    print("\n!! SETUP FAILURE: unexpected GetAudioInfo payload shape")
+    sys.exit(2)
+
+# The stall threshold is well under the probe: a 300 ms probe run inline
+# produces a >=300 ms gap, run in the pool it produces ~20 ms beats.
+verdict = stall > 100 or on_main
+print("\nRESULT:", "SLOW (issue #135 reproduced)" if verdict else "FAST")
+sys.exit(1 if verdict else 0)

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -114,7 +114,7 @@ run service-audit  repro_c1_dispatch_gate.py repro_c2_hold.py repro_c3_config.py
                    repro_c4_timer.py repro_c5_ydotoold_unit.py repro_c6_speech_backend.py repro_c7_loop_tap_stops_vad.py \
                    repro_c8_batch_error_toast.py repro_c8_config_watch.py repro_c8_keyless_local.py \
                    smoke_queue_ops.py verify_queue_invariants.py
-run chronicle-perf repro_chronicle_stall.py verify_archive.py \
+run chronicle-perf repro_chronicle_stall.py repro_audio_info_stall.py verify_archive.py \
                    verify_chronicle_contract.py verify_endpoints.py verify_http_envelope.py
 run cancel-tokens  repro_a_outcome_mislabel.py repro_b_transcript_after_stop.py \
                    repro_c_streaming_after_stop.py repro_d_mic_disconnect.py \


### PR DESCRIPTION
Closes #135

GetAudioInfo was the one disk/process-touching D-Bus method still answered inline on the GLib main loop. `get_audio_info()` calls `_refresh_audio_detection()` unconditionally (`wpctl status`, 3 s timeout; `pw-dump` when the sink changed) and `has_echo_cancel()` (`pw-cli list-objects`, 3 s, until cached). extension.js issues it at proxy init and on every bus-name-appeared, i.e. at login and after every service restart -- the window where #50 measured the same probes at 3.9 s while PipeWire was still coming up. For that long no StateChanged/AudioLevel/SubtitleUpdate went out and StartListening/Stop waited behind it.

**Fix:** dispatch through `_run_async(invocation, "(s)", self.service.get_audio_info)` like every sibling method. The refresh is left unconditional: off the main loop it costs nothing the UI can see, and gating it on `_audio_detected` would leave the audio menu at "unknown" until the first utterance. No extension.js change needed.

**Repro:** `tests/repros/chronicle-perf/repro_audio_info_stall.py` -- the chronicle-perf heartbeat instrument with `_refresh_audio_detection` stubbed to sleep 300 ms and `has_echo_cancel` pinned so no `pw-cli` is spawned. Two-sided:

| tree | worst heartbeat gap | probe thread | rc |
|---|---|---|---|
| main `025df92` | 319.1 ms | MainThread | 1 (reproduced) |
| this branch | 20.2 ms | dbus_0 | 0 |

Registered in `run_all.sh`; full gauntlet: 50 checks, all green.

**Hedge, verbatim from the issue:** the inline cost at login is INFERRED from #50's measurement, not re-measured; on warm PipeWire wpctl is ~12 ms and the stall is invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)