### PR TITLE
fix(service): drop the startup deprecation lines — and the D-Bus invocation leak behind one of them (#114)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,13 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
   unguarded `inj.name` in the swap's *log line* raised AttributeError out of the whole STT cycle
   -- nothing recognized, nothing typed, on the ordinary healthy-Azure path.
 
+- **`connection.register_object` leaks, `GLib.unix_signal_add` warns -- use the shims (#114)**: Python's
+  `register_object` shadows `g_dbus_connection_register_object_with_closures`, which GLib 2.84 deprecated
+  because the closure is handed an owned `GDBusMethodInvocation` nothing releases -- measured ~1.5 kB per D-Bus
+  method call on PyGObject 3.56 / GLib 2.88, flat through `register_object_with_closures2`. Go through
+  `_register_dbus_object()` and `_unix_signal_add` (GLibUnix when present, old API on GNOME 46-48 hosts); a
+  bare call reintroduces both the leak and the startup deprecation lines, and `tests/repros/deprecations`
+  goes red -- it runs the real `main()` on a private bus and counts warnings attributed to the service file.
 - **ydotool stuck keys**: If a ydotool command is interrupted between key-down and key-up, the virtual device retains that key as pressed. The service auto-restarts `ydotoold` to recover. Scripts: `fix-ydotool.sh`, `install-ydotool.sh`.
 - **pw-record ignores SIGTERM**: Must use SIGKILL (`proc.kill()`) to stop PipeWire recorder processes.
 - **Half-duplex drain**: On speakers, 0.5s delay after TTS before opening mic to prevent echo pickup.

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -56,6 +56,45 @@ gi.require_version("Gio", "2.0")
 gi.require_version("GLib", "2.0")
 from gi.repository import Gio, GLib
 
+# Deprecation-free platform bindings (#114). Every start used to log three
+# deprecation lines, and the noise hid real warnings in the first ten journal
+# lines. Both replacements fall back on hosts that predate them -- the
+# extension supports GNOME 46-50, i.e. GLib 2.80-2.88.
+#
+# * GLib 2.80 split the Unix-only API into GLibUnix, and PyGObject 3.56 warns
+#   on every ACCESS of GLib.unix_signal_add (twice: SIGTERM and SIGINT).
+#   GLibUnix.signal_add has the same shape: (priority, signum, handler,
+#   user_data) -> source id; measured delivering a real signal with its
+#   user_data on GLib 2.88.
+# * GLib 2.84 deprecated g_dbus_connection_register_object_with_closures --
+#   the C function Python's DBusConnection.register_object shadows -- for
+#   register_object_with_closures2, and not cosmetically: the old closure
+#   was handed an owned GDBusMethodInvocation that nothing released.
+#   MEASURED on PyGObject 3.56.2 / GLib 2.88: ~1.5 kB leaked per D-Bus method
+#   call through register_object (3012/2916/2796 kB per 2000 calls), flat
+#   (0 kB) through register_object_with_closures2, identical dispatch of
+#   method calls, property Get and error returns. So every GetState and hotkey
+#   grew the service; the closures2 path is a fix, not a rename.
+try:
+    gi.require_version("GLibUnix", "2.0")
+    from gi.repository import GLibUnix as _GLibUnix
+    _unix_signal_add = getattr(_GLibUnix, "signal_add", None)
+except (ValueError, ImportError):
+    _unix_signal_add = None
+if _unix_signal_add is None:
+    # Old host: the attribute access below is exactly what warns on new ones,
+    # so it is taken only where there is nothing to warn about.
+    _unix_signal_add = GLib.unix_signal_add
+
+
+def _register_dbus_object(connection, object_path, interface_info,
+                          method_call, get_property, set_property):
+    """connection.register_object(...) without the deprecated (leaking) path."""
+    register = getattr(Gio.DBusConnection, "register_object_with_closures2",
+                       None) or Gio.DBusConnection.register_object
+    return register(connection, object_path, interface_info,
+                    method_call, get_property, set_property)
+
 # ---------------------------------------------------------------------------
 # Import speech modules from speech-to-cli
 # ---------------------------------------------------------------------------
@@ -5768,8 +5807,8 @@ def _spiel_get_property(connection, sender, object_path, interface_name,
 
 def _on_spiel_bus_acquired(connection, name):
     node = Gio.DBusNodeInfo.new_for_xml(SPIEL_INTERFACE_XML)
-    connection.register_object(
-        SPIEL_OBJECT_PATH,
+    _register_dbus_object(
+        connection, SPIEL_OBJECT_PATH,
         node.lookup_interface("org.freedesktop.Speech.Provider"),
         _spiel_method_call, _spiel_get_property, None)
     log.info("Spiel provider registered as %s", name)
@@ -5782,7 +5821,8 @@ def on_bus_acquired(connection, name, service, handler):
     node_info = Gio.DBusNodeInfo.new_for_xml(INTROSPECTION_XML)
     interface_info = node_info.lookup_interface(INTERFACE_NAME)
 
-    connection.register_object(
+    _register_dbus_object(
+        connection,
         OBJECT_PATH,
         interface_info,
         handler.handle_method_call,
@@ -5963,8 +6003,8 @@ def main():
         loop.quit()
         return GLib.SOURCE_REMOVE
 
-    GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGTERM, _on_signal, signal.SIGTERM)
-    GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGINT, _on_signal, signal.SIGINT)
+    _unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGTERM, _on_signal, signal.SIGTERM)
+    _unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGINT, _on_signal, signal.SIGINT)
 
     try:
         loop.run()

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -82,6 +82,7 @@ tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
 | `spellbook` | #119 | `025df92` | **verified** — 8 fail: `cast stop`, `cast halt`, every punctuated trigger (`Cast, stop.`, `Cast - skip`, `Invoke... skip`, …); the denylist, overlay and op-table checks stay green on both sides |
 | `leak-scan` | #126 | `025df92` | **verified** — 4 hits (tracked unit ×2, two plans) |
 | `config-keys` | #120 #127 | `025df92` | **verified** — B fails: 8 keys against speech-to-cli before its #21 (`language`, `voice_commands` + 6 shell-only `show_*`), 6 after; D fails: the same 6 `show_*` (no Python reader); A, C pass |
+| `deprecations` | #114 | `a20afea` | **verified** — 3 deprecation lines at service start (`GLib.unix_signal_add` ×2, `Gio.DBusConnection.register_object` ×1 — PyGObject warns once per deprecated GI function per process, so two register sites make one line); `GetState` and the Spiel `Name` property answer on both sides. Runs the real `main()` on a private `dbus-run-session` bus the suite re-execs itself under; `register_object` also leaked ~1.5 kB per D-Bus method call (measured; flat through `register_object_with_closures2`) |
 
 `leak-scan` (`tests/leak-scan.sh`, bash) is the odd one out: it scans this
 repo's **tracked tree**, not `GS_SVC_PATH`, so pointing the runner at an

--- a/tests/repros/deprecations/repro_114_startup_deprecations.py
+++ b/tests/repros/deprecations/repro_114_startup_deprecations.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Startup deprecation warnings (#114) -- and the leak behind one of them.
+
+Every service start logged three deprecation lines: `GLib.unix_signal_add is
+deprecated; use GLibUnix.signal_add` twice (SIGTERM, SIGINT) and
+`Gio.DBusConnection.register_object is deprecated` once -- PyGObject warns once
+per deprecated GI function per PROCESS (measured: three registrations, one
+line), so the second register site never showed.  The noise hid real warnings in the first
+ten journal lines -- and the D-Bus one was not cosmetic.  Python's
+`register_object` shadows `g_dbus_connection_register_object_with_closures`,
+which GLib 2.84 deprecated for `_with_closures2` because the old closure was
+handed an OWNED GDBusMethodInvocation that nothing released.  MEASURED on
+PyGObject 3.56.2 / GLib 2.88: ~1.5 kB leaked per method call through
+`register_object` (3012/2916/2796 kB per 2000 calls), flat through
+`register_object_with_closures2`; refcount at handler entry 4 vs 3.  Every
+GetState and every hotkey grew the service.
+
+This runs the REAL `main()` -- not the two lines in isolation -- because the
+fix is a pair of shims and a shim that is defined but not wired is exactly the
+regression a call-site check cannot see:
+
+  1. re-exec under a private `dbus-run-session`, so owning `org.gnome.Speaks`
+     touches nothing on the desktop and needs no live service to be absent;
+  2. import the service through the service-audit harness (isolated CONFIG,
+     per-PID scratch, no mic / WS / injector), pin `spiel_provider` on so BOTH
+     register sites run, HTTP on an ephemeral port;
+  3. a verifier thread waits for the bus names, calls `GetState` and reads the
+     Spiel `Name` property over the bus -- the registered closures must
+     dispatch and return through whichever API was picked -- then sends
+     SIGTERM to this process;
+  4. `main()` must RETURN: only the signal source installed by the code under
+     test can turn that SIGTERM into `loop.quit()`.  If the shim is broken the
+     default disposition kills the process (rc 143) or the watchdog exits 1.
+
+Warnings are recorded with `warnings.catch_warnings(record=True)` under
+`simplefilter("always")` and counted only when they are attributed to the
+service file itself, so PyGObject's own import-time `unix_signal_add_full`
+chatter (fires under -W always, never in the journal) cannot pad the number.
+
+CONTROL: before `main()` the instrument is proven live -- touching the
+deprecated `GLib.unix_signal_add` attribute (or, if a future PyGObject has
+removed it, registering a throwaway object with `register_object`) must record
+a deprecation.  If neither deprecated API exists any more the check is
+vacuous and exits 2, not 0.
+
+Baseline: a20afea (main before #114) -> 3 deprecation lines, exit 1.
+Fixed   : 0 lines, GetState answered, Spiel Name == "GNOME Speaks", exit 0.
+
+exit 0 = clean, 1 = the defect is present, 2 = setup failure.
+"""
+import os
+import shutil
+import sys
+
+# --- 1. private bus, BEFORE any harness import (the harness creates scratch at
+# import and would leak it across an exec) --------------------------------------
+if os.environ.get("GS_REPRO_PRIVATE_BUS") != "1":
+    runner = shutil.which("dbus-run-session")
+    if not runner:
+        print("!! SETUP FAILURE: dbus-run-session not installed")
+        sys.exit(2)
+    env = dict(os.environ, GS_REPRO_PRIVATE_BUS="1")
+    os.execve(runner, [runner, "--", sys.executable, os.path.abspath(__file__)] + sys.argv[1:], env)
+
+import json          # noqa: E402
+import signal        # noqa: E402
+import threading     # noqa: E402
+import time          # noqa: E402
+import warnings      # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(HERE), "service-audit"))
+import harness  # noqa: E402
+
+# main() runs restore_prior_engine() and the ydotool/IBus injector prepare()
+# first thing; neither is under test and both reach for the real desktop.
+os.environ["XDG_RUNTIME_DIR"] = os.path.join(harness.SCRATCH, "runtime")
+os.makedirs(os.environ["XDG_RUNTIME_DIR"], exist_ok=True)
+os.environ["GNOME_SPEAKS_HTTP_PORT"] = "0"     # ephemeral, never 7710
+
+import gi  # noqa: E402
+gi.require_version("Gio", "2.0")
+gi.require_version("GLib", "2.0")
+from gi.repository import Gio, GLib  # noqa: E402
+
+SVC = os.path.realpath(harness.SVC_PATH)
+SPIEL_IFACE = "org.freedesktop.Speech.Provider"
+
+
+def fail(msg):
+    print(f"[FAIL] {msg}")
+    sys.exit(1)
+
+
+def setup_failure(msg):
+    print(f"!! SETUP FAILURE: {msg}")
+    sys.exit(2)
+
+
+# --- 2. the service, isolated ----------------------------------------------------
+mod, _events = harness.load()
+
+
+class _NullInjector:
+    name = "null"
+
+    def prepare(self): pass
+    def recover(self): pass
+    def end(self): pass
+    def cancel(self): pass
+
+
+def _no_network():
+    raise RuntimeError("no network from a repro")
+
+
+mod.restore_prior_engine = lambda reason="startup": False
+mod.get_injector = lambda: _NullInjector()
+mod.HAS_WS = False
+mod.state.get_http_session = _no_network
+for name in ("has_echo_cancel",):
+    if hasattr(mod, name):
+        setattr(mod, name, lambda *a, **k: False)
+for name in ("_invalidate_stt_ws", "_discard_prewarmed_rec"):
+    if hasattr(mod, name):
+        setattr(mod, name, lambda *a, **k: None)
+
+# Both register sites: pin the Spiel provider on, in CONFIG and in the scratch
+# config file so a mid-run _reload_config_flags() cannot undo it.
+mod.CONFIG["spiel_provider"] = True
+with open(mod.CONFIG_PATH, encoding="utf-8") as f:
+    _cfg = json.load(f)
+_cfg["spiel_provider"] = True
+with open(mod.CONFIG_PATH, "w", encoding="utf-8") as f:
+    json.dump(_cfg, f)
+harness.assert_isolated(mod)
+
+
+def _deprecations(records):
+    return [w for w in records
+            if issubclass(w.category, DeprecationWarning)
+            and os.path.realpath(w.filename) == SVC]
+
+
+# --- CONTROL: the instrument must see a deprecation before we trust its zero ---
+with warnings.catch_warnings(record=True) as ctl:
+    warnings.simplefilter("always")
+    control_api = None
+    if hasattr(GLib, "unix_signal_add"):
+        getattr(GLib, "unix_signal_add")          # attribute ACCESS is what warns
+        control_api = "GLib.unix_signal_add"
+    elif hasattr(Gio.DBusConnection, "register_object"):
+        _c = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        _iface = Gio.DBusNodeInfo.new_for_xml(
+            '<node><interface name="repro.Control"><method name="M"/></interface></node>'
+        ).lookup_interface("repro.Control")
+        _c.register_object("/repro/control", _iface, lambda *a: None, None, None)
+        control_api = "Gio.DBusConnection.register_object"
+n_ctl = sum(1 for w in ctl if issubclass(w.category, DeprecationWarning))
+if control_api is None:
+    setup_failure("neither deprecated API exists on this PyGObject; nothing to discriminate")
+if n_ctl == 0:
+    setup_failure(f"control {control_api} recorded 0 deprecations -- instrument is blind")
+print(f"control: {control_api} -> {n_ctl} deprecation(s) recorded (instrument live)")
+
+# --- 3. verifier: over the bus, then SIGTERM ---------------------------------------
+result = {"GetState": None, "SpielName": None, "error": None, "main_returned": False}
+main_done = threading.Event()
+
+
+def _name_has_owner(conn, name):
+    r = conn.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
+                       "org.freedesktop.DBus", "NameHasOwner",
+                       GLib.Variant("(s)", (name,)), None, 0, 2000, None)
+    return r.unpack()[0]
+
+
+def verifier():
+    try:
+        conn = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        deadline = time.monotonic() + 15.0
+        while time.monotonic() < deadline:
+            if _name_has_owner(conn, mod.BUS_NAME) and _name_has_owner(conn, mod.SPIEL_BUS_NAME):
+                break
+            time.sleep(0.05)
+        else:
+            result["error"] = "bus names never appeared"
+            os.kill(os.getpid(), signal.SIGTERM)
+            return
+        r = conn.call_sync(mod.BUS_NAME, mod.OBJECT_PATH, mod.INTERFACE_NAME,
+                           "GetState", None, None, 0, 5000, None)
+        result["GetState"] = r.unpack()[0]
+        r = conn.call_sync(mod.SPIEL_BUS_NAME, mod.SPIEL_OBJECT_PATH,
+                           "org.freedesktop.DBus.Properties", "Get",
+                           GLib.Variant("(ss)", (SPIEL_IFACE, "Name")), None, 0, 5000, None)
+        result["SpielName"] = r.unpack()[0]
+    except Exception as exc:  # noqa: BLE001
+        result["error"] = repr(exc)
+    finally:
+        # 4. Only the source installed by the code under test can turn this into
+        # loop.quit(). Watchdog: if main() has not returned, the handler is gone.
+        os.kill(os.getpid(), signal.SIGTERM)
+        if not main_done.wait(10.0):
+            print("[FAIL] SIGTERM did not bring main() back within 10 s -- the signal "
+                  "source under test is not installed")
+            sys.stdout.flush()
+            os._exit(1)
+
+
+threading.Thread(target=verifier, name="verifier", daemon=True).start()
+
+sys.argv = [SVC]
+with warnings.catch_warnings(record=True) as rec:
+    warnings.simplefilter("always")
+    mod.main()
+result["main_returned"] = True
+main_done.set()
+
+deps = _deprecations(rec)
+print(f"deprecation lines attributed to the service during main(): {len(deps)}")
+for w in deps:
+    print(f"    {os.path.basename(w.filename)}:{w.lineno}: {w.category.__name__}: {w.message}")
+print(f"GetState -> {result['GetState']!r}; Spiel Name -> {result['SpielName']!r}; "
+      f"error={result['error']}")
+
+if result["error"]:
+    fail(f"bus round-trip failed: {result['error']}")
+if not isinstance(result["GetState"], str):
+    fail(f"GetState did not answer a string: {result['GetState']!r}")
+if result["SpielName"] != "GNOME Speaks":
+    fail(f"Spiel Name property wrong: {result['SpielName']!r}")
+if deps:
+    fail(f"{len(deps)} deprecation line(s) at service start (expected 0)")
+print("[PASS] service start: 0 deprecation lines; both D-Bus objects answer; "
+      "SIGTERM handled through the installed signal source")

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -135,6 +135,12 @@ run spellbook      verify_spellbook.py
 # _SYNC_FLAGS vs service CONFIG reads. Reads state.py from SPEECH_ENGINE_PATH
 # (~/Projects/speech-to-cli), so a sibling-repo whitelist gap is red HERE.
 run config-keys    verify_config_key_contract.py
+# deprecations (#114): runs the REAL main() on a private dbus-run-session bus
+# (the suite re-execs itself under one), so it needs no live service to be
+# absent and touches nothing on the desktop. Owns org.gnome.Speaks there,
+# round-trips GetState and the Spiel Name property, then SIGTERMs itself
+# through the signal source under test.
+run deprecations   repro_114_startup_deprecations.py
 
 # leak-scan is bash and scans the TRACKED TREE of this repo, not GS_SVC_PATH:
 # the repo is public and the maintainer's home path, LAN names and the HA


### PR DESCRIPTION
Closes #114

## Root cause (measured, PyGObject 3.56.2 / GLib 2.88 / Python 3.14)

Every service start logged three deprecation lines, hiding real warnings in the first ten journal lines (this boot, 12 starts: 2× `unix_signal_add` + 1× `register_object` per start, read from the journal).

1. **`GLib.unix_signal_add` ×2** — PyGObject's GLib override marks every `GLib.unix_*` wrapper with `deprecated_attr`, which warns on each attribute *access*; two call sites (SIGTERM, SIGINT), two lines. `GLibUnix.signal_add(priority, signum, handler, user_data) -> int` has the same shape — measured delivering a real signal with its `user_data`.
2. **`Gio.DBusConnection.register_object` ×1** — a GI-level `DeprecationWarning`. Python's `register_object` shadows `g_dbus_connection_register_object_with_closures`, which GLib 2.84 deprecated for `register_object_with_closures2` because the old closure is handed an **owned `GDBusMethodInvocation` that nothing releases**.

   **This one was not cosmetic.** Fresh process per API on a private bus, RSS after warm-up then +2000 calls ×3:

   | API | Δ RSS per 2000 calls | refcount at handler entry |
   |---|---|---|
   | `register_object` | +3012 / +2916 / +2796 kB (~1.5 kB/call) | 4 |
   | `register_object_with_closures2` | +176 / +64 / **+0** kB | 3 |

   Identical dispatch of method calls, `Properties.Get` and `return_dbus_error` (6006/6006). Every `GetState` and every hotkey grew the service.

## Fix — the smallest behaviour-preserving change, and why not `filterwarnings`

Two shims near the gi imports, both falling back for GNOME 46–48 hosts (GLib 2.80–2.82):

- `_unix_signal_add` = `GLibUnix.signal_add` when `gi.require_version("GLibUnix", "2.0")` succeeds, else `GLib.unix_signal_add` (the fallback's attribute access is the very thing that warns, so it is only taken where there is nothing to warn about).
- `_register_dbus_object(...)` = `register_object_with_closures2` when the binding has it, else `register_object`. Both call sites (`org.gnome.Speaks`, Spiel provider) go through it.

Silencing the `register_object` line with a scoped `warnings.filterwarnings` was weighed and rejected: it would have kept a real per-call leak.

## Verification

- `tests/repros/run_all.sh` bare in the worktree: **66 checks: 66 pass, 0 fail — ALL SUITES GREEN** (main: 65).
- `python3 verify_wake_gate.py`: all checks passed.
- **New suite `tests/repros/deprecations/repro_114_startup_deprecations.py`** — runs the **real `main()`** (a shim defined but not wired is exactly what a call-site check cannot see) under a private `dbus-run-session` the suite re-execs itself into, with the service-audit harness isolation (no mic / WS / injector / live config; HTTP on an ephemeral port), `spiel_provider` pinned on so both register sites run. A verifier thread waits for both bus names, calls `GetState` and reads the Spiel `Name` property over the bus, then SIGTERMs the process — `main()` must return through the signal source under test. Warnings are recorded under `simplefilter("always")` and counted only when attributed to the service file; a **control** proves the instrument records a deprecation before its zero is believed.
  - baseline `a20afea`: **3** deprecation lines → exit 1 (`GetState`/Spiel `Name` green there too)
  - this branch: **0** lines → exit 0, `GetState` → `'idle'`, Spiel `Name` → `'GNOME Speaks'`, SIGTERM handled
  - Measured on the way: PyGObject warns **once per deprecated GI function per process**, so two register sites make one line (noted in the README row).
- Leak scan (the repo's `tests/leak-scan.sh` pattern) on the diff vs `origin/main` and the new file: 0 (control: 1).
- Out of scope, documented in the suite: `GLib.unix_signal_add_full is deprecated` at gi import is PyGObject-internal, fires only under `-W always`, never in the journal.

Service not restarted (lead does it after merge). Extension untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
