### PR TITLE
fix: cap consecutive STT error cycles in continuous dictation (#117)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -138,6 +138,9 @@ INACTIVITY_TIMEOUT_SEC = int(
 )  # 10 minutes default; set to 0 to disable (e.g. when the HTTP API must stay reachable)
 
 MAX_LISTEN_SECONDS = 30
+# Continuous dictation: this many CONSECUTIVE STT error cycles (not silence)
+# stop the loop for the current run, with one toast naming the route (#117).
+LOOP_ERROR_CAP = 3
 
 # ---------------------------------------------------------------------------
 # DBus introspection XML
@@ -1901,6 +1904,12 @@ class GnomeSpeaksService:
         # STT mode selection (auto, streaming, whisper, vad, fixed)
         self._stt_mode = "auto"
 
+        # Loop mode: consecutive batch STT ERROR cycles in this run (#117).
+        # Reset by a fresh (non-quick) start, by any cycle that yields text or
+        # silence, and when the cap fires. The streaming cycle loop keeps its
+        # own counter -- its cycles never leave the worker.
+        self._loop_error_cycles = 0
+
         # Inactivity timer (touched from every worker thread via _set_state)
         self._inactivity_source_id = None
         self._inactivity_lock = threading.Lock()
@@ -2325,6 +2334,9 @@ class GnomeSpeaksService:
 
         if not quick:
             self._reload_config_flags()
+            # A deliberate start is a new run: an error streak from the last
+            # one must not shorten this one (#117).
+            self._loop_error_cycles = 0
             if not self._audio_detected:
                 _refresh_audio_detection()
                 self._audio_detected = True
@@ -2460,9 +2472,7 @@ class GnomeSpeaksService:
             self._deliver_stt_result(result, mode, cancel_token)
         except Exception as exc:
             log.exception("Batch STT (%s) failed: %s", mode, exc)
-            GLib.idle_add(self._emit_error, f"STT failed: {exc}")
-            self._idle_after_stt()
-            _schedule_warmup()
+            self._stt_error_exit(mode, str(exc), cancel_token)
         finally:
             self._cancels.retire(cancel_token)
 
@@ -2488,12 +2498,12 @@ class GnomeSpeaksService:
         error = result.get("error")
         if error:
             log.error("Batch STT (%s) failed: %s", mode, error)
-            GLib.idle_add(self._emit_error, f"STT failed: {error}")
-            GLib.idle_add(self._emit_transcription_ready, "")
-            self._idle_after_stt()
-            _schedule_warmup()
+            self._stt_error_exit(mode, str(error), cancel_token)
             return
 
+        # Text or clean silence: the backend answered, so the error streak
+        # (#117) is over whatever happens next.
+        self._loop_error_cycles = 0
         user_text = result.get("text", "")
 
         self._set_state("processing")
@@ -2536,6 +2546,62 @@ class GnomeSpeaksService:
             GLib.idle_add(self._restart_listening_cb(
                 lambda: (CONFIG.get("continuous_dictation", False)
                          and not self._stop_event.is_set())))
