### PR TITLE
feat(extension): visible 'service unavailable' badge state; tap starts the unit (#113)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,8 @@ scripts that exit 0 or 1. Validate changes by:
 5. Shell-side changes: headless session (`--nested` is dead on 50, see gotchas) --
    `dbus-run-session -- gnome-shell --headless --virtual-monitor 1280x720`, then
    enable/disable/re-enable and require **zero** JS errors, shell CRITICALs, and St warnings.
+   `tests/repros/shell-rig/run.sh [checkout]` does exactly that in a sandbox and reads the
+   badge's computed `St.ThemeNode` values from inside the shell (see `tests/repros/README.md`).
 6. Wake-word secure gate: `python3 verify_wake_gate.py` from the checkout root -- no env vars,
    no desktop, no daemon (it imports `ibus_injector` from its own directory). 24 checks; exit 0
    means all passed.

--- a/extension.js
+++ b/extension.js
@@ -175,7 +175,18 @@ const States = {
     LISTENING: 'listening',
     PROCESSING: 'processing',
     SPEAKING: 'speaking',
+    // Not a service state: the extension's own verdict that org.gnome.Speaks
+    // has no owner on the bus. Entered from the name-vanished watch and the
+    // proxy-failure paths, left when the name appears again (#113).
+    UNAVAILABLE: 'unavailable',
 };
+
+// The systemd user unit install.sh writes; what a tap starts while the
+// badge is in the UNAVAILABLE state.
+const SERVICE_UNIT = 'gnome-speaks.service';
+// How long after a successful `systemctl start` we wait for the bus name
+// before telling the user the unit came up without claiming it.
+const SERVICE_START_WAIT_MS = 10000;
 
 const STATE_CONFIG = {
     [States.IDLE]: {
@@ -207,6 +218,16 @@ const STATE_CONFIG = {
         styleClass: 'gnome-speaks-speaking',
         showLabel: true,
         accessibleName: 'GNOME Speaks — speaking, activate to stop',
+    },
+    [States.UNAVAILABLE]: {
+        // The struck mic IS the state: dimmed glass, no ring, and the label
+        // is revealed on hover/focus as a tooltip rather than shown always,
+        // so the badge stays as compact as idle.
+        iconName: 'microphone-disabled-symbolic',
+        label: 'Service not running — tap to start',
+        styleClass: 'gnome-speaks-unavailable',
+        showLabel: false,
+        accessibleName: 'GNOME Speaks service not running — activate to start it',
     },
 };
 
@@ -240,6 +261,7 @@ export default class GnomeSpeaksExtension extends Extension {
         this._dragBadgeStartX = 0;
         this._dragBadgeStartY = 0;
         this._badgeVisible = true;
+        this._serviceStartPending = false;
         this._audioLevel = 0;
         this._lastAudioLevelTime = 0;
         this._lastPartialTime = 0;
@@ -288,7 +310,11 @@ export default class GnomeSpeaksExtension extends Extension {
             Gio.BusNameWatcherFlags.NONE,
             () => {
                 if (this._destroyed) return;
-                // Name appeared (service started or restarted)
+                // Name appeared (service started or restarted). Leave the
+                // unavailable state optimistically; the GetState reply
+                // below corrects it if the service is already busy.
+                if (this._state === States.UNAVAILABLE)
+                    this._setState(States.IDLE);
                 if (this._proxyReady)
                     this._syncState();
                 else if (!this._proxyPending)
@@ -296,8 +322,11 @@ export default class GnomeSpeaksExtension extends Extension {
             },
             () => {
                 if (this._destroyed) return;
-                // Name vanished (service stopped) — reset badge to idle
-                this._setState(States.IDLE);
+                // Name vanished (service stopped, crashed, or was never
+                // running -- GLib fires this immediately when the name has
+                // no owner at watch time). Say so on the badge instead of
+                // pretending to be idle; a tap here starts the unit (#113).
+                this._setState(States.UNAVAILABLE);
             },
         );
     }
@@ -609,6 +638,13 @@ export default class GnomeSpeaksExtension extends Extension {
             return Clutter.EVENT_PROPAGATE;
         });
         this._signals.push({obj: this._badge, id: pressId});
+
+        // Tooltip for the unavailable state: the label rides along on
+        // hover and keyboard focus, and goes away with them.
+        for (let sig of ['notify::hover', 'key-focus-in', 'key-focus-out']) {
+            let id = this._badge.connect(sig, () => this._refreshUnavailableLabel());
+            this._signals.push({obj: this._badge, id});
+        }
 
         let motionId = this._badge.connect('motion-event', (actor, event) => {
             if (this._dragButton !== 1)
@@ -1387,6 +1423,16 @@ export default class GnomeSpeaksExtension extends Extension {
     _buildPanelMenu() {
         let menu = this._panelButton.menu;
 
+        // Service health, first thing in the menu: an insensitive info row
+        // while running, an actionable one while not (#113).
+        this._menuServiceItem = new PopupMenu.PopupMenuItem('Service: running');
+        this._menuServiceItem.connect('activate', () => {
+            if (this._state === States.UNAVAILABLE)
+                this._startService();
+        });
+        menu.addMenuItem(this._menuServiceItem);
+        this._updateServiceMenuItem();
+
         menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem('Actions'));
 
         this._menuListenItem = new PopupMenu.PopupMenuItem('Start Listening');
@@ -1563,6 +1609,11 @@ export default class GnomeSpeaksExtension extends Extension {
             return;
 
         switch (this._state) {
+        case States.UNAVAILABLE:
+            this._menuListenItem.label.text = 'Start Listening';
+            this._menuListenItem.setSensitive(false);
+            this._menuStopItem.setSensitive(false);
+            break;
         case States.IDLE:
             this._menuListenItem.label.text = 'Start Listening';
             this._menuListenItem.setSensitive(true);
@@ -1598,8 +1649,121 @@ export default class GnomeSpeaksExtension extends Extension {
             this._menuConversationToggle = null;
             this._menuVoiceQualityItem = null;
             this._menuAudioInfoItem = null;
+            this._menuServiceItem = null;
             this._langSubMenu = null;
         }
+    }
+
+    _updateServiceMenuItem() {
+        if (!this._menuServiceItem)
+            return;
+        if (this._state === States.UNAVAILABLE) {
+            this._menuServiceItem.label.text = this._serviceStartPending
+                ? 'Service: starting…'
+                : 'Service: not running — activate to start';
+            this._menuServiceItem.setSensitive(!this._serviceStartPending);
+        } else {
+            this._menuServiceItem.label.text = 'Service: running';
+            this._menuServiceItem.setSensitive(false);
+        }
+    }
+
+    // -- Service lifecycle (the extension's only subprocess) ---------------
+
+    _isCompactState(state) {
+        return state === States.IDLE || state === States.UNAVAILABLE;
+    }
+
+    // The unavailable badge is as compact as idle; its label doubles as the
+    // tooltip and is shown only while hovered, focused, or starting.
+    _refreshUnavailableLabel() {
+        if (!this._label || !this._badge)
+            return;
+        if (this._state !== States.UNAVAILABLE)
+            return;
+        let reveal = this._serviceStartPending || this._badge.hover || this._badge.has_key_focus();
+        if (reveal) {
+            this._label.text = this._serviceStartPending
+                ? 'Starting service…'
+                : STATE_CONFIG[States.UNAVAILABLE].label;
+            this._label.show();
+        } else {
+            this._label.text = '';
+            this._label.hide();
+        }
+    }
+
+    // `systemctl --user start gnome-speaks.service`, asynchronously: the
+    // shell's main loop never waits on it. Success is not "systemctl exited
+    // 0" -- it is the bus name appearing, which the name watch turns into a
+    // state change; a unit that exits 0 and never claims the name is
+    // reported after SERVICE_START_WAIT_MS. Failure gets ONE toast.
+    _startService() {
+        if (this._destroyed || this._serviceStartPending)
+            return;
+        if (this._state !== States.UNAVAILABLE)
+            return;
+        this._serviceStartPending = true;
+        this._refreshUnavailableLabel();
+        this._updateServiceMenuItem();
+
+        let proc;
+        try {
+            proc = Gio.Subprocess.new(
+                ['systemctl', '--user', 'start', SERVICE_UNIT],
+                Gio.SubprocessFlags.STDOUT_SILENCE | Gio.SubprocessFlags.STDERR_PIPE);
+        } catch (e) {
+            // systemctl missing, or spawn refused
+            this._onServiceStartFinished(false, e.message);
+            return;
+        }
+        proc.communicate_utf8_async(null, null, (p, res) => {
+            if (this._destroyed) return;
+            let ok = false;
+            let detail = '';
+            try {
+                let [, , stderr] = p.communicate_utf8_finish(res);
+                ok = p.get_successful();
+                detail = (stderr || '').trim().split('\n')[0];
+            } catch (e) {
+                detail = e.message;
+            }
+            this._onServiceStartFinished(ok, detail);
+        });
+    }
+
+    _onServiceStartFinished(ok, detail) {
+        if (this._destroyed) return;
+        if (!ok) {
+            console.warn(`[GNOME Speaks] systemctl --user start ${SERVICE_UNIT} failed: ${detail}`);
+            this._serviceStartPending = false;
+            this._refreshUnavailableLabel();
+            this._updateServiceMenuItem();
+            this._showError('service start failed');
+            Main.notify('GNOME Speaks',
+                `Could not start ${SERVICE_UNIT}${detail ? `: ${detail}` : ''}`);
+            return;
+        }
+        // systemctl returned 0. Either the name has already appeared (the
+        // watch flipped the state and cleared the pending flag) or the unit
+        // is still coming up -- give it a bounded wait before saying so.
+        if (this._state !== States.UNAVAILABLE)
+            return;
+        let timeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, SERVICE_START_WAIT_MS, () => {
+            this._removeTimeout('service-start-wait');
+            if (this._destroyed) return GLib.SOURCE_REMOVE;
+            if (this._state === States.UNAVAILABLE && this._serviceStartPending) {
+                console.warn(`[GNOME Speaks] ${SERVICE_UNIT} started but did not claim ${DBUS_NAME} within ${SERVICE_START_WAIT_MS} ms`);
+                this._serviceStartPending = false;
+                this._refreshUnavailableLabel();
+                this._updateServiceMenuItem();
+                this._showError('service did not come up');
+                Main.notify('GNOME Speaks',
+                    `${SERVICE_UNIT} started but is not on the bus yet — check its journal.`);
+            }
+            return GLib.SOURCE_REMOVE;
+        });
+        this._trackTimeout(timeoutId, 'service-start-wait');
     }
 
     _positionBadge() {
@@ -1719,6 +1883,7 @@ export default class GnomeSpeaksExtension extends Extension {
                         console.warn(`[GNOME Speaks] DBus proxy creation failed: ${error.message}`);
                         this._proxy = null;
                         this._proxyReady = false;
+                        this._setState(States.UNAVAILABLE);
                         return;
                     }
                     this._proxy = p;
@@ -1732,6 +1897,7 @@ export default class GnomeSpeaksExtension extends Extension {
             this._proxyPending = false;
             this._proxy = null;
             this._proxyReady = false;
+            this._setState(States.UNAVAILABLE);
         }
     }
 
@@ -1894,6 +2060,13 @@ export default class GnomeSpeaksExtension extends Extension {
         this._badge.add_style_class_name(config.styleClass);
         this._badge.accessible_name = config.accessibleName;
 
+        // The service is back (or we are being told it is): a start we
+        // kicked off has done its job, and the wait for it is moot.
+        if (oldState === States.UNAVAILABLE) {
+            this._serviceStartPending = false;
+            this._cancelTimeout('service-start-wait');
+        }
+
         // Update waveform bar color for state
         if (this._waveformBars) {
             let barClass = {
@@ -1910,7 +2083,7 @@ export default class GnomeSpeaksExtension extends Extension {
         // Update icon
         if (this._icon) {
             this._icon.icon_name = config.iconName;
-            this._icon.x_expand = (newState === States.IDLE);
+            this._icon.x_expand = this._isCompactState(newState);
         }
 
         // Update label
@@ -1923,10 +2096,12 @@ export default class GnomeSpeaksExtension extends Extension {
                 this._label.hide();
             }
         }
+        // Unavailable reveals its label as a tooltip (hover/focus) instead.
+        this._refreshUnavailableLabel();
 
-        // Pills: hidden in idle, shown when active
-        let showPills = newState !== States.IDLE;
-        let wasShowingPills = oldState && oldState !== States.IDLE;
+        // Pills: hidden in idle/unavailable, shown when active
+        let showPills = !this._isCompactState(newState);
+        let wasShowingPills = oldState && !this._isCompactState(oldState);
         if (showPills !== wasShowingPills) {
             this._showPills(showPills);
             // Only refresh pill content when transitioning visibility
@@ -1941,6 +2116,7 @@ export default class GnomeSpeaksExtension extends Extension {
         // Update panel icon and menu
         this._updatePanelIcon(newState);
         this._updatePanelMenu();
+        this._updateServiceMenuItem();
 
         // Re-sync mode flags when returning to idle (catches one-shot AI mode).
         // Debounce: skip if we just synced < 2s ago (avoids D-Bus flood in AI+Loop)
@@ -1977,7 +2153,7 @@ export default class GnomeSpeaksExtension extends Extension {
         }
 
         // Fade waveform when leaving active states
-        if (newState === States.IDLE && this._waveformContainer) {
+        if (this._isCompactState(newState) && this._waveformContainer) {
             this._waveformContainer.ease({
                 opacity: 0, duration: 400,
                 mode: Clutter.AnimationMode.EASE_OUT_QUAD,
@@ -2005,11 +2181,11 @@ export default class GnomeSpeaksExtension extends Extension {
             this._cancelTimeout('subtitle-fadeout');
         }
 
-        // Reposition badge + glow + subtitle if going to/from idle (size changes)
-        if ((oldState === States.IDLE && newState !== States.IDLE) ||
-            (oldState !== States.IDLE && newState === States.IDLE)) {
+        // Reposition badge + glow + subtitle if going to/from a compact
+        // state (idle/unavailable) -- the size changes
+        if (this._isCompactState(oldState) !== this._isCompactState(newState)) {
             if (!this._customPosition) {
-                let delay = (newState === States.IDLE) ? 16 : 50;
+                let delay = this._isCompactState(newState) ? 16 : 50;
                 let timeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
                     if (this._destroyed) return GLib.SOURCE_REMOVE;
                     this._positionBadge();
@@ -2037,6 +2213,7 @@ export default class GnomeSpeaksExtension extends Extension {
             'gnome-speaks-panel-listening',
             'gnome-speaks-panel-processing',
             'gnome-speaks-panel-speaking',
+            'gnome-speaks-panel-unavailable',
         ];
 
         for (let cls of panelClasses)
@@ -2125,6 +2302,9 @@ export default class GnomeSpeaksExtension extends Extension {
 
     _onBadgeClicked() {
         switch (this._state) {
+        case States.UNAVAILABLE:
+            this._startService();
+            break;
         case States.IDLE:
             this._callMethod('StartListening');
             break;
@@ -2142,6 +2322,16 @@ export default class GnomeSpeaksExtension extends Extension {
 
     _callMethod(methodName, ...args) {
         if (this._destroyed) return;
+        if (this._state === States.UNAVAILABLE) {
+            // Nothing is listening on the other end. Reaching for dictation
+            // means "bring it back"; anything else gets told why it did
+            // nothing instead of a red flash and a debug-level log line.
+            if (methodName === 'StartListening' || methodName === 'StopListening')
+                this._startService();
+            else
+                Main.notify('GNOME Speaks', 'The service is not running — tap the badge to start it.');
+            return;
+        }
         if (!this._proxy) {
             this._initProxy();
             let timeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -253,6 +253,46 @@
 }
 
 /* ============================================================
+ * STATE: UNAVAILABLE — the service is gone (#113)
+ *
+ * Idle's compact glass, dimmed a step further, with the struck mic as
+ * the whole signal: nothing lights because there is nothing to light.
+ * Hover and keyboard focus borrow the "trouble" ember at low opacity and
+ * reveal the label ("Service not running — tap to start") as the tooltip.
+ * The same rule serves :hover and :focus so a keyboard user gets the
+ * identical reveal a pointer does.
+ * ============================================================ */
+
+.gnome-speaks-unavailable {
+    padding: 6px 9px;
+    background-color: rgba(16, 18, 26, 0.52);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.22);
+}
+
+.gnome-speaks-unavailable StIcon {
+    icon-size: 18px;
+    color: rgba(255, 255, 255, 0.34);
+}
+
+.gnome-speaks-unavailable .gnome-speaks-badge-label {
+    color: rgba(255, 214, 214, 0.86);
+    font-weight: normal;
+}
+
+.gnome-speaks-unavailable:hover,
+.gnome-speaks-unavailable:focus {
+    background-color: rgba(30, 16, 18, 0.80);
+    border: 1px solid rgba(255, 96, 96, 0.38);
+    box-shadow: 0 0 12px rgba(255, 96, 96, 0.16);
+}
+
+.gnome-speaks-unavailable:hover StIcon,
+.gnome-speaks-unavailable:focus StIcon {
+    color: rgba(255, 150, 150, 0.9);
+}
+
+/* ============================================================
  * PILLS — one shared shape, tinted by meaning
  * ============================================================ */
 
@@ -512,6 +552,12 @@
 
 .gnome-speaks-panel-speaking {
     color: rgba(178, 122, 255, 1.0);
+}
+
+/* The struck mic in the top bar, dimmed below idle: visible at a glance,
+ * never loud -- the badge carries the affordance. */
+.gnome-speaks-panel-unavailable {
+    color: rgba(255, 255, 255, 0.38);
 }
 
 /* ============================================================

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -98,6 +98,7 @@ tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
 | `prefs-rig` | #82 | merge base of the branch | more warnings than baseline = fail |
 | `spellbook` | #119, #152 | `025df92` / `a20afea` | **verified** — 8 fail on `025df92`: `cast stop`, `cast halt`, every punctuated trigger (`Cast, stop.`, `Cast - skip`, `Invoke... skip`, …); the denylist, overlay and op-table checks stay green on both sides. The #152 seam checks (`USER_SPELLBOOK_PATH` honours `GS_SPELLBOOK_USER_PATH`; the service reads the seam, not a literal) are red on `a20afea` |
 | `leak-scan` | #126 | `025df92` | **verified** — 4 hits (tracked unit ×2, two plans) |
+| `shell-rig` | #113 | `3c70314` | **verified** — t0 fails 8 checks: state `idle`, no service row; every later step green on both sides |
 | `config-keys` | #120 #127 | `025df92` | **verified** — B fails: 8 keys against speech-to-cli before its #21 (`language`, `voice_commands` + 6 shell-only `show_*`), 6 after; D fails: the same 6 `show_*` (no Python reader); A, C pass |
 | `deprecations` | #114 | `a20afea` | **verified** — 3 deprecation lines at service start (`GLib.unix_signal_add` ×2, `Gio.DBusConnection.register_object` ×1 — PyGObject warns once per deprecated GI function per process, so two register sites make one line); `GetState` and the Spiel `Name` property answer on both sides. Runs the real `main()` on a private `dbus-run-session` bus the suite re-execs itself under; `register_object` also leaked ~1.5 kB per D-Bus method call (measured; flat through `register_object_with_closures2`) |
 
@@ -262,6 +263,41 @@ B. reaper ENABLED   -> rc=0  26 orphans reaped
 
 It is not wired into `run_all.sh`: it starts 26 processes and verifies the
 reaper, not the service. Run it when touching the probe or the reaper.
+
+## shell-rig is a real headless gnome-shell
+
+`tests/repros/shell-rig/run.sh [checkout]` is the other non-python suite and,
+like prefs-rig, is **not** collected by `run_all.sh` (a headless shell is
+~15 s of startup and needs `gnome-shell` on the machine). It installs a
+checkout's `extension.js` + `stylesheet.css` into a sandboxed
+`XDG_DATA_HOME`, boots `gnome-shell --headless --virtual-monitor 1280x720`
+on a private bus with **no service activation**, and reads the badge from
+*inside* the shell through a rig-only probe extension: computed
+`St.ThemeNode` colours, accessible name, label visibility, panel-menu rows,
+the notifications `Main.notify` produced. It is the instrument the "St CSS:
+measure, don't reason" gotcha asks for. The timeline: no service on the bus
+→ a stub owns `org.gnome.Speaks` and announces `listening` → the stub dies
+→ hover / keyboard focus → a badge tap → the dictation-hotkey seam → the
+stub returns idle → dies again → disable / re-enable. Exit 0 also requires
+zero gnome-speaks `JS ERROR` / `CRITICAL` / St-warning lines in the shell log.
+
+Two things it is careful about, both measured:
+
+- **The tap spawns `systemctl --user start gnome-speaks.service` for real**,
+  against a sandboxed `XDG_RUNTIME_DIR`, so it fails to connect (`Failed to
+  connect to user scope bus via local transport`) and can never start, stop
+  or touch the real unit. `run.sh` proves that with a control *before* the
+  shell starts and aborts if the sandboxed systemctl ever reaches a manager.
+  The failure is what the rig wants: it is the toast path.
+- **Its bus socket is `$RUN/runtime/bus`** (`unix:runtime=yes`). The stock
+  `unix:dir=` form appends `/dbus-XXXXXXXXXX` and overflowed `sun_path` from a
+  worktree path — surfacing only as `dbus-run-session: EOF reading address`.
+  A depth guard now fails setup with the reason instead.
+
+The pending "Starting…" state is read by `TapAndDump`, which taps and dumps
+in **one main-loop turn**: on a machine where the sandboxed spawn fails in
+under 300 ms a dump scheduled "shortly after" the tap arrives too late and
+reads a false negative.
 
 ## prefs-rig is not python
 

--- a/tests/repros/shell-rig/driver.sh
+++ b/tests/repros/shell-rig/driver.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Runs INSIDE dbus-run-session with the sandbox env from run.sh. Starts the
+# headless shell, waits for the probe, walks the timeline, kills the shell,
+# hands the dumps to verify.py.
+set -u
+HERE=$(cd "$(dirname "$0")" && pwd)
+LOG="$RUN/shell.log"
+DUMPS="$RUN/dumps"; mkdir -p "$DUMPS"
+
+gsettings set org.gnome.shell disable-user-extensions false
+gsettings set org.gnome.shell enabled-extensions "['$UUID', 'speaks-probe@rig']"
+gsettings set org.gnome.shell welcome-dialog-last-shown-version '999' 2>/dev/null || true
+
+gnome-shell --headless --virtual-monitor 1280x720 >"$LOG" 2>&1 &
+SHELL_PID=$!
+die() { echo "!! RIG DID NOT COMPLETE: $*"; kill "$SHELL_PID" 2>/dev/null; grep -iE "gnome-speaks|speaks-probe|JS ERROR|CRITICAL" "$LOG" | tail -30; exit 3; }
+
+probe() { gdbus call --session --dest org.gnome.Speaks.RigProbe --object-path /org/gnome/Speaks/RigProbe --method "org.gnome.Speaks.RigProbe.$@" 2>/dev/null; }
+dump() {  # $1 = name, $2 = probe method (default Dump)
+    local out
+    out=$(probe "${2:-Dump}") || return 1
+    # gdbus prints ('<json>',) with the string GVariant-escaped; unwrap it.
+    python3 - "$out" >"$DUMPS/$1.json" <<'PY'
+import sys, ast, json
+s = sys.argv[1].strip()
+assert s.startswith("(") and s.endswith(",)"), s[:80]
+inner = s[1:-2]
+print(json.dumps(json.loads(ast.literal_eval(inner)), indent=1))
+PY
+}
+
+for i in $(seq 1 60); do
+    kill -0 "$SHELL_PID" 2>/dev/null || die "gnome-shell exited early"
+    probe Dump >/dev/null && break
+    sleep 1
+done
+probe Dump >/dev/null || die "probe never answered on the bus"
+sleep 2   # let bus_watch_name deliver its first verdict and the stage settle
+
+dump t0_no_service || die "dump t0"
+
+python3 "$HERE/stub_service.py" --state listening >"$RUN/stub.log" 2>&1 &
+STUB_PID=$!
+sleep 3   # name appears (+0s), StateChanged(listening) (+1s), theme settles
+dump t1_stub_listening || die "dump t1"
+
+kill "$STUB_PID"; wait "$STUB_PID" 2>/dev/null
+sleep 1.5
+dump t2_stub_gone || die "dump t2"
+
+probe SetHover true; sleep 0.5; dump t3_hover || die "dump t3"
+probe SetHover false; sleep 0.5; dump t4_unhover || die "dump t4"
+probe SetFocus true; sleep 0.5; dump t5_focus || die "dump t5"
+probe SetFocus false; sleep 0.5; dump t6_unfocus || die "dump t6"
+
+# A tap: systemctl runs against the sandboxed runtime dir and fails.
+dump t7_tap_pending TapAndDump || die "dump t7"
+sleep 3;  dump t8_tap_failed || die "dump t8"
+
+# The dictation hotkey seam while unavailable, and a non-listen method.
+probe Call StartListening; sleep 3; dump t9_hotkey || die "dump t9"
+probe Call SpeakClipboard; sleep 0.5; dump t10_other_method || die "dump t10"
+
+# Service comes back idle: leaves the state, menu row flips.
+python3 "$HERE/stub_service.py" --state idle >"$RUN/stub2.log" 2>&1 &
+STUB_PID=$!
+sleep 3
+dump t11_stub_idle || die "dump t11"
+kill "$STUB_PID"; wait "$STUB_PID" 2>/dev/null
+sleep 1.5
+dump t12_gone_again || die "dump t12"
+
+# disable / re-enable must be clean
+gnome-extensions disable "$UUID"; sleep 1
+gnome-extensions enable "$UUID"; sleep 3
+dump t13_reenabled || die "dump t13"
+
+kill "$SHELL_PID"; wait "$SHELL_PID" 2>/dev/null
+# Belt and braces: with no servicedir nothing should have mounted anything,
+# but a FUSE mount left inside the run dir would survive rm -rf.
+for m in $(awk -v r="$RUN/" 'index($2, r) == 1 {print $2}' /proc/mounts); do
+    fusermount3 -u "$m" 2>/dev/null || fusermount -u "$m" 2>/dev/null || true
+done
+python3 "$HERE/verify.py" "$DUMPS" "$LOG" "$SRC"

--- a/tests/repros/shell-rig/probe/extension.js
+++ b/tests/repros/shell-rig/probe/extension.js
@@ -1,0 +1,157 @@
+// Rig-only probe. Lives INSIDE the headless shell so it can read what no
+// outside instrument can: the computed St.ThemeNode of the gnome-speaks
+// badge, its accessible name, the label's visibility, the panel menu rows,
+// and the notifications Main.notify produced. It drives the badge through
+// the same seams a pointer or keyboard would (_onBadgeClicked, hover,
+// key focus) and never touches the real desktop -- it only ever runs in
+// the sandbox run.sh builds.
+import Gio from 'gi://Gio';
+import St from 'gi://St';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+const TARGET = 'gnome-speaks@jphein';
+
+const IFACE = `<node>
+  <interface name="org.gnome.Speaks.RigProbe">
+    <method name="Dump"><arg direction="out" type="s" name="json"/></method>
+    <method name="SetHover"><arg direction="in" type="b" name="on"/></method>
+    <method name="SetFocus"><arg direction="in" type="b" name="on"/></method>
+    <method name="Tap"/>
+    <method name="TapAndDump"><arg direction="out" type="s" name="json"/></method>
+    <method name="Call"><arg direction="in" type="s" name="method"/></method>
+  </interface>
+</node>`;
+
+function color(c) {
+    try {
+        return c ? c.to_string() : null;
+    } catch (e) {
+        return `?${e.message}`;
+    }
+}
+
+export default class RigProbe extends Extension {
+    enable() {
+        this._dbus = Gio.DBusExportedObject.wrapJSObject(IFACE, this);
+        this._dbus.export(Gio.DBus.session, '/org/gnome/Speaks/RigProbe');
+        this._ownerId = Gio.bus_own_name_on_connection(Gio.DBus.session,
+            'org.gnome.Speaks.RigProbe', Gio.BusNameOwnerFlags.NONE, null, null);
+    }
+
+    disable() {
+        if (this._ownerId) {
+            Gio.bus_unown_name(this._ownerId);
+            this._ownerId = 0;
+        }
+        if (this._dbus) {
+            this._dbus.unexport();
+            this._dbus = null;
+        }
+    }
+
+    _target() {
+        let ext = Main.extensionManager.lookup(TARGET);
+        return ext ? ext.stateObj : null;
+    }
+
+    Dump() {
+        let out = {target_loaded: false};
+        let t = this._target();
+        if (!t) return JSON.stringify(out);
+        out.target_loaded = true;
+        out.state = t._state;
+        out.service_start_pending = t._serviceStartPending;
+        out.notify_is_function = typeof Main.notify === 'function';
+        let badge = t._badge;
+        if (badge) {
+            let node = null;
+            try { node = badge.get_theme_node(); } catch (e) { out.badge_node_error = e.message; }
+            out.badge = {
+                classes: badge.get_style_class_name(),
+                accessible_name: badge.accessible_name,
+                hover: badge.hover,
+                has_key_focus: badge.has_key_focus(),
+                width: badge.get_width(),
+                bg: node ? color(node.get_background_color()) : null,
+                border: node ? color(node.get_border_color(St.Side.TOP)) : null,
+                padding_left: node ? node.get_padding(St.Side.LEFT) : null,
+            };
+        }
+        if (t._icon) {
+            let node = null;
+            try { node = t._icon.get_theme_node(); } catch (e) { /* off-stage */ }
+            out.icon = {
+                name: t._icon.icon_name,
+                color: node ? color(node.get_foreground_color()) : null,
+                size: node ? node.get_length('icon-size') : null,
+            };
+        }
+        if (t._label) {
+            let node = null;
+            try { node = t._label.get_theme_node(); } catch (e) { /* off-stage */ }
+            out.label = {
+                visible: t._label.visible,
+                text: t._label.text,
+                color: node ? color(node.get_foreground_color()) : null,
+            };
+        }
+        if (t._pills)
+            out.pills_visible = t._pills.map(p => p.visible);
+        if (t._panelIcon) {
+            let node = null;
+            try { node = t._panelIcon.get_theme_node(); } catch (e) { /* off-stage */ }
+            out.panel_icon = {
+                name: t._panelIcon.icon_name,
+                classes: t._panelIcon.get_style_class_name(),
+                color: node ? color(node.get_foreground_color()) : null,
+            };
+        }
+        let row = item => item ? {text: item.label.text, sensitive: item.sensitive} : null;
+        out.menu = {
+            service: row(t._menuServiceItem),
+            listen: row(t._menuListenItem),
+            stop: row(t._menuStopItem),
+        };
+        try {
+            out.notifications = Main.messageTray.getSources()
+                .flatMap(s => s.notifications || [])
+                .map(n => ({title: n.title, body: n.body}));
+        } catch (e) {
+            out.notifications_error = e.message;
+        }
+        return JSON.stringify(out);
+    }
+
+    SetHover(on) {
+        let t = this._target();
+        if (t && t._badge) t._badge.hover = on;
+    }
+
+    SetFocus(on) {
+        let t = this._target();
+        if (!t || !t._badge) return;
+        if (on) t._badge.grab_key_focus();
+        else global.stage.set_key_focus(null);
+    }
+
+    Tap() {
+        let t = this._target();
+        if (!t) return;
+        t._releaseKeyFocusFromPointer();
+        t._onBadgeClicked();
+    }
+
+    // The tap and the dump in ONE main-loop turn: the systemctl child
+    // cannot have exited yet, so this is the only honest look at the
+    // "Starting…" state on a machine where the sandboxed spawn fails fast.
+    TapAndDump() {
+        this.Tap();
+        return this.Dump();
+    }
+
+    Call(method) {
+        let t = this._target();
+        if (t) t._callMethod(method);
+    }
+}

--- a/tests/repros/shell-rig/probe/metadata.json
+++ b/tests/repros/shell-rig/probe/metadata.json
@@ -1,0 +1,7 @@
+{
+  "uuid": "speaks-probe@rig",
+  "name": "GNOME Speaks rig probe",
+  "description": "Test-only: exports org.gnome.Speaks.RigProbe to read the badge's St.ThemeNode values inside a headless shell. Never install on a real desktop.",
+  "shell-version": ["46", "47", "48", "49", "50"],
+  "version": 1
+}

--- a/tests/repros/shell-rig/run.sh
+++ b/tests/repros/shell-rig/run.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Load a checkout's extension.js + stylesheet.css into a REAL headless
+# gnome-shell on a private session bus and measure the badge from inside
+# (computed St.ThemeNode colours, accessible name, label visibility, panel
+# menu rows, notifications) while org.gnome.Speaks is absent, present, and
+# gone again. `--nested` is dead on GNOME 50; this is the replacement rig the
+# "St CSS: measure, don't reason" gotcha asks for.
+#
+#   ./run.sh                    # the checkout this script lives in
+#   ./run.sh /path/to/checkout  # a worktree, or an extracted SHA
+#
+# ISOLATION CONTRACT (do not weaken any of these):
+#   - Everything lives under $HERE/run-$$ and is deleted on exit. No fixed
+#     paths, so two rigs can run at once.
+#   - HOME, XDG_{DATA,CONFIG,CACHE,RUNTIME}_HOME/DIR and GSETTINGS_BACKEND=
+#     keyfile are exported into the dbus-run-session child ONLY. The shell
+#     never sees the real dconf, the real extensions dir, or the real
+#     Wayland display (DISPLAY/WAYLAND_DISPLAY are unset).
+#   - XDG_RUNTIME_DIR is sandboxed, so `systemctl --user` spawned by the
+#     badge CANNOT reach the real user manager: it fails to connect, which
+#     is exactly the failure path the rig wants to see toasted. The control
+#     below proves that before the shell starts; if it ever succeeds, the
+#     run is aborted rather than risk starting or touching the real unit.
+#   - The bus is dbus-run-session's own, so the stub owning org.gnome.Speaks
+#     never collides with the running service.
+#
+# EXIT CONTRACT -- assert the LINE, not just the code:
+#   0  every check passed and the shell logged no gnome-speaks errors
+#   1  REGRESSION            -> "!! FAIL ..." lines from verify.py
+#   2  SETUP FAILURE         -> "!! SETUP FAILURE: ..."
+#   3  RIG DID NOT COMPLETE  -> "!! RIG ..." (shell never came up, probe unreachable)
+set -u
+set -o pipefail
+setup_fail() { echo "!! SETUP FAILURE: $*"; exit 2; }
+rig_fail()   { echo "!! RIG DID NOT COMPLETE: $*"; exit 3; }
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+SRC=${1:-$(cd "$HERE/../../.." && pwd)}
+SRC=$(cd "$SRC" 2>/dev/null && pwd) || setup_fail "no such checkout: ${1:-}"
+for f in extension.js stylesheet.css metadata.json schemas/org.gnome.shell.extensions.gnome-speaks.gschema.xml; do
+    [ -f "$SRC/$f" ] || setup_fail "$SRC/$f missing"
+done
+for bin in gnome-shell dbus-run-session gdbus gsettings glib-compile-schemas python3; do
+    command -v "$bin" >/dev/null || setup_fail "$bin not on PATH"
+done
+
+RUN="$HERE/run-$$"
+cleanup() {
+    # Unmount anything a child left under the run dir before removing it.
+    for m in $(awk -v r="$RUN/" 'index($2, r) == 1 {print $2}' /proc/mounts 2>/dev/null); do
+        fusermount3 -u "$m" 2>/dev/null || fusermount -u "$m" 2>/dev/null || true
+    done
+    rm -rf "$RUN"
+}
+trap cleanup EXIT
+mkdir -p "$RUN"/{home,data,config,cache} || setup_fail "mkdir $RUN"
+mkdir -m 700 "$RUN/runtime" || setup_fail "mkdir runtime"
+
+UUID=gnome-speaks@jphein
+EXT="$RUN/data/gnome-shell/extensions/$UUID"
+mkdir -p "$EXT/schemas"
+cp "$SRC/extension.js" "$SRC/stylesheet.css" "$SRC/metadata.json" "$EXT/"
+cp "$SRC/schemas/org.gnome.shell.extensions.gnome-speaks.gschema.xml" "$EXT/schemas/"
+glib-compile-schemas "$EXT/schemas/" || setup_fail "schema compile"
+PROBE="$RUN/data/gnome-shell/extensions/speaks-probe@rig"
+mkdir -p "$PROBE" && cp "$HERE/probe/extension.js" "$HERE/probe/metadata.json" "$PROBE/"
+
+# ---- control: the sandboxed systemctl must NOT reach the real manager ----
+if env -i PATH="$PATH" HOME="$RUN/home" XDG_RUNTIME_DIR="$RUN/runtime" \
+      DBUS_SESSION_BUS_ADDRESS="unix:path=$RUN/runtime/no-such-bus" \
+      systemctl --user is-active gnome-speaks.service >/dev/null 2>&1; then
+    setup_fail "sandboxed systemctl --user REACHED a user manager; refusing to run"
+fi
+
+# The bus socket is $XDG_RUNTIME_DIR/bus (unix:runtime=yes). sun_path is 108
+# bytes; `unix:dir=` appends /dbus-XXXXXXXXXX and overflowed it from a
+# worktree path (measured: "Failed to start message bus: Socket name too
+# long", surfacing only as dbus-run-session's "EOF reading address"). Guard
+# the shorter form too, so a deep checkout fails with a reason, not a riddle.
+BUS_SOCK="$RUN/runtime/bus"
+[ ${#BUS_SOCK} -le 100 ] || setup_fail "run dir too deep for a unix socket (${#BUS_SOCK} > 100 bytes): $BUS_SOCK"
+
+# A private bus with NO service activation: the stock session.conf would let
+# the shell pull in xdg-desktop-portal (which FUSE-mounts $XDG_RUNTIME_DIR/doc
+# INSIDE the run dir and defeats cleanup), gnome-keyring, gvfs and a second
+# ibus-daemon. Everything this rig needs is either the shell itself or a
+# process the driver starts by hand.
+BUSCONF="$RUN/bus.conf"
+cat >"$BUSCONF" <<XML
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>session</type>
+  <keep_umask/>
+  <listen>unix:runtime=yes</listen>
+  <auth>EXTERNAL</auth>
+  <policy context="default">
+    <allow send_destination="*" eavesdrop="true"/>
+    <allow eavesdrop="true"/>
+    <allow own="*"/>
+  </policy>
+</busconfig>
+XML
+
+export RUN SRC UUID
+# The whole timeline runs inside one private bus. Nothing below is exported
+# into THIS shell.
+env -u DISPLAY -u WAYLAND_DISPLAY -u DBUS_SESSION_BUS_ADDRESS \
+    HOME="$RUN/home" XDG_DATA_HOME="$RUN/data" XDG_CONFIG_HOME="$RUN/config" \
+    XDG_CACHE_HOME="$RUN/cache" XDG_RUNTIME_DIR="$RUN/runtime" \
+    GSETTINGS_BACKEND=keyfile XDG_SESSION_TYPE=wayland \
+    dbus-run-session --config-file="$BUSCONF" -- bash "$HERE/driver.sh"
+rc=$?
+case $rc in
+    0) ;;
+    1) exit 1 ;;
+    3) rig_fail "driver exit 3 (see $RUN/shell.log excerpt above)" ;;
+    *) rig_fail "driver exit $rc" ;;
+esac

--- a/tests/repros/shell-rig/stub_service.py
+++ b/tests/repros/shell-rig/stub_service.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Own org.gnome.Speaks on the CURRENT session bus and answer GetState.
+
+Rig-only. Under dbus-run-session that bus is private, so this never collides
+with the real service. `--state X` is what GetState answers AND what a
+StateChanged signal announces one second after the name is acquired, so
+the rig can park the badge in a non-idle state before the stub is killed
+(a service dying mid-utterance is the interesting vanish).
+"""
+import sys
+import gi
+gi.require_version('Gio', '2.0')
+from gi.repository import Gio, GLib
+
+STATE = sys.argv[sys.argv.index('--state') + 1] if '--state' in sys.argv else 'idle'
+XML = """<node><interface name="org.gnome.Speaks">
+  <method name="GetState"><arg direction="out" type="s"/></method>
+  <signal name="StateChanged"><arg type="s"/></signal>
+</interface></node>"""
+info = Gio.DBusNodeInfo.new_for_xml(XML).interfaces[0]
+conn = None
+
+
+def on_call(c, sender, path, iface, method, params, inv):
+    if method == 'GetState':
+        inv.return_value(GLib.Variant('(s)', (STATE,)))
+    else:
+        inv.return_dbus_error('org.gnome.Speaks.Stub', 'stub does not implement ' + method)
+
+
+def announce():
+    conn.emit_signal(None, '/org/gnome/Speaks', 'org.gnome.Speaks', 'StateChanged',
+                     GLib.Variant('(s)', (STATE,)))
+    print('stub: announced', STATE, flush=True)
+    return GLib.SOURCE_REMOVE
+
+
+def on_acquired(c, name):
+    global conn
+    conn = c
+    c.register_object('/org/gnome/Speaks', info, on_call, None, None)
+    print('stub: owns', name, flush=True)
+    GLib.timeout_add(1000, announce)
+
+
+Gio.bus_own_name(Gio.BusType.SESSION, 'org.gnome.Speaks', Gio.BusNameOwnerFlags.NONE,
+                 None, on_acquired, lambda c, n: print('stub: lost', n, flush=True))
+GLib.MainLoop().run()

--- a/tests/repros/shell-rig/verify.py
+++ b/tests/repros/shell-rig/verify.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Turn the driver's dumps into PASS/FAIL lines. Exit 1 on any FAIL.
+
+Every check names the dump it read. The measurements that matter for #113
+are printed even when they pass, so a reviewer sees the computed colours
+rather than a green word.
+"""
+import json, os, re, sys
+
+dumps_dir, log, src = sys.argv[1:4]
+fails = 0
+
+
+def load(name):
+    with open(os.path.join(dumps_dir, name + '.json')) as f:
+        return json.load(f)
+
+
+def check(cond, what):
+    global fails
+    print(('   ok   ' if cond else '!! FAIL ') + what)
+    if not cond:
+        fails += 1
+
+
+t0 = load('t0_no_service')
+check(t0['target_loaded'], 't0: gnome-speaks extension loaded in the headless shell')
+check(t0['notify_is_function'], 't0: Main.notify is a function on this shell')
+check(t0['state'] == 'unavailable', f"t0: no service on the bus -> state {t0['state']!r} (baseline main: 'idle')")
+check('gnome-speaks-unavailable' in t0['badge']['classes'].split(), f"t0: badge classes {t0['badge']['classes']!r}")
+check('gnome-speaks-idle' not in t0['badge']['classes'].split(), 't0: idle class NOT also present')
+check(t0['badge']['accessible_name'].startswith('GNOME Speaks service not running'),
+      f"t0: accessible name {t0['badge']['accessible_name']!r}")
+check(t0['icon']['name'] == 'microphone-disabled-symbolic', f"t0: icon {t0['icon']['name']!r}")
+check(t0['label']['visible'] is False, 't0: label hidden while not hovered/focused (compact)')
+check(t0['menu']['service'] and 'not running' in t0['menu']['service']['text'] and t0['menu']['service']['sensitive'],
+      f"t0: menu service row {t0['menu']['service']!r}")
+check(t0['menu']['listen']['sensitive'] is False and t0['menu']['stop']['sensitive'] is False,
+      't0: Start Listening / Stop rows insensitive')
+check(t0['panel_icon']['name'] == 'microphone-disabled-symbolic' and 'gnome-speaks-panel-unavailable' in t0['panel_icon']['classes'],
+      f"t0: panel icon {t0['panel_icon']!r}")
+print(f"        measured t0: badge bg={t0['badge']['bg']} border={t0['badge']['border']} pad={t0['badge']['padding_left']} "
+      f"icon={t0['icon']['color']}@{t0['icon']['size']} panel={t0['panel_icon']['color']}")
+
+t1 = load('t1_stub_listening')
+check(t1['state'] == 'listening', f"t1: stub owns the name + StateChanged -> {t1['state']!r}")
+check('gnome-speaks-unavailable' not in t1['badge']['classes'].split(), 't1: unavailable class removed')
+check(all(t1.get('pills_visible', [])), f"t1: pills shown while listening {t1.get('pills_visible')}")
+check(t1['menu']['service']['text'] == 'Service: running' and t1['menu']['service']['sensitive'] is False,
+      f"t1: menu service row {t1['menu']['service']!r}")
+
+t2 = load('t2_stub_gone')
+check(t2['state'] == 'unavailable', f"t2: name vanished mid-listen -> {t2['state']!r}")
+check(not any(t2.get('pills_visible', [])), f"t2: pills hidden again {t2.get('pills_visible')}")
+check('gnome-speaks-listening' not in t2['badge']['classes'].split(), 't2: listening class removed')
+check(t2['label']['visible'] is False, 't2: label hidden')
+
+t3 = load('t3_hover')
+check(t3['badge']['hover'] is True, 't3: hover set')
+check(t3['label']['visible'] is True and t3['label']['text'].startswith('Service not running'),
+      f"t3: hover reveals tooltip label {t3['label']['text']!r}")
+print(f"        measured t3 (hover): bg={t3['badge']['bg']} border={t3['badge']['border']} icon={t3['icon']['color']} label={t3['label']['color']}")
+check(t3['badge']['border'] != t0['badge']['border'], 't3: hover ring differs from rest (rule applies)')
+check(t3['icon']['color'] != t0['icon']['color'], 't3: hover icon tint differs from rest')
+
+t4 = load('t4_unhover')
+check(t4['label']['visible'] is False, 't4: unhover hides the label again')
+
+t5 = load('t5_focus')
+check(t5['badge']['has_key_focus'] is True, 't5: badge has key focus')
+check(t5['label']['visible'] is True, 't5: keyboard focus reveals the label (a11y parity)')
+print(f"        measured t5 (focus): border={t5['badge']['border']} icon={t5['icon']['color']}")
+check(t5['badge']['border'] == t3['badge']['border'], 't5: :focus ring == :hover ring')
+t6 = load('t6_unfocus')
+check(t6['label']['visible'] is False, 't6: focus out hides the label')
+
+t7 = load('t7_tap_pending')
+check(t7['service_start_pending'] is True, 't7: tap -> start pending')
+check(t7['label']['visible'] is True and 'Starting' in t7['label']['text'], f"t7: label {t7['label']['text']!r}")
+check('starting' in t7['menu']['service']['text'].lower() and t7['menu']['service']['sensitive'] is False,
+      f"t7: menu row while starting {t7['menu']['service']!r}")
+
+t8 = load('t8_tap_failed')
+check(t8['service_start_pending'] is False, 't8: systemctl (sandboxed) failed -> pending cleared')
+check(t8['state'] == 'unavailable', 't8: still unavailable')
+toasts = [n for n in t8.get('notifications', []) if 'Could not start gnome-speaks.service' in (n.get('body') or '')]
+check(len(toasts) == 1, f"t8: exactly one failure toast: {toasts!r}")
+check(t8['label']['visible'] is False, 't8: label hidden again after failure (not hovered)')
+
+t9 = load('t9_hotkey')
+toasts9 = [n for n in t9.get('notifications', []) if 'Could not start gnome-speaks.service' in (n.get('body') or '')]
+check(len(toasts9) == 2, f"t9: hotkey seam (StartListening) attempted a start too -> {len(toasts9)} failure toasts")
+t10 = load('t10_other_method')
+other = [n for n in t10.get('notifications', []) if 'not running' in (n.get('body') or '') and 'tap the badge' in n['body']]
+check(len(other) == 1, f"t10: non-listen method while unavailable -> explanatory toast {other!r}")
+
+t11 = load('t11_stub_idle')
+check(t11['state'] == 'idle', f"t11: service back -> {t11['state']!r}")
+check('gnome-speaks-idle' in t11['badge']['classes'].split() and 'gnome-speaks-unavailable' not in t11['badge']['classes'].split(),
+      f"t11: classes {t11['badge']['classes']!r}")
+check(t11['icon']['name'] == 'audio-input-microphone-symbolic', 't11: mic icon restored')
+check(t11['menu']['service']['text'] == 'Service: running', 't11: menu row running')
+print(f"        measured t11 (idle): bg={t11['badge']['bg']} border={t11['badge']['border']} icon={t11['icon']['color']}")
+check(t11['badge']['bg'] != t0['badge']['bg'], 't11: idle glass != unavailable glass (state is visually distinct)')
+
+t12 = load('t12_gone_again')
+check(t12['state'] == 'unavailable', 't12: second vanish -> unavailable')
+t13 = load('t13_reenabled')
+check(t13['target_loaded'] and t13['state'] == 'unavailable', f"t13: disable/enable clean, state {t13['state']!r}")
+
+# ---- shell log: zero gnome-speaks JS errors / CRITICALs / St warnings ----
+with open(log, errors='replace') as f:
+    lines = f.readlines()
+bad = [l.rstrip() for l in lines if re.search(r'JS ERROR|CRITICAL|Ignoring excess|St-WARNING|Clutter-CRITICAL', l)
+       and re.search(r'gnome-speaks|speaks-probe|extension\.js', l)]
+check(not bad, f"shell log: {len(bad)} gnome-speaks error/critical/St-warning lines")
+for l in bad[:20]:
+    print('        ' + l)
+# Control: the log must show the extension actually enabling, or "zero
+# errors" is the zero of an instrument that saw nothing.
+loaded = any('gnome-speaks' in l for l in lines)
+print(f"        control: shell.log has {sum('gnome-speaks' in l for l in lines)} lines mentioning gnome-speaks ({len(lines)} total)")
+
+print(f"\n{'!! FAIL' if fails else 'PASS'}: {fails} failing check(s)")
+sys.exit(1 if fails else 0)


### PR DESCRIPTION
Closes #113

## What

When `org.gnome.Speaks` vanishes from the bus the badge used to reset silently to idle: a tap did nothing and every D-Bus error logged at debug. Now the extension has a distinct **service unavailable** state:

- **Badge**: struck mic (`microphone-disabled-symbolic`), dimmed glass, no ring. Accessible name `GNOME Speaks service not running — activate to start it`. The label doubles as the **tooltip** — revealed on hover **and** on keyboard focus (`Service not running — tap to start`), hidden otherwise so the badge stays as compact as idle. Hover/focus borrow the "trouble" ember at low opacity.
- **Entered** from the name-vanished watch (GLib fires it immediately when the name has no owner at watch time, so a login with the service down lands here too) and from both proxy-creation failure paths. **Left** on name-appeared (optimistic idle, corrected by the `GetState` reply).
- **Tap / Enter / Space / the dictation hotkey** run `systemctl --user start gnome-speaks.service` through a new async `Gio.Subprocess` + `communicate_utf8_async` seam — the extension had no subprocess seam before (it does no I/O), so this is the first and only one; the shell's main loop never waits on it. Success is *the bus name appearing*, not exit 0; a unit that exits 0 and never claims the name is reported after 10 s. Failure gets **one** `Main.notify` toast carrying systemctl's first stderr line. Any other method invoked while unavailable (Speak Clipboard, etc.) gets an explanatory toast instead of a red flash.
- **Panel menu**: a `Service: running` (insensitive info row) / `Service: not running — activate to start` (actionable) / `Service: starting…` row, first in the menu. Start Listening / Stop are insensitive while unavailable; the panel icon takes the struck mic.

CLAUDE.md gotchas honoured: every programmatic switch write still goes through `_setSwitchQuietly` (no new switch writes were added); `console.*` only; one `box-shadow` per rule; labels addressed by NAME (`.gnome-speaks-unavailable .gnome-speaks-badge-label`), no `StLabel` type selectors.

> ⚠️ **extension.js / stylesheet.css changes activate at next login** (Wayland). Nothing here restarts the service or the shell.

## Verified

**Measured, not reasoned** — second commit adds `tests/repros/shell-rig/`, a real `gnome-shell --headless` on a private bus with no service activation, plus a rig-only probe extension that reads the badge from *inside* the shell (computed `St.ThemeNode` colours, accessible name, label visibility, menu rows, `Main.notify` output) and a stub that owns `org.gnome.Speaks` on the sandbox bus.

- This branch: **47/47 PASS**, zero gnome-speaks `JS ERROR` / `CRITICAL` / St-warning lines across enable → vanish → appear(listening) → vanish → hover → focus → tap → hotkey seam → appear(idle) → vanish → disable → re-enable.
- Baseline `3c70314` (main before this): **fails t0, 8 checks** — state `idle`, no service row. The rig discriminates.
- Measured colours (badge): unavailable rest `bg #10121a85 / border #ffffff0c / icon #ffffff57@18px`; hover & focus (identical) `border #ff606061 / icon #ff9696e6 / label #ffd6d6dc`; idle for contrast `bg #10121aa8 / border #ffffff11 / icon #ffffff8c`.
- The tap in the rig runs the **real** `systemctl --user start` against a sandboxed `XDG_RUNTIME_DIR`; a control proves before the shell starts that it cannot reach a user manager (`Failed to connect to user scope bus via local transport`), so the rig can never start/stop the real unit — and that failure is exactly the toast path under test. `TapAndDump` reads the pending "Starting…" state in one main-loop turn because the sandboxed spawn fails in <300 ms.
- `tests/repros/run_all.sh` (bare): **62 checks: 62 pass, ALL SUITES GREEN**. `python3 verify_wake_gate.py`: all passed. `node --check extension.js` clean. Leak scan (`<lan-host>|<wake-word>|<lan-ip>|<site-domain>|~`) = 0 in the branch diff and in every touched file.

## Not verified

- **Not run on the live shell** (worktree; extension changes activate at next login). The headless shell has no real pointer — hover is driven via `St.Widget.hover`, focus via `grab_key_focus()`, the tap via the same `_onBadgeClicked()` the release handler calls. A real click-through was not exercised.
- **The success path of the start** (name appears *after* `systemctl` exits 0, pending cleared by the watch) is exercised only indirectly: the stub returning to the bus covers "state leaves UNAVAILABLE and clears pending"; a real `systemctl` success was impossible in the sandbox by design.
- The rig is not collected by `run_all.sh` (needs `gnome-shell`, ~15 s startup) — documented in `tests/repros/README.md` and CLAUDE.md item 5.
- Out of scope, left for a follow-up: the issue's `GET /status`-style `· local speech · IBus` detail on the menu row (the row is `running / not running / starting…` only).
