### PR TITLE
fix: pin the user spellbook overlay out of the repro harnesses (#152)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Two-process design connected by session D-Bus (`org.gnome.Speaks`):
 | `injector.py` | imported by the service | The `Injector` seam: the contract both injection backends implement | ~120 |
 | `ibus_injector.py` | imported by the service | `IbusInjector` — text injection as an IBus engine (D-Bus commits, preedit, crash recovery) | ~660 |
 | `spellbook.py` | imported by the service | Incantation matcher + executor ("cast …" → local actions); denylist | ~390 |
-| `spellbook.json` | data | 15 repo spells (self-control); user overlay at `~/.config/speech-to-cli/spellbook.json` merges + hot-reloads | — |
+| `spellbook.json` | data | 15 repo spells (self-control); user overlay at `~/.config/speech-to-cli/spellbook.json` (seam: `spellbook.USER_SPELLBOOK_PATH` / env `GS_SPELLBOOK_USER_PATH`) merges + hot-reloads | — |
 | `spiel_provider.py` | imported by the service | Spiel/libspiel synthesis side (`org.gnome.Speaks.Speech.Provider`); off unless `spiel_provider` | ~120 |
 | `prefs.js` | GNOME Extensions app (GJS/Gtk4) | 6-page preferences window (task-first redesign, #5e49049) | ~1,540 |
 | `stylesheet.css` | GNOME Shell | Badge states, pills, animations, subtitle overlay, chronicle scroll | ~560 |
@@ -292,6 +292,13 @@ before changing one:
   exactly like a service regression and nearly got a good commit reverted.
   Scratch is per-PID, and reset/cleanup only ever touch a directory the running
   process created.
+- **Never JP's live spellbook overlay** (#152). The service merges
+  `~/.config/speech-to-cli/spellbook.json` over the repo spells at construction,
+  so a harness-built service carried the personal spells (24 loaded, 15 repo).
+  The overlay path is a seam — `spellbook.USER_SPELLBOOK_PATH`, env
+  `GS_SPELLBOOK_USER_PATH` — never a literal in the service; `isolation.py`
+  pins it to an empty scratch overlay and every `make_service()` asserts the
+  loaded count equals the repo `spellbook.json`.
 - **Never JP's live config.** `state.load_config()` reads
   `~/.config/speech-to-cli/config.json` at import, and `_reload_config_flags()`
   re-reads it *mid-run* for every `_SYNC_FLAGS` key -- so pinning a key after

--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -1974,11 +1974,13 @@ class GnomeSpeaksService:
                          name="tts-queue-dispatcher").start()
 
         # Voice spellbook (incantation layer) — "cast …" routes here instead
-        # of typing/LLM. Repo default + user overlay, mtime hot-reload.
+        # of typing/LLM. Repo default + user overlay, mtime hot-reload. The
+        # overlay path is spellbook's seam, never a literal here (#152): the
+        # repro harnesses pin it into scratch before constructing a service.
         self._spellbook_paths = (
             os.path.join(os.path.dirname(os.path.abspath(__file__)),
                          "spellbook.json"),
-            os.path.expanduser("~/.config/speech-to-cli/spellbook.json"),
+            spellbook.USER_SPELLBOOK_PATH,
         )
         self._spellbook = spellbook.load_spellbook(*self._spellbook_paths)
         self._spellbook_mtimes = self._spellbook_stat()

--- a/spellbook.py
+++ b/spellbook.py
@@ -4,7 +4,8 @@
 
 Utterances beginning with a trigger word ("cast …") route here instead of
 typing or the LLM. Spells are data (spellbook.json in the repo, with a user
-overlay at ~/.config/speech-to-cli/spellbook.json); this module matches and
+overlay at ~/.config/speech-to-cli/spellbook.json, see USER_SPELLBOOK_PATH
+below); this module matches and
 executes them through callbacks injected by the service, so it has no GLib
 or audio dependencies of its own and can be sanity-tested standalone.
 """
@@ -19,6 +20,20 @@ import urllib.error
 import urllib.request
 
 log = logging.getLogger("gnome-speaks")
+
+# The user overlay path is a SEAM, not a literal (#152). The service reads
+# USER_SPELLBOOK_PATH when it builds its spellbook, so a test harness can pin
+# it into a scratch dir and a verdict can never depend on the personal spells
+# in ~/.config -- which carry the wake phrase and LAN names, and which a
+# spell-routing repro could otherwise match by accident. Override for a whole
+# process with the env var GS_SPELLBOOK_USER_PATH (read ONCE, at import; set it
+# to the empty string for "no overlay at all"), or assign the attribute before
+# the service is constructed.
+DEFAULT_USER_SPELLBOOK_PATH = os.path.expanduser(
+    "~/.config/speech-to-cli/spellbook.json")
+USER_SPELLBOOK_PATH = (os.environ["GS_SPELLBOOK_USER_PATH"]
+                       if "GS_SPELLBOOK_USER_PATH" in os.environ
+                       else DEFAULT_USER_SPELLBOOK_PATH)
 
 # Actions that must never be voice-castable, no matter what the config says.
 # Matched (case-insensitive) against the JSON-serialized action; an entry

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -48,7 +48,22 @@ Two rules the suites enforce on themselves, both learned the hard way on
   defaults plus an explicit `CONFIG_PINS` dict and repoints `CONFIG_PATH` at a
   scratch file — so the live file can be neither read nor written — then
   `assert_isolated(mod)`, which **raises** unless `CHRONICLE_PATH`,
-  `CONFIG_PATH` and `XDG_STATE_HOME` all resolve inside the scratch dir.
+  `CONFIG_PATH`, `XDG_STATE_HOME` and `spellbook.USER_SPELLBOOK_PATH` all
+  resolve inside the scratch dir.
+* **No live spellbook overlay** (#152). The service merges
+  `~/.config/speech-to-cli/spellbook.json` over the repo spells, so every
+  harness-built service used to carry the developer's *personal* spells
+  (measured: `Spellbook loaded: 24 spells` = 15 repo + 9 overlay) — read-only,
+  but a spell-routing repro could match a personal incantation, and those
+  spells carry the wake phrase and LAN names. `isolate_config()` now pins
+  `spellbook.USER_SPELLBOOK_PATH` (the seam the service reads at construction;
+  env `GS_SPELLBOOK_USER_PATH` sets it for a whole process) to an **empty**
+  overlay in scratch, `assert_isolated()` asserts it, and every
+  `make_service()` calls `isolation.assert_repo_spellbook()`, which counts
+  what the instance actually loaded against the repo `spellbook.json`. The
+  pin must land **before** `GnomeSpeaksService()` — the instance loads its
+  book in `__init__`. A service whose `spellbook.py` has no seam is refused
+  (setup failure), the same way an unset `CHRONICLE_PATH` is.
 
 ## Baselines are pinned SHAs, never branch names
 
@@ -79,7 +94,7 @@ tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
 | `pin-lifecycle` | #46 ×#57 | `15dd402` | compound X: X1 FAIL, X2 PASS, X3 FAIL |
 | `version-cache` | #53 / #85 | two-sided, below | `577a05f` passes, `7eaeb02` fails |
 | `prefs-rig` | #82 | merge base of the branch | more warnings than baseline = fail |
-| `spellbook` | #119 | `025df92` | **verified** — 8 fail: `cast stop`, `cast halt`, every punctuated trigger (`Cast, stop.`, `Cast - skip`, `Invoke... skip`, …); the denylist, overlay and op-table checks stay green on both sides |
+| `spellbook` | #119, #152 | `025df92` / `a20afea` | **verified** — 8 fail on `025df92`: `cast stop`, `cast halt`, every punctuated trigger (`Cast, stop.`, `Cast - skip`, `Invoke... skip`, …); the denylist, overlay and op-table checks stay green on both sides. The #152 seam checks (`USER_SPELLBOOK_PATH` honours `GS_SPELLBOOK_USER_PATH`; the service reads the seam, not a literal) are red on `a20afea` |
 | `leak-scan` | #126 | `025df92` | **verified** — 4 hits (tracked unit ×2, two plans) |
 | `config-keys` | #120 #127 | `025df92` | **verified** — B fails: 8 keys against speech-to-cli before its #21 (`language`, `voice_commands` + 6 shell-only `show_*`), 6 after; D fails: the same 6 `show_*` (no Python reader); A, C pass |
 
@@ -190,7 +205,9 @@ form has its own short-form failure. If you do add `-e`, write every count as
   **passes**. It is the instrument, not a convenience.
 * **`assert_isolated()`** — the harness version proves the *paths* are
   redirected; `subtitle_spy.assert_isolated()` delegates to it and adds the
-  other half, that the CONFIG *pins actually took*. A path can be redirected
+  other half, that the CONFIG *pins actually took*. `assert_repo_spellbook()`
+  is the same second half for the spellbook overlay: the path pin alone cannot
+  see a pin applied *after* construction, only the loaded count can (#152). A path can be redirected
   correctly while a pin is silently missing, and `terminal_mode` really is
   `True` on the developer desktop. Keep both halves if these are ever folded
   together.

--- a/tests/repros/cancel-tokens/harness.py
+++ b/tests/repros/cancel-tokens/harness.py
@@ -253,6 +253,9 @@ def load(fake_tts_seconds=1.0):
 
 def make_service(mod):
     svc = mod.GnomeSpeaksService()
+    # #152: the overlay pin is a path; prove it TOOK by counting what this
+    # instance actually loaded against the repo spellbook.json.
+    isolation.assert_repo_spellbook(svc, SVC_PATH)
     svc._audio_detected = True
     svc.play_sound = lambda *a, **k: True
     return svc

--- a/tests/repros/chronicle-perf/harness.py
+++ b/tests/repros/chronicle-perf/harness.py
@@ -156,6 +156,9 @@ def load(fake_tts_seconds=1.0):
 
 def make_service(mod):
     svc = mod.GnomeSpeaksService()
+    # #152: the overlay pin is a path; prove it TOOK by counting what this
+    # instance actually loaded against the repo spellbook.json.
+    isolation.assert_repo_spellbook(svc, SVC_PATH)
     svc._audio_detected = True
     svc.play_sound = lambda *a, **k: True
     return svc

--- a/tests/repros/dead-recorder/harness.py
+++ b/tests/repros/dead-recorder/harness.py
@@ -254,6 +254,9 @@ def load(fake_tts_seconds=1.0):
 
 def make_service(mod):
     svc = mod.GnomeSpeaksService()
+    # #152: the overlay pin is a path; prove it TOOK by counting what this
+    # instance actually loaded against the repo spellbook.json.
+    isolation.assert_repo_spellbook(svc, SVC_PATH)
     svc._audio_detected = True
     svc.play_sound = lambda *a, **k: True
     return svc

--- a/tests/repros/isolation.py
+++ b/tests/repros/isolation.py
@@ -8,7 +8,8 @@ isolation contract had to be made five times, and copies drift.
 
 Two external inputs used to decide these repros' verdicts, and both produced
 results that read as product regressions. Everything here exists for one of
-them.
+them -- plus a third found later (#152), the user spellbook overlay, see
+SPELLBOOK_OVERLAY below.
 
 1. JP's LIVE ~/.config/speech-to-cli/config.json. state.load_config() reads it
    at import, so CONFIG started as ~47 live desktop keys. Worse,
@@ -63,6 +64,17 @@ CONFIG_PINS = {
 }
 
 REAL_STATE = os.path.join(os.path.expanduser("~/.local/state"), "gnome-speaks")
+
+# The user spellbook overlay (#152). A third external input the original
+# contract missed: the service merged ~/.config/speech-to-cli/spellbook.json
+# over the repo spells, so every harness-built service carried the developer's
+# PERSONAL spells (MEASURED: "Spellbook loaded: 24 spells" = 15 repo + 9
+# overlay). Read-only, but a spell-routing repro could match a personal
+# incantation, and those spells carry the wake phrase and LAN names. The
+# overlay is now pinned to an EMPTY file in scratch -- a real file, not a
+# missing one, so the "user" merge branch still runs and stat()s cleanly.
+SPELLBOOK_OVERLAY = "spellbook-user.json"
+REAL_SPELLBOOK_OVERLAY = os.path.expanduser("~/.config/speech-to-cli/spellbook.json")
 
 
 def setup_scratch(prefix, scratch_root):
@@ -147,7 +159,56 @@ def isolate_config(mod, scratch, pins=None):
     mod.CONFIG_PATH = path
     mod.CONFIG.clear()
     mod.CONFIG.update(baseline)
+    isolate_spellbook(mod, scratch)
     return baseline
+
+
+def isolate_spellbook(mod, scratch):
+    """Pin the user spellbook overlay to an empty file inside `scratch`.
+
+    Goes through `spellbook.USER_SPELLBOOK_PATH`, the seam the service reads
+    when it constructs its spellbook -- so this must run BEFORE
+    `GnomeSpeaksService()`; a pin applied afterwards changes nothing the
+    instance already loaded. Raises on a service whose spellbook has no seam:
+    that tree cannot be isolated, and a run that cannot be isolated must not
+    report a verdict (the same rule assert_isolated applies to an unset path).
+    """
+    sb = getattr(mod, "spellbook", None)
+    if sb is None or not hasattr(sb, "USER_SPELLBOOK_PATH"):
+        raise AssertionError(
+            "service has no spellbook.USER_SPELLBOOK_PATH seam (#152) -- "
+            "cannot pin the user overlay, refusing to run")
+    overlay = os.path.join(scratch, SPELLBOOK_OVERLAY)
+    with open(overlay, "w", encoding="utf-8") as f:
+        json.dump({"spells": []}, f)
+    sb.USER_SPELLBOOK_PATH = overlay
+    return overlay
+
+
+def repo_spell_count(svc_path):
+    """How many spells the repo spellbook.json NEXT TO the service ships."""
+    book = os.path.join(os.path.dirname(os.path.abspath(svc_path)),
+                        "spellbook.json")
+    with open(book, encoding="utf-8") as f:
+        return len(json.load(f)["spells"])
+
+
+def assert_repo_spellbook(svc, svc_path):
+    """Prove a built service loaded EXACTLY the repo spells and nothing else.
+
+    The pin above redirects the path; this checks the pin TOOK, by counting
+    what the instance actually holds against the repo file. Both halves are
+    needed (the same shape as assert_isolated vs subtitle_spy's pin check):
+    a redirected path with a stale or wrong count is still a leak. Fewer than
+    the repo count means a repo spell failed validation, which is also wrong.
+    """
+    want = repo_spell_count(svc_path)
+    got = len(getattr(svc, "_spellbook", {}).get("spells", {}))
+    if got != want:
+        raise AssertionError(
+            f"service loaded {got} spells but the repo ships {want} -- "
+            f"a spellbook overlay leaked into the harness (#152)")
+    return got
 
 
 def assert_isolated(mod, scratch):
@@ -161,6 +222,8 @@ def assert_isolated(mod, scratch):
         "CHRONICLE_PATH": getattr(mod, "CHRONICLE_PATH", None),
         "CONFIG_PATH": getattr(mod, "CONFIG_PATH", None),
         "XDG_STATE_HOME": os.environ.get("XDG_STATE_HOME"),
+        "spellbook.USER_SPELLBOOK_PATH": getattr(
+            getattr(mod, "spellbook", None), "USER_SPELLBOOK_PATH", None),
     }
     for name, value in checks.items():
         if value is None:
@@ -172,6 +235,8 @@ def assert_isolated(mod, scratch):
                 f"{scratch!r} -- refusing to run")
         if os.path.realpath(REAL_STATE) in (real, os.path.dirname(real)):
             raise AssertionError(f"{name} points at the live state dir")
+        if real == os.path.realpath(REAL_SPELLBOOK_OVERLAY):
+            raise AssertionError(f"{name} points at the live spellbook overlay")
     return True
 
 

--- a/tests/repros/service-audit/harness.py
+++ b/tests/repros/service-audit/harness.py
@@ -154,6 +154,9 @@ def load(fake_tts_seconds=1.0):
 
 def make_service(mod):
     svc = mod.GnomeSpeaksService()
+    # #152: the overlay pin is a path; prove it TOOK by counting what this
+    # instance actually loaded against the repo spellbook.json.
+    isolation.assert_repo_spellbook(svc, SVC_PATH)
     svc._audio_detected = True
     svc.play_sound = lambda *a, **k: True
     return svc

--- a/tests/repros/spellbook/verify_spellbook.py
+++ b/tests/repros/spellbook/verify_spellbook.py
@@ -18,6 +18,10 @@ Contract under test (#119):
   4. Op table: every dbus_self.op in spellbook.json has an `op == "<op>"`
      branch in the service's _spell_ctx_dbus -- a typo'd op today is a
      silent FIZZLE_TEXT at runtime, and nothing else checks the join.
+  5. USER_SPELLBOOK_PATH seam (#152): the overlay path defaults to the
+     ~/.config location, honours GS_SPELLBOOK_USER_PATH verbatim (empty =
+     no overlay), and the SERVICE reads the seam rather than a literal --
+     that is what lets tests/repros/isolation.py pin it into scratch.
 
 Imports spellbook.py from the tree under test, NOT the service: the service
 pulls in speech-to-cli and JP's live config at import, and nothing here needs
@@ -226,9 +230,42 @@ def main():
               BOOK_PATH, os.path.join(_SCRATCH, "nope.json"))["spells"])
           == sorted(repo_names))
 
-    print("-- op table: spellbook.json <-> _spell_ctx_dbus")
+    print("-- USER_SPELLBOOK_PATH seam (#152; red on a20afea)")
+    # The overlay path must be a seam the harnesses can pin, not a literal.
+    # Each variant re-execs the module: the env var is read ONCE, at import.
+    saved = os.environ.pop("GS_SPELLBOOK_USER_PATH", None)
+    try:
+        fresh = load_module()
+        check("default overlay path is ~/.config/speech-to-cli/spellbook.json",
+              getattr(fresh, "USER_SPELLBOOK_PATH", None)
+              == os.path.expanduser("~/.config/speech-to-cli/spellbook.json"),
+              repr(getattr(fresh, "USER_SPELLBOOK_PATH", None)))
+        pinned = os.path.join(_SCRATCH, "pinned-overlay.json")
+        os.environ["GS_SPELLBOOK_USER_PATH"] = pinned
+        fresh = load_module()
+        check("GS_SPELLBOOK_USER_PATH pins the overlay path verbatim",
+              getattr(fresh, "USER_SPELLBOOK_PATH", None) == pinned,
+              repr(getattr(fresh, "USER_SPELLBOOK_PATH", None)))
+        os.environ["GS_SPELLBOOK_USER_PATH"] = ""
+        fresh = load_module()
+        check("empty GS_SPELLBOOK_USER_PATH means no overlay",
+              getattr(fresh, "USER_SPELLBOOK_PATH", None) == ""
+              and sorted(fresh.load_spellbook(
+                  BOOK_PATH, fresh.USER_SPELLBOOK_PATH)["spells"])
+              == sorted(repo_names))
+    finally:
+        if saved is None:
+            os.environ.pop("GS_SPELLBOOK_USER_PATH", None)
+        else:
+            os.environ["GS_SPELLBOOK_USER_PATH"] = saved
     with open(SVC_PATH) as f:
         src = f.read()
+    check("service reads spellbook.USER_SPELLBOOK_PATH",
+          "spellbook.USER_SPELLBOOK_PATH" in src)
+    check("service has no literal overlay path",
+          'expanduser("~/.config/speech-to-cli/spellbook.json")' not in src)
+
+    print("-- op table: spellbook.json <-> _spell_ctx_dbus")
     m = re.search(r"def _spell_ctx_dbus\(self, op\):.*?\n    def ", src,
                   re.S)
     check("service has _spell_ctx_dbus", m is not None)


### PR DESCRIPTION
Closes #152

## Root cause  (measured)
`GnomeSpeaksService.__init__` built `_spellbook_paths` with a **literal** `expanduser("~/.config/speech-to-cli/spellbook.json")`. The harness isolation contract (`tests/repros/isolation.py`) pinned `CONFIG_PATH` / `CHRONICLE_PATH` / `XDG_STATE_HOME` — there was no seam for the overlay, so nothing to pin and nothing to assert. Every harness-built service merged the developer's personal spells: **`Spellbook loaded: 24 spells`** (15 repo + 9 overlay) on the dev machine, pre-fix.

## Fix
- **`spellbook.py`** — `USER_SPELLBOOK_PATH` module seam (default unchanged); env `GS_SPELLBOOK_USER_PATH` read once at import, empty string = no overlay. No `state.CONFIG` key → no speech-to-cli whitelist change.
- **`gnome-speaks-service.py`** — reads `spellbook.USER_SPELLBOOK_PATH`; the literal is gone. Runtime behaviour for a normal install is identical.
- **`tests/repros/isolation.py`** — `isolate_spellbook()` (from `isolate_config()`) writes an **empty** overlay into the per-PID scratch and pins the seam *before* construction; `assert_isolated()` requires the seam inside scratch and never at the live overlay; `assert_repo_spellbook()` counts what the built instance loaded against the repo `spellbook.json`. A tree with no seam is refused (setup failure), like an unset `CHRONICLE_PATH`.
- **All four `make_service()` builders** (service-audit, chronicle-perf, cancel-tokens, dead-recorder) assert the count. Every other suite imports one of them; version-cache isolates but builds no instance; injector-seam/c5/c6 never construct.
- **`verify_spellbook.py`** — 5 new seam checks. **Red on `a20afea` (FAILURES: 5, everything else green).**
- Docs: `tests/repros/README.md`, `CLAUDE.md`.

## Measurements
| what | value |
|---|---|
| pre-fix harness `Spellbook loaded` | **24** |
| post-fix harness | **15** (= repo `spellbook.json`) |
| CONTROL — pin removed | `assert_isolated` refuses: seam resolves OUTSIDE scratch |
| CONTROL — pinned, then seam re-pointed at the live overlay before construction | logs 24; `assert_repo_spellbook` raises "24 vs 15" |
| `verify_wake_gate.py` | all checks passed |
| py_compile | ok |
| diff leak scan (`<lan-host>\|<wake-word>\|<lan-ip>\|<site-domain>\|~`) + `tests/leak-scan.sh` | 0 / PASS |
| bare `tests/repros/run_all.sh` on head (rebased onto 2ccd171; #146 repros e/f build via `make_service` and measured `Spellbook loaded: 15`) | **65 checks: 65 pass, 0 fail — ALL SUITES GREEN** (head `bc44b02`; also 62/62 on the pre-rebase a20afea base) |

prefs rig / rig-owned fixture: `prefs.js` touches the overlay path only in a button handler under the rig's sandboxed `$HOME`; the rig has no spellbook reference. Not affected.

Hedge: the user overlay was opened only to *count* its spells; no contents were read, copied or quoted anywhere.