+
+    def _stt_error_exit(self, mode, error, cancel_token):
+        """One batch STT cycle ended in an ERROR -- not silence. The single
+        exit for the worker's exception path and the {"error": ...} result
+        (#130), so the two cannot drift.
+
+        Single-shot: toast at once, as before. Continuous dictation: one
+        error is not the end of the run -- a single Azure hiccup used to kill
+        the loop -- so re-enter listening, but count it, and after
+        LOOP_ERROR_CAP CONSECUTIVE error cycles stop this run with ONE toast
+        that names the speech route (#117). The loop flag is left on: the next
+        tap resumes the loop. Silence never counts.
+
+        The restart is gated like every restart guard: on
+        CONFIG['continuous_dictation'] AND _stop_event, re-checked when the
+        source fires. _stop_event is set by stop_listening() -- the tap that
+        ends a loop run (#110) -- and by stop(); the token is stop()'s verdict
+        and is checked here too, so a session stop() abandoned can never
+        re-open the mic.
+        """
+        GLib.idle_add(self._emit_transcription_ready, "")
+        self._idle_after_stt()
+        _schedule_warmup()
+        looping = (CONFIG.get("continuous_dictation", False)
+                   and not self._stop_event.is_set()
+                   and not cancel_token.cancelled)
+        if not looping:
+            self._loop_error_cycles = 0
+            GLib.idle_add(self._emit_error, f"STT failed: {error}")
+            return
+        self._loop_error_cycles += 1
+        if self._loop_error_cycles >= LOOP_ERROR_CAP:
+            cycles = self._loop_error_cycles
+            self._loop_error_cycles = 0
+            self._report_loop_error_cap(cycles, error)
+            return
+        log.warning("Loop: STT error %d/%d (%s: %s), re-entering listening",
+                    self._loop_error_cycles, LOOP_ERROR_CAP, mode, error)
+        GLib.idle_add(self._restart_listening_cb(
+            lambda: (CONFIG.get("continuous_dictation", False)
+                     and not self._stop_event.is_set())))
+
+    def _report_loop_error_cap(self, cycles, error):
+        """The single place the "loop stopped on errors" verdict reaches the
+        user (#117): ONE toast naming the speech route -- the diagnosis -- and
+        the last failure. Both loop shapes (batch restarts and the streaming
+        cycle loop) report through here so the wording, and the once-ness,
+        cannot drift apart. The loop flag is deliberately not touched: the
+        next tap resumes continuous dictation.
+        """
+        route = _speech_route_words()
+        log.warning("Loop stopped after %d consecutive STT errors (%s): %s",
+                    cycles, route, error)
+        GLib.idle_add(self._emit_error,
+                      f"Continuous dictation paused after {cycles} STT failures "
+                      f"in a row ({route}): {error}")
 
     def _report_recorder_dead(self, cycle):
         """The single place the lost-microphone verdict reaches the user.
@@ -2773,6 +2839,13 @@ class GnomeSpeaksService:
         recorder_dead = threading.Event()
         failed = None
         inj = None           # pinned backend; bound below, released in cleanup
+        # Loop mode: consecutive cycles that ended in a WS ERROR with no text
+        # (#117). Step 9 used to read "no phrases" as "no speech" and re-enter
+        # listening forever when the socket died inside a cycle -- silently,
+        # one reconnect per cycle. `loop_error_stop` is (cycles, last error)
+        # once the cap fires; it is reported after cleanup, once.
+        error_cycles = 0
+        loop_error_stop = None
         try:
             # 2. Get persistent WebSocket (with exponential backoff retry).
             ws = None
@@ -2906,6 +2979,7 @@ class GnomeSpeaksService:
                 end_word_event = threading.Event()
                 sender_done = threading.Event()
                 raw_frames = []
+                cycle_errors = []    # WS send/recv failures this cycle (#117)
                 typed_partial = [""]
                 raw_partial = [""]
                 typer = _LiveTyper(typed_partial, _log, inj) if live_typing else None
@@ -2917,7 +2991,8 @@ class GnomeSpeaksService:
                 def send_audio(_req_id=request_id, _raw_frames=raw_frames,
                                _end_word_event=end_word_event,
                                _sender_done=sender_done,
-                               _rec_dead=recorder_dead):
+                               _rec_dead=recorder_dead,
+                               _cycle_errors=cycle_errors):
                     try:
                         # Calibrate noise threshold (cached — reads only 1 frame after first call)
                         energy_threshold, cal_frames = calibrate_noise(tap)
@@ -2990,6 +3065,7 @@ class GnomeSpeaksService:
                                 ws.send(_make_ws_audio_msg(_req_id, chunk), opcode=websocket.ABNF.OPCODE_BINARY)
                             except Exception as exc:
                                 _log(f"WS send error at frame {total_frames}: {exc}")
+                                _cycle_errors.append(f"WS send error: {exc}")
                                 break
 
                             energy = rms_energy(chunk)
@@ -3036,6 +3112,7 @@ class GnomeSpeaksService:
                         _log(f"REC END: speech={speech_frames} total={total_frames}")
                     except Exception as exc:
                         _log(f"sender exception: {exc}")
+                        _cycle_errors.append(f"sender error: {exc}")
                     finally:
                         # Send end-of-audio marker for this utterance
                         try:
@@ -3072,6 +3149,7 @@ class GnomeSpeaksService:
                                 continue
                         except Exception as exc:
                             _log(f"WS recv error: {exc}")
+                            cycle_errors.append(f"WS recv error: {exc}")
                             break
 
                         mtype = _parse_ws_msg(msg, phrases, partial_holder, end_word_event, end_word, _log,
@@ -3194,6 +3272,7 @@ class GnomeSpeaksService:
                 # In loop mode the cycle continues listening; replies queue until
                 # the mic closes (never TTS over an open mic).
                 if user_text and self._try_cast(user_text):
+                    error_cycles = 0    # recognized text: the backend works (#117)
                     if live_typing and typed_partial[0]:
                         inj.send_backspaces(len(typed_partial[0]))
                     GLib.idle_add(self._emit_transcription_ready, user_text)
@@ -3219,11 +3298,29 @@ class GnomeSpeaksService:
                 # 9. Emit results and type/copy
                 # In loop mode, skip the "processing" flicker if nothing was said —
                 # just silently re-enter listening on the next cycle.
+                # A cycle that produced text, or ended in clean silence, is a
+                # working backend: the error streak (#117) is over.
+                if user_text or not cycle_errors:
+                    error_cycles = 0
                 if (is_loop and not user_text and not _stopping()
                         and not recorder_dead.is_set()):
                     if live_typing and typed_partial[0]:
                         inj.send_backspaces(len(typed_partial[0]))
-                    _log("no speech in loop cycle, continuing")
+                    if cycle_errors:
+                        # Not silence: the socket failed and nothing was
+                        # recognized. Re-enter listening (the next cycle's
+                        # session init reconnects), but only LOOP_ERROR_CAP
+                        # times in a row -- then stop this run, once, with the
+                        # route named (#117). Reported after cleanup.
+                        error_cycles += 1
+                        _log(f"WS error cycle {error_cycles}/{LOOP_ERROR_CAP}: "
+                             f"{cycle_errors[-1]}")
+                        if error_cycles >= LOOP_ERROR_CAP:
+                            loop_error_stop = (error_cycles, cycle_errors[-1])
+                            GLib.idle_add(self._emit_transcription_ready, "")
+                            break
+                    else:
+                        _log("no speech in loop cycle, continuing")
                     # Quiet cycle = natural gap for starved queue items (agent
                     # messages, spell replies) to play before the mic reopens.
                     self._drain_speech_gap()
@@ -3366,6 +3463,12 @@ class GnomeSpeaksService:
             return
 
         self._idle_after_stt()
+
+        # The loop-error cap (#117): once, after idle, gated on the token like
+        # the recorder report above -- a stop() that abandoned this session
+        # owns its own silence.
+        if loop_error_stop is not None and not cancel_token.cancelled:
+            self._report_loop_error_cap(*loop_error_stop)
 
         # If stop_event was set by turn_end (natural_end) in single-shot mode,
         # and continuous dictation is on, restart via start_listening (legacy path

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -65,6 +65,7 @@ tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
 | suite | issue / PR | baseline | expected there |
 |---|---|---|---|
 | `service-audit` | #18–#20, #110, #124 (c8 config-watch), #130 | `7899ccb` | derived (`merge^1`), not re-run; c8 batch-error-toast verified against `025df92` (E1 fails) |
+| `service-audit/repro_c9_loop_error_cap` | #117 | `a20afea` | **verified** — S1 fails (streaming: 98 cycles in 4 s, zero Errors — the silent forever-loop), B1/B2/B3 fail (batch: 1 cycle, toast on the first error, no route words — the issue's "re-enters forever" premise is *false* for batch on the baseline; it stopped, but after one hiccup). Controls B4, B5, S2 green on both sides |
 | `chronicle-perf` | #22 / #27 | `6a1ecae` | derived (`merge^1`), not re-run |
 | `chronicle-perf/repro_audio_info_stall` | #135 | `025df92` | **verified** — 319 ms stall, probe on MainThread |
 | `injector-seam` | #24 | `ea47ff1` | derived (`merge^1`), not re-run |

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -113,6 +113,7 @@ run() {   # run <suite> <script>...
 run service-audit  repro_c1_dispatch_gate.py repro_c2_hold.py repro_c3_config.py \
                    repro_c4_timer.py repro_c5_ydotoold_unit.py repro_c6_speech_backend.py repro_c7_loop_tap_stops_vad.py \
                    repro_c8_batch_error_toast.py repro_c8_config_watch.py repro_c8_keyless_local.py \
+                   repro_c9_loop_error_cap.py \
                    smoke_queue_ops.py verify_queue_invariants.py
 run chronicle-perf repro_chronicle_stall.py repro_audio_info_stall.py verify_archive.py \
                    verify_chronicle_contract.py verify_endpoints.py verify_http_envelope.py

--- a/tests/repros/service-audit/repro_c9_loop_error_cap.py
+++ b/tests/repros/service-audit/repro_c9_loop_error_cap.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""repro: in Continuous Dictation, STT ERRORS stop the loop after a cap; silence
+never does (#117, a #110 follow-up).
+
+Two loop shapes, two different failures on the pre-fix baseline (a20afea):
+
+  streaming  A WebSocket that dies INSIDE a cycle (connect + session init
+             succeed, recv/send raise) produced no phrases, and step 9 read
+             "no phrases" as "no speech in loop cycle, continuing" -- so the
+             cycle loop re-entered listening FOREVER, silently: no toast, no
+             idle, one reconnect per cycle.  This is the loop the issue names.
+  batch      A raising stt_dispatch (or the #130 {"error": ...} dict) toasted
+             on the FIRST error and ended the run -- no retry at all, and the
+             toast never named the speech route.  Not a spin, but one Azure
+             hiccup killed the loop.
+
+After the fix both paths agree: 3 CONSECUTIVE error cycles stop the loop for
+this run, go idle, emit exactly ONE Error signal that names the route
+(_speech_route_words()), and leave CONFIG['continuous_dictation'] on so the
+next tap resumes the loop.  A cycle that produces text -- or clean silence --
+resets the streak.
+
+  B1  batch, stt_dispatch RAISES every cycle          -> 3 cycles, 1 Error
+      (route words + the exception), idle, flag still True
+  B2  batch, stt_dispatch returns {"error": ...}     -> same (the #130 shape)
+  B3  batch, errors are NOT consecutive (e e text e e e) -> the text resets the
+      streak: 6 cycles, 1 Error, and the text was typed
+  B4  control: batch SILENCE ({"text": ""}) never trips the cap -> 0 Errors
+  B5  control: loop OFF, one error -> exactly 1 Error at once (#130 preserved),
+      1 cycle, and it does not carry the loop wording
+  S1  streaming, ws.recv/ws.send raise every cycle   -> 3 cycles, 1 Error
+      (route words), idle, flag still True.  On the baseline this ran ~dozens
+      of cycles in the window with ZERO Errors.
+  S2  control: streaming SILENCE (turn_end, no phrases) for several cycles
+      -> 0 Errors, still listening (repro_i's loop, plus "the cap stays quiet")
+
+The route is PINNED to "azure_down" (wyoming.skip_reason) so the assertion is
+on a literal ("Azure on cooldown after a failure"), not on whatever the
+function under test happens to return.
+
+Run:  GS_SVC_PATH=<gnome-speaks-service.py> python3 repro_c9_loop_error_cap.py
+Exit 0 = all hold; 1 = a verdict failed; 2 = setup failure.
+"""
+import sys
+import time
+
+import harness
+
+FAILS = []
+CAP = 3                 # the contract, not mod.LOOP_ERROR_CAP: a changed cap must fail here
+ROUTE_WORDS = "Azure on cooldown after a failure"     # _SPEECH_ROUTE_WORDS["azure_down"]
+SETTLE = 6.0            # s to wait for a batch run to go quiet
+STREAM_WINDOW = 4.0     # s the streaming session may run before we look
+
+
+def check(label, cond, detail=""):
+    print(f"  {'OK  ' if cond else 'FAIL'} ({label}) {detail}")
+    if not cond:
+        FAILS.append(label)
+
+
+# ---------------------------------------------------------------------------
+# fakes
+# ---------------------------------------------------------------------------
+class _Inj:
+    name = "fake"
+
+    def __init__(self):
+        self.typed = []
+
+    def available(self):
+        return True
+
+    def commit(self, text):
+        self.typed.append(text)
+
+    def paste(self, text):
+        self.typed.append(text)
+
+    def finalize(self, text):
+        self.typed.append(text)
+
+    def type_text(self, text):
+        pass
+
+    def send_backspaces(self, n):
+        pass
+
+    def supports_preedit(self):
+        return False
+
+    def end(self):
+        pass
+
+    def cancel(self):
+        pass
+
+
+class LiveStdout:
+    def read(self, n):
+        time.sleep(0.005)
+        return b"\x00" * n
+
+
+class LiveProc:
+    """A healthy recorder: the dead-recorder verdict must stay out of this."""
+    returncode = None
+
+    def __init__(self):
+        self.stdout = LiveStdout()
+
+    def poll(self):
+        return None
+
+    def terminate(self):
+        pass
+
+    def kill(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 0
+
+
+class DyingWS:
+    """Connect and session init succeed; the socket then dies under us."""
+
+    def settimeout(self, t):
+        pass
+
+    def send(self, payload, opcode=None):
+        raise ConnectionResetError("fake: connection reset by peer")
+
+    def recv(self):
+        time.sleep(0.02)
+        raise ConnectionResetError("fake: connection reset by peer")
+
+
+class SilentWS:
+    """Azure answers every utterance with a bare turn_end: clean silence."""
+
+    def settimeout(self, t):
+        pass
+
+    def send(self, payload, opcode=None):
+        pass
+
+    def recv(self):
+        time.sleep(0.05)
+        return b"turn_end"
+
+
+# ---------------------------------------------------------------------------
+# drivers
+# ---------------------------------------------------------------------------
+def fresh_service(mod, loop_on, stt_mode):
+    svc = harness.make_service(mod)
+    svc._stt_mode = stt_mode
+    svc._reload_config_flags = lambda *a, **k: None   # keep the pins below
+    svc._save_config_flag = lambda *a, **k: None
+    svc._wake_gate_blocks = lambda: False
+    svc._try_cast = lambda text: False
+    svc._drain_speech_gap = lambda *a, **k: None
+    errors = []
+    svc._emit_error = lambda msg: errors.append(msg) or False
+    mod.CONFIG["continuous_dictation"] = loop_on
+    mod.CONFIG["conversation_mode"] = False
+    mod.CONFIG["dictation_mode"] = True
+    return svc, errors
+
+
+def settle(svc, quiet=0.3, timeout=SETTLE):
+    """Wait until the STT thread is gone and state has been idle for `quiet` s."""
+    deadline = time.monotonic() + timeout
+    idle_since = None
+    while time.monotonic() < deadline:
+        t = svc._stt_thread
+        alive = t is not None and t.is_alive()
+        if not alive and svc.current_state == "idle":
+            idle_since = idle_since or time.monotonic()
+            if time.monotonic() - idle_since >= quiet:
+                return True
+        else:
+            idle_since = None
+        time.sleep(0.02)
+    return False
+
+
+def run_batch(mod, script, loop_on=True):
+    """Drive the batch (vad) worker with a scripted stt_dispatch.
+
+    script: list of callables or values; each cycle pops one.  A callable is
+    CALLED (so it may raise); anything else is returned as the result.  When the
+    script runs out the fake returns silence, which ends a batch loop cleanly.
+    Returns (cycles, errors, typed, settled, flag_after).
+    """
+    calls = [0]
+    inj = _Inj()
+    mod.get_injector = lambda: inj
+    mod.HAS_VAD = True
+    mod.GLib.idle_add = lambda fn, *a, **k: fn(*a, **k)    # run restarts inline
+
+    def fake_dispatch(**kw):
+        i = calls[0]
+        calls[0] += 1
+        if i >= len(script):
+            return {"text": ""}
+        step = script[i]
+        return step() if callable(step) else step
+    mod.stt_dispatch = fake_dispatch
+
+    svc, errors = fresh_service(mod, loop_on, "vad")
+    rc = svc.start_listening()
+    if rc != "ok":
+        raise RuntimeError(f"start_listening refused: {rc}")
+    settled = settle(svc)
+    if not settled:
+        svc.stop()
+        time.sleep(0.3)
+    return calls[0], errors, inj.typed, settled, mod.CONFIG.get("continuous_dictation")
+
+
+def run_streaming(mod, ws, window=STREAM_WINDOW):
+    """Drive the streaming cycle with a fake recorder and a fake WebSocket."""
+    cycles = [0]
+    inj = _Inj()
+    mod.get_injector = lambda: inj
+    mod.HAS_WS = True
+    mod.HAS_VAD = False
+    mod.GLib.idle_add = lambda fn, *a, **k: fn(*a, **k)
+    mod._take_prewarmed_rec = lambda *a, **k: LiveProc()
+    mod._get_stt_ws = lambda *a, **k: (ws, True)
+    mod._make_ws_audio_msg = lambda *a, **k: b""
+    mod._rest_stt_fallback = lambda *a, **k: ""
+    mod._invalidate_stt_ws = lambda *a, **k: None
+    mod._parse_ws_msg = lambda msg, *a, **k: "turn_end"
+    mod.wyoming_mod.skip_azure = lambda: False       # streaming stays streaming
+
+    def count_cycle(*a, **k):
+        cycles[0] += 1
+    mod._init_stt_ws_session = count_cycle
+
+    svc, errors = fresh_service(mod, True, "streaming")
+    rc = svc.start_listening()
+    if rc != "ok":
+        raise RuntimeError(f"start_listening refused: {rc}")
+    # Either the cap ends the session (settle returns early) or the window does.
+    settled = settle(svc, quiet=0.3, timeout=window)
+    state_seen = svc.current_state
+    if not settled:
+        svc.stop()
+        time.sleep(0.3)
+    return cycles[0], errors, settled, state_seen, mod.CONFIG.get("continuous_dictation")
+
+
+def is_cap_toast(msg):
+    return ROUTE_WORDS in msg
+
+
+def main():
+    try:
+        mod, _events = harness.load()
+    except Exception as exc:
+        print(f"!! SETUP FAILURE: cannot load service: {exc}")
+        return 2
+    print(f"service under test: {harness.SVC_PATH}")
+    # Pin the route so the toast assertion is on a literal.
+    mod.wyoming_mod.skip_reason = lambda: "azure_down"
+    if mod._speech_route_words() != ROUTE_WORDS:
+        print(f"!! SETUP FAILURE: route pin did not take: {mod._speech_route_words()!r}")
+        return 2
+
+    def boom():
+        raise RuntimeError("fake: Azure STT unreachable; offline fallback failed")
+
+    # --- B1: batch, raising every cycle ------------------------------------
+    cycles, errors, typed, settled, flag = run_batch(mod, [boom] * 12)
+    caps = [e for e in errors if is_cap_toast(e)]
+    check("B1", settled and cycles == CAP and len(errors) == 1 and len(caps) == 1
+          and "fake: Azure STT unreachable" in errors[0] and flag is True and typed == [],
+          f"cycles={cycles} errors={errors!r} settled={settled} flag={flag}")
+
+    # --- B2: batch, the #130 error dict every cycle -----------------------
+    err = {"error": "Azure STT unreachable (ConnectionError); offline fallback failed"}
+    cycles, errors, typed, settled, flag = run_batch(mod, [err] * 12)
+    caps = [e for e in errors if is_cap_toast(e)]
+    check("B2", settled and cycles == CAP and len(errors) == 1 and len(caps) == 1
+          and "ConnectionError" in errors[0] and flag is True and typed == [],
+          f"cycles={cycles} errors={errors!r} settled={settled} flag={flag}")
+
+    # --- B3: consecutive means consecutive ---------------------------------
+    script = [boom, boom, {"text": "hello there"}, boom, boom, boom, boom, boom]
+    cycles, errors, typed, settled, flag = run_batch(mod, script)
+    check("B3", settled and cycles == 6 and len(errors) == 1 and is_cap_toast(errors[0])
+          and typed == ["hello there"] and flag is True,
+          f"cycles={cycles} errors={len(errors)} typed={typed!r} settled={settled}")
+
+    # --- B4: control -- silence never trips the cap -------------------------
+    cycles, errors, typed, settled, flag = run_batch(mod, [{"text": ""}] * 6)
+    check("B4", settled and errors == [] and flag is True and typed == [],
+          f"cycles={cycles} errors={errors!r} settled={settled} flag={flag}")
+
+    # --- B5: control -- loop OFF keeps the #130 immediate toast -------------
+    cycles, errors, typed, settled, flag = run_batch(mod, [boom] * 3, loop_on=False)
+    check("B5", settled and cycles == 1 and len(errors) == 1
+          and "fake: Azure STT unreachable" in errors[0] and not is_cap_toast(errors[0]),
+          f"cycles={cycles} errors={errors!r}")
+
+    # --- S1: streaming, the socket dies inside every cycle ------------------
+    cycles, errors, settled, state_seen, flag = run_streaming(mod, DyingWS())
+    caps = [e for e in errors if is_cap_toast(e)]
+    check("S1", settled and cycles == CAP and len(errors) == 1 and len(caps) == 1
+          and "connection reset" in errors[0] and state_seen == "idle" and flag is True,
+          f"cycles={cycles} errors={errors!r} settled={settled} state={state_seen} flag={flag}")
+
+    # --- S2: control -- streaming silence keeps looping, no toast -----------
+    cycles, errors, settled, state_seen, flag = run_streaming(mod, SilentWS(), window=2.0)
+    check("S2", not settled and cycles >= 3 and errors == [] and state_seen == "listening",
+          f"cycles={cycles} errors={errors!r} state={state_seen}")
+
+    if FAILS:
+        print(f"FAIL: {len(FAILS)} verdict(s) -- loop-mode STT errors are not capped at "
+              f"{CAP} consecutive cycles with one route-naming toast: {FAILS}")
+        return 1
+    print(f"PASS: {CAP} consecutive STT error cycles stop the loop with one route-naming "
+          "toast; text and silence reset it; the loop flag survives")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #117.

## What was actually happening on `main` (measured on a20afea)

The issue says an STT error in Continuous Dictation "re-enters listening each cycle". That is true for one loop shape and false for the other:

- **Streaming cycle loop — reproduced.** A WebSocket that dies *inside* a cycle (connect and `_init_stt_ws_session` succeed, then `recv`/`send` raise) yields no phrases, and step 9 read "no phrases" as *"no speech in loop cycle, continuing"*. The next cycle's session init reconnects and it repeats. **Measured: 98 cycles in 4 s, zero Error signals, state still `listening`.** Silent, one reconnect per cycle, forever. The existing "STT session init failed" toast only fires when the *reconnect* fails, so an Azure that accepts the socket and then drops the session never toasts at all.
- **Batch worker — did not loop.** A raising `stt_dispatch`, or the #130 `{"error": …}` dict, toasted `STT failed: …` on the **first** error and idled with no restart (the restart at the bottom of `_deliver_stt_result` is gated on `user_text`). So one Azure hiccup *ended* the loop instead of spinning it, and the toast never named the route.

## Fix

Both paths now agree: **3 consecutive error cycles** (`LOOP_ERROR_CAP`) stop the loop for this run, go idle, and emit **one** Error toast naming the speech route via `_speech_route_words()`:

> Continuous dictation paused after 3 STT failures in a row (Azure on cooldown after a failure): WS recv error: …

`continuous_dictation` is left on, so the next tap resumes the loop. Silence never counts (a batch cycle of silence still ends the loop as before; a streaming cycle of silence still just keeps listening), and any cycle that yields text — including a spell cast — resets the streak.

- **Batch:** `_stt_error_exit()` is the single exit for the worker's exception and the `{"error"}` dict. Single-shot keeps the immediate #130 toast. In loop mode it counts, idles, and re-enters via `_restart_listening_cb` with the standard guard (`continuous_dictation` and not `_stop_event`, re-checked when the source fires), also refusing when the session token was cancelled — a `stop()` can never re-open the mic. Counter resets on any text/silence delivery and on a non-quick `start_listening()` (a deliberate new run).
- **Streaming:** a per-cycle `cycle_errors` list is appended at the three WS failure sites (sender send error, sender exception, receiver recv error). Step 9 counts a cycle only if it ended with no text *and* an error; at the cap it emits `TranscriptionReady("")` and breaks. The toast fires once after cleanup + `_idle_after_stt()`, gated on the cancel token exactly like the dead-recorder report.
- `_report_loop_error_cap()` is the one place the wording lives, so the two shapes cannot drift.

Deliberately untouched: the reconnect-failure "STT session init failed" toast (already terminal and single; `dead-recorder/repro_g` covers it) and `_offline_stt_session` (delivers `{"text"}`, never an error dict).

## Repro — `tests/repros/service-audit/repro_c9_loop_error_cap.py` (registered in `run_all.sh`)

Route pinned to `azure_down` so the assertion is on the literal *"Azure on cooldown after a failure"*, not on the function under test.

| case | a20afea (unfixed) | this branch |
|---|---|---|
| B1 batch raises every cycle → 3 cycles, 1 route toast, idle, flag on | FAIL — 1 cycle, `STT failed:` toast | OK |
| B2 batch `{"error"}` every cycle | FAIL — same | OK |
| B3 `e e text e e e` → text resets the streak: 6 cycles, 1 toast, text typed | FAIL — 1 cycle | OK |
| B4 control: batch silence never trips the cap | OK | OK |
| B5 control: loop OFF → immediate #130 toast, 1 cycle | OK | OK |
| S1 streaming recv/send raise → 3 cycles, 1 toast, idle | **FAIL — 98 cycles, 0 Errors, still listening** | OK |
| S2 control: streaming silence keeps looping, 0 Errors | OK | OK |

## Gates

- `tests/repros/run_all.sh` (bare, this worktree, rebased on 5635100): **66 checks: 66 pass, 0 fail — ALL SUITES GREEN** (main's 65 + c9). The final rebase onto 2ccd171 (#153) is docs-only; `gnome-speaks-service.py` and `tests/` are byte-identical between the two heads.
- Baseline runner on a20afea before any edit: 62 checks, 61 pass — the one red was `offline-handoff case D` (`gaps=[(40,42)]`), which passes 2/2 when re-run alone; a timing flake under load (the runner header documents the suites as timing-sensitive), not a main regression.
- `python3 verify_wake_gate.py`: all checks passed · py_compile clean · leak scan with the team's private-name pattern on the diff and the new file: 0 (planted control 1).

## Out of scope, flagged

Batch loop mode also ends on **silence** (`if user_text and continuous_dictation` → restart). With `speech_backend=local` the streaming path is routed to vad, i.e. onto this path, so that configuration's loop ends at the first `NO_SPEECH_TIMEOUT`, whereas the streaming loop waits 60 s and continues. Not #117; not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
