### PR TITLE
fix: persist SetLanguage so the next listen does not revert it (#133)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -4315,8 +4315,13 @@ class GnomeSpeaksService:
             done_event.set()
 
     def set_language(self, language):
-        """Change the STT language at runtime."""
-        CONFIG["language"] = language
+        """Change the STT language at runtime.
+
+        Persist it: "language" is in _SYNC_FLAGS, so a bare CONFIG write is
+        overwritten from disk by the next start_listening()'s
+        _reload_config_flags() (#133).
+        """
+        self._save_config_flag("language", language)
         log.info("Language set to: %s", language)
         _invalidate_stt_ws()
         return True


### PR DESCRIPTION
Closes #133

`set_language()` wrote only `CONFIG['language']`; since `language` is in `_SYNC_FLAGS`, the next `start_listening()` → `_reload_config_flags()` overwrote it from disk. Now persisted via `_save_config_flag('language', …)`.

Verification: `tests/repros/run_all.sh` 49/49 green; a scratch check (set_language('fr-FR') → forced `_reload_config_flags()`) reads runtime=fr-FR, disk=fr-FR on this branch, disk=None on main.