### PR TITLE
feat(install): warn about systemd drop-ins that override the unit (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ cd gnome-speaks
 The installer will:
 1. Copy extension files to `~/.local/share/gnome-shell/extensions/gnome-speaks@jphein/`
 2. Compile GSettings schemas
-3. Install and start the systemd user service
+3. Install and start the systemd user service — and **warn** about any drop-in
+   (`~/.config/systemd/user/gnome-speaks.service.d/*.conf`) that silently overrides it
 4. Register the D-Bus service for auto-activation (plus the inert [Spiel provider](#spiel-provider) name)
 5. Install missing Python dependencies
 6. Enable the extension
@@ -424,6 +425,30 @@ journalctl --user -u gnome-speaks -f
 
 # Restart after config changes
 systemctl --user restart gnome-speaks
+```
+
+### Troubleshooting
+
+**Stuck offline, ignoring your Azure key, or a setting that will not stick? Check for a
+systemd drop-in.** systemd merges every `~/.config/systemd/user/gnome-speaks.service.d/*.conf`
+into the unit on every start, silently, and the file survives `./install.sh`,
+`./install.sh --uninstall` and `git pull`. A leftover `offline.conf` carrying
+`Environment=SPEECH_FORCE_OFFLINE=1` forced the service offline — with **no** Azure fallback,
+because that variable is a test override, not a setting — for weeks before anyone looked
+(#103). `./install.sh` now lists every such drop-in and its `Environment=` lines with a
+`[WARN]`, and `./install.sh --check-dropins` runs only that check (exit 1 if any exist).
+
+```bash
+# What systemd actually runs: the unit, then every drop-in merged into it
+systemctl --user cat gnome-speaks
+
+# Which speech route the service took at start. "forced offline: SPEECH_FORCE_OFFLINE
+# is set, no Azure fallback" means the environment did this, not the network.
+journalctl --user -u gnome-speaks -b | grep 'Speech route at start'
+
+# Remove an unwanted drop-in and re-read the unit
+rm ~/.config/systemd/user/gnome-speaks.service.d/offline.conf
+systemctl --user daemon-reload && systemctl --user restart gnome-speaks
 ```
 
 ## HTTP API

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,69 @@ warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
 error()   { echo -e "${RED}[ERR]${NC}   $*"; }
 step()    { echo -e "${CYAN}${BOLD}==>${NC} ${BOLD}$*${NC}"; }
 
+usage() {
+    cat <<USAGE
+Usage: $0 [--uninstall|-u] [--check-dropins] [--help|-h]
+
+  (no flag)        install the extension, the systemd user service, D-Bus
+                   activation files and Python deps
+  -u, --uninstall  remove all of the above (drop-ins are listed, not deleted)
+  --check-dropins  only list systemd drop-ins that override $SYSTEMD_SERVICE
+                   and print their Environment= lines; exit 1 if any exist
+  -h, --help       this text
+
+A drop-in is any *.conf under $SYSTEMD_USER_DIR/$SYSTEMD_SERVICE.d/ (or the
+/etc and ~/.local/share equivalents). systemd merges it into the unit on every
+start and it survives install, uninstall and git pull -- a forgotten
+offline.conf carrying Environment=SPEECH_FORCE_OFFLINE=1 forced the service
+offline, with NO Azure fallback, for weeks (#103, #115). The service logs the
+route it took at start: journalctl --user -u $SYSTEMD_SERVICE -b | grep 'Speech route'
+USAGE
+}
+
+# ---- Drop-in audit -------------------------------------------
+# systemd's user lookup path for <unit>.d/*.conf, the dirs a human plausibly
+# writes (systemd.unit(5)). Every *.conf is merged into the unit; anything not
+# ending in .conf (offline.conf.disabled, a .bak) is ignored by systemd and so
+# by this check -- the two must agree, or the WARN lies in one direction.
+dropin_dirs() {
+    echo "$SYSTEMD_USER_DIR/$SYSTEMD_SERVICE.d"
+    echo "$HOME/.local/share/systemd/user/$SYSTEMD_SERVICE.d"
+    echo "/etc/systemd/user/$SYSTEMD_SERVICE.d"
+}
+
+# Lists every drop-in and its Environment= lines with a WARN.
+# Returns 0 when there are none, 1 when at least one exists. Never exits.
+check_dropins() {
+    local found=0 d f envs
+    while IFS= read -r d; do
+        [[ -d "$d" ]] || continue
+        for f in "$d"/*.conf; do
+            [[ -f "$f" ]] || continue
+            found=1
+            warn "Drop-in overrides $SYSTEMD_SERVICE: $f"
+            # `|| true`: grep exits 1 on zero matches, and under -e/pipefail
+            # a drop-in with no Environment= line would abort the installer.
+            mapfile -t envs < <(grep -nE '^[[:space:]]*Environment=' "$f" || true)
+            if [[ ${#envs[@]} -eq 0 ]]; then
+                warn "    (no Environment= lines; see the file for what it overrides)"
+            else
+                local e
+                for e in "${envs[@]}"; do warn "    $e"; done
+            fi
+        done
+    done < <(dropin_dirs)
+    if [[ $found -eq 1 ]]; then
+        warn "Drop-ins are merged into the unit on EVERY start and survive install,"
+        warn "uninstall and git pull. Environment=SPEECH_FORCE_OFFLINE=1 there forces"
+        warn "offline with NO Azure fallback (#103). If that is not what you want:"
+        warn "    rm <file> && systemctl --user daemon-reload && systemctl --user restart $SYSTEMD_SERVICE"
+        warn "Inspect the merged unit with: systemctl --user cat $SYSTEMD_SERVICE"
+        return 1
+    fi
+    return 0
+}
+
 # ============================================================
 # UNINSTALL
 # ============================================================
@@ -57,6 +120,10 @@ do_uninstall() {
     else
         warn "Systemd service file not found — nothing to remove."
     fi
+
+    # Drop-ins are user-authored, so they are listed and left in place; they
+    # will apply again to the next install (#115).
+    check_dropins || warn "Drop-ins above were NOT removed."
 
     # Reload systemd daemon
     info "Reloading systemd user daemon..."
@@ -101,9 +168,18 @@ do_uninstall() {
 # ============================================================
 # Parse flags
 # ============================================================
-if [[ "${1:-}" == "--uninstall" || "${1:-}" == "-u" ]]; then
-    do_uninstall
-fi
+case "${1:-}" in
+    --uninstall|-u) do_uninstall ;;
+    --check-dropins)
+        if check_dropins; then
+            success "No systemd drop-in overrides $SYSTEMD_SERVICE."
+            exit 0
+        fi
+        exit 1 ;;
+    --help|-h) usage; exit 0 ;;
+    "") ;;
+    *) error "Unknown option: $1"; echo; usage; exit 2 ;;
+esac
 
 # ============================================================
 # INSTALL
@@ -184,6 +260,10 @@ else
     error "Cannot install systemd service."
     exit 1
 fi
+
+# Drop-ins override what was just written and this is the only moment a
+# reader is looking at the unit (#115). `|| true`: a WARN, not a failure.
+check_dropins && success "No systemd drop-in overrides the unit." || true
 
 # Reload systemd daemon to pick up the new service
 info "Reloading systemd user daemon..."

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -102,10 +102,15 @@ tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
 | `shell-rig` | #113 | `3c70314` | **verified** — t0 fails 8 checks: state `idle`, no service row; every later step green on both sides |
 | `config-keys` | #120 #127 | `025df92` | **verified** — B fails: 8 keys against speech-to-cli before its #21 (`language`, `voice_commands` + 6 shell-only `show_*`), 6 after; D fails: the same 6 `show_*` (no Python reader); A, C pass |
 | `deprecations` | #114 | `a20afea` | **verified** — 3 deprecation lines at service start (`GLib.unix_signal_add` ×2, `Gio.DBusConnection.register_object` ×1 — PyGObject warns once per deprecated GI function per process, so two register sites make one line); `GetState` and the Spiel `Name` property answer on both sides. Runs the real `main()` on a private `dbus-run-session` bus the suite re-execs itself under; `register_object` also leaked ~1.5 kB per D-Bus method call (measured; flat through `register_object_with_closures2`) |
+| `install-dropins` | #115 / #103 | `a20afea` | **not re-run, by design** — that `install.sh` ignores unknown flags and would perform a full install (and restart the live service) when handed `--check-dropins`; the suite refuses any installer without the flag (SETUP FAILURE 2, verified against `a20afea`), so discrimination is by construction |
 
-`leak-scan` (`tests/leak-scan.sh`, bash) is the odd one out: it scans this
-repo's **tracked tree**, not `GS_SVC_PATH`, so pointing the runner at an
-extracted SHA does not re-scan that SHA — run the script from a checkout of it.
+Two suites are bash and ignore `GS_SVC_PATH`, so pointing the runner at an
+extracted SHA does not re-test that SHA — run them from a checkout of it:
+`leak-scan` (`tests/leak-scan.sh`) scans this repo's **tracked tree**, and
+`install-dropins` (`tests/repros/install-dropins/verify_dropin_warning.sh`)
+drives this repo's `install.sh --check-dropins` against a scratch `$HOME` under
+`tmp/repros/` — the developer's real `~/.config` is never read, and only the
+check flag is invoked, so nothing is installed and no `systemctl` runs.
 
 `config-keys` is the one suite whose verdict also depends on a **sibling repo**:
 it parses `state.py` from `SPEECH_ENGINE_PATH` (default `~/Projects/speech-to-cli`),

--- a/tests/repros/install-dropins/verify_dropin_warning.sh
+++ b/tests/repros/install-dropins/verify_dropin_warning.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# install.sh --check-dropins (#115): a forgotten
+# ~/.config/systemd/user/gnome-speaks.service.d/offline.conf carrying
+# Environment=SPEECH_FORCE_OFFLINE=1 forced the service offline for weeks
+# (#103) and nothing in the install flow said so. The installer now lists every
+# such drop-in with a WARN. This is its control, in both directions:
+#
+#   A  positive control  a planted offline.conf -> WARN names the file AND each
+#                        Environment= line, rc=1. Proves the instrument sees
+#                        BEFORE any zero below is believed.
+#   B  no Environment=   a drop-in with only RestartSec= is still listed
+#   C  .conf.disabled    NOT listed, rc=0 -- systemd ignores it, so must we
+#   D  silence           no drop-in dir at all -> zero WARN lines, rc=0
+#
+# Everything runs against a SCRATCH $HOME under this repo's gitignored
+# tmp/repros/, created by this process and deleted on exit. The developer's
+# real ~/.config is never read or written -- install.sh derives every path
+# from $HOME. Only `--check-dropins` is invoked: nothing is installed,
+# no systemctl call is made.
+#
+# Exit contract, shared with tests/repros/run_all.sh:
+#   0 clean · 1 the defect is present · 2 SETUP FAILURE
+set -u
+set -o pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# tests/repros/<suite>/ -> repo root is THREE levels up (the #59 trap: ../.. is tests/).
+REPO="$(cd "$HERE/../../.." && pwd)"
+INSTALL="${GS_INSTALL_SH:-$REPO/install.sh}"
+[ -f "$INSTALL" ] || { echo "!! SETUP FAILURE: no $INSTALL"; exit 2; }
+# NEVER hand an installer that does not know the flag: the pre-#115 install.sh
+# ignores unknown arguments and performs a FULL INSTALL -- including
+# `systemctl --user restart` of the LIVE service, which $HOME does not scope.
+# So this suite cannot be re-run against its baseline; discrimination is by
+# construction (the flag did not exist), and this guard is what makes that
+# safe rather than merely true today.
+grep -qF -- '--check-dropins)' "$INSTALL" || {
+    echo "!! SETUP FAILURE: $INSTALL has no --check-dropins mode; refusing to run it (it would install)"
+    exit 2
+}
+
+# /etc is outside $HOME and outside our control: a real drop-in there would make
+# case D fail for a reason that is not a defect. Refuse to measure rather than
+# report a bogus red (or, worse, weaken D to tolerate it).
+if compgen -G "/etc/systemd/user/gnome-speaks.service.d/*.conf" >/dev/null; then
+    echo "!! SETUP FAILURE: a system-wide drop-in exists in /etc/systemd/user/gnome-speaks.service.d/"
+    exit 2
+fi
+
+mkdir -p "$REPO/tmp/repros" 2>/dev/null
+SCRATCH=$(mktemp -d "$REPO/tmp/repros/dropins-$$-XXXX" 2>/dev/null) \
+    || { echo "!! SETUP FAILURE: cannot create scratch under $REPO/tmp/repros"; exit 2; }
+trap 'rm -rf "$SCRATCH"' EXIT INT TERM
+FAKE_HOME="$SCRATCH/home"
+DROPIN_DIR="$FAKE_HOME/.config/systemd/user/gnome-speaks.service.d"
+mkdir -p "$FAKE_HOME"
+
+rc=0
+pass() { echo "[PASS] $*"; }
+fail() { echo "[FAIL] $*"; rc=1; }
+run_check() {   # sets OUT and ST; strips ANSI colour so patterns are literal
+    OUT=$(HOME="$FAKE_HOME" "$INSTALL" --check-dropins 2>&1 | sed 's/\x1b\[[0-9;]*m//g')
+    ST=${PIPESTATUS[0]}
+}
+warn_count() { printf '%s\n' "$OUT" | grep -cF '[WARN]' || true; }
+
+# ---- A: positive control ------------------------------------------------
+mkdir -p "$DROPIN_DIR"
+cat > "$DROPIN_DIR/offline.conf" <<'CONF'
+[Service]
+# forgotten test override
+Environment=SPEECH_FORCE_OFFLINE=1
+  Environment=GS_PLANTED_SECOND=yes
+CONF
+run_check
+if [ "$ST" -eq 1 ] \
+   && printf '%s\n' "$OUT" | grep -qF '[WARN]' \
+   && printf '%s\n' "$OUT" | grep -qF "$DROPIN_DIR/offline.conf" \
+   && printf '%s\n' "$OUT" | grep -qF 'Environment=SPEECH_FORCE_OFFLINE=1' \
+   && printf '%s\n' "$OUT" | grep -qF 'Environment=GS_PLANTED_SECOND=yes' \
+   && ! printf '%s\n' "$OUT" | grep -qF 'forgotten test override'; then
+    pass "A planted offline.conf -> rc=1, WARN names file + both Environment= lines, comment not echoed"
+else
+    fail "A planted offline.conf -> rc=$ST ($(warn_count) WARN lines)"
+    printf '%s\n' "$OUT" | sed 's/^/      /'
+fi
+
+# ---- B: a drop-in with no Environment= is still a drop-in ---------------
+rm -f "$DROPIN_DIR/offline.conf"
+printf '[Service]\nRestartSec=5\n' > "$DROPIN_DIR/restart.conf"
+run_check
+if [ "$ST" -eq 1 ] \
+   && printf '%s\n' "$OUT" | grep -qF "$DROPIN_DIR/restart.conf" \
+   && printf '%s\n' "$OUT" | grep -qF 'no Environment= lines'; then
+    pass "B restart.conf (no Environment=) -> rc=1, listed with the no-Environment note"
+else
+    fail "B restart.conf (no Environment=) -> rc=$ST"
+    printf '%s\n' "$OUT" | sed 's/^/      /'
+fi
+
+# ---- C: systemd reads *.conf only; so must the check ---------------------
+rm -f "$DROPIN_DIR/restart.conf"
+printf '[Service]\nEnvironment=SPEECH_FORCE_OFFLINE=1\n' > "$DROPIN_DIR/offline.conf.disabled"
+run_check
+if [ "$ST" -eq 0 ] && [ "$(warn_count)" -eq 0 ]; then
+    pass "C offline.conf.disabled -> rc=0, zero WARN (agrees with systemd)"
+else
+    fail "C offline.conf.disabled -> rc=$ST ($(warn_count) WARN lines)"
+    printf '%s\n' "$OUT" | sed 's/^/      /'
+fi
+
+# ---- D: silence when there is nothing to say -----------------------------
+rm -rf "$FAKE_HOME/.config"
+run_check
+if [ "$ST" -eq 0 ] && [ "$(warn_count)" -eq 0 ] \
+   && printf '%s\n' "$OUT" | grep -qF '[OK]'; then
+    pass "D no drop-in dir -> rc=0, zero WARN, one [OK] line"
+else
+    fail "D no drop-in dir -> rc=$ST ($(warn_count) WARN lines)"
+    printf '%s\n' "$OUT" | sed 's/^/      /'
+fi
+
+# ---- containment: nothing outside the scratch dir was created ------------
+[ -d "$FAKE_HOME" ] && [ "${FAKE_HOME#"$REPO/tmp/repros/"}" != "$FAKE_HOME" ] \
+    && pass "scratch HOME lives under tmp/repros/ and is removed on exit" \
+    || fail "scratch HOME escaped tmp/repros/: $FAKE_HOME"
+
+if [ $rc -eq 0 ]; then echo "ALL GREEN"; else echo "FAILURES: see [FAIL] lines above"; fi
+exit $rc

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -153,6 +153,13 @@ run deprecations   repro_114_startup_deprecations.py
 out=$(timeout 60 "$REPO/tests/leak-scan.sh" 2>&1); st=$?
 line leak-scan "leak-scan.sh (tracked tree)" "$st" "$out"
 
+# install-dropins (#115) is bash too and tests install.sh, not the service:
+# `--check-dropins` against a SCRATCH $HOME under tmp/repros/ -- planted
+# offline.conf must WARN (positive control first), .conf.disabled and an
+# empty home must not. Nothing is installed and no systemctl call is made.
+out=$(timeout 60 "$HERE/install-dropins/verify_dropin_warning.sh" 2>&1); st=$?
+line install-dropins "verify_dropin_warning.sh" "$st" "$out"
+
 # ---------------------------------------------------------------------------
 # offline-handoff: ONE PROCESS PER CASE, on purpose.
 #


### PR DESCRIPTION
Closes #115

## Why

A forgotten `~/.config/systemd/user/gnome-speaks.service.d/offline.conf` carrying `Environment=SPEECH_FORCE_OFFLINE=1` forced the service offline — with **no** Azure fallback, because that variable is a test override, not a setting — for weeks (#103). `systemctl status` shows a `Drop-In:` line only if you know to look, and nothing in the install flow said anything.

## What

**install.sh**
- `check_dropins()`: lists every `*.conf` under the unit's `.d/` in `~/.config`, `~/.local/share` and `/etc` with a `[WARN]`, plus each `Environment=` line (or a "no Environment= lines" note). Non-`.conf` files are ignored, as systemd ignores them, so the check cannot disagree with what actually runs.
- Runs right after the unit is rendered (the one moment a reader is looking at it) and on `--uninstall`, where the files are **listed, not deleted** — they are user-authored and will apply again to the next install.
- `--check-dropins` runs only the audit (exit 1 if any exist); `--help` documents it; an **unknown flag is now an error (exit 2)** instead of a silent full install.
- `grep … || true` inside the `mapfile` — under `set -euo pipefail` a drop-in with zero `Environment=` lines would otherwise abort the installer (covered by control B).

**README** — new *Troubleshooting* subsection under *Service management*: `systemctl --user cat`, the `Speech route at start` log line (`forced offline: SPEECH_FORCE_OFFLINE is set, no Azure fallback` = the environment did this, not the network), and how to remove a drop-in. Installer step list mentions the warning.

**Control** — `tests/repros/install-dropins/verify_dropin_warning.sh`, wired into `run_all.sh` (74 → 75 checks on top of origin/main 5dde4b4). Scratch `$HOME` under `tmp/repros/`, created by the process and removed on exit; the developer's real `~/.config` is never read; only `--check-dropins` is invoked, so nothing is installed and no `systemctl` runs.

```
[PASS] A planted offline.conf -> rc=1, WARN names file + both Environment= lines, comment not echoed
[PASS] B restart.conf (no Environment=) -> rc=1, listed with the no-Environment note
[PASS] C offline.conf.disabled -> rc=0, zero WARN (agrees with systemd)
[PASS] D no drop-in dir -> rc=0, zero WARN, one [OK] line
[PASS] scratch HOME lives under tmp/repros/ and is removed on exit
```

⚠️ **Baseline deliberately NOT re-run.** The pre-#115 `install.sh` ignores unknown arguments, so handing it `--check-dropins` would perform a full install — including `systemctl --user restart` of the *live* service, which `$HOME` does not scope. The suite greps for the flag and refuses (SETUP FAILURE 2; verified against an `a20afea` copy via `GS_INSTALL_SH`). Discrimination is by construction and the README table says so.

## Gates

- `bash -n` on `install.sh`, `run_all.sh`, `verify_dropin_warning.sh`: clean
- `tests/repros/run_all.sh` bare: `75 checks: 75 pass, 0 fail` · `ALL SUITES GREEN` on head edae589, rebased on origin/main 5dde4b4 (74 there: this PR adds exactly one)
- leak scan on diff + new files: 0 hits; `tests/leak-scan.sh`: PASS
- Real-HOME negative (read-only): `[OK] No systemd drop-in overrides gnome-speaks.service.` rc=0

No service change; nothing to restart. Extension untouched.

