### PR TITLE
perf(ibus): derive the restore target once per bus and layout, not per utterance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,17 @@ Synchronous fallback: cloud-chat-assistant, Bedrock
   (`$XDG_RUNTIME_DIR/gnome-speaks/prior-engine` written *before* the swap, restore-on-start,
   `ExecStopPost=… --restore-ime`, and a session watchdog). Do not treat any of them as optional,
   and keep `restore_prior_engine()` dependency-free — it must run with no config and no instance.
+- **The IBus restore target is derived once per bus and layout, not per utterance** (#136): on GNOME
+  `GetGlobalEngine` answers empty on EVERY acquire (the shell owns input sources), so
+  `derive_restore_target()` is the normal path, and `bus.list_engines()` inside it deserialised 974
+  `EngineDesc`s (23 ms, serial with the first keystroke) per utterance, plus one `IBUS-WARNING` per
+  empty reply. `_EngineNameMemo` remembers the (layout, variant) → engine name per bus object (a
+  reconnect or `restore_prior_engine()`'s startup probe starts cold; a miss is never stored), and
+  `acquire()` stops asking `GetGlobalEngine` after one empty answer on that bus. The input-sources
+  read is deliberately NOT cached — it is the authority, it costs ~0.5 ms, and re-reading it is what
+  makes a layout switch land on the next utterance without a `changed` signal (which would need a
+  main loop on the thread that created the GSettings object; the STT worker has none).
+  `tests/repros/injector-seam/repro_derive_cache.py` counts both calls.
 - **The cancel wire is not the cancel verdict**: `state._cancel_event` (speech-to-cli) is a single
   process-global bit shared by every STT and TTS call. It can *interrupt* an operation, but it can
   never say **which** one was cancelled, and the next operation's `CancelRegistry.begin()`

--- a/ibus_injector.py
+++ b/ibus_injector.py
@@ -37,6 +37,7 @@ import logging
 import os
 import threading
 import time
+import weakref
 
 from injector import Injector
 
@@ -123,6 +124,74 @@ def clear_prior_engine():
 INPUT_SOURCES_SCHEMA = "org.gnome.desktop.input-sources"
 
 
+class _EngineNameMemo:
+    """Remember what the daemon calls an XKB layout, per bus (#136).
+
+    On GNOME `derive_restore_target()` runs on EVERY utterance -- the shell
+    owns input sources and leaves the daemon's global engine unset, so the
+    "fallback" is the normal path -- and 23 ms of it was `list_engines()`:
+    deserialising every EngineDesc the daemon knows (974 on the desk it was
+    measured on) to find one name. That answer depends on nothing but the
+    daemon's engine list, so it is memoised per (layout, variant) for the
+    lifetime of the bus object it was asked of. A different bus -- a
+    reconnect, or the probe `restore_prior_engine()` opens at startup --
+    starts from nothing, so the dependency-free path is never handed a name
+    learned over some other connection.
+
+    Only a FOUND name is stored. A miss is asked again next time, so a layout
+    the daemon does not (yet) know is never shadowed by a remembered "no".
+
+    Deliberately NOT cached: the input-sources read that decides WHICH layout
+    to look up. It is the authority the shell itself writes, it costs ~0.5 ms,
+    and re-reading it per call is what makes a layout switch take effect on
+    the very next utterance -- with no `changed` signal to plumb and no main
+    loop for that signal to depend on (a GSettings object created on the STT
+    worker thread would deliver its signals to a main context nothing
+    iterates, and `restore_prior_engine()` runs before the loop exists).
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._bus_ref = None      # weakref to the bus these names came from
+        self._bus_strong = None   # only for a bus that cannot be weakly referenced
+        self._names = {}
+
+    def _same_bus(self, bus):
+        if self._bus_ref is not None:
+            return self._bus_ref() is bus
+        return self._bus_strong is not None and self._bus_strong is bus
+
+    def _bind(self, bus):
+        self._names = {}
+        self._bus_ref = self._bus_strong = None
+        try:
+            self._bus_ref = weakref.ref(bus)
+        except TypeError:
+            self._bus_strong = bus
+
+    def get(self, bus, layout, variant):
+        with self._lock:
+            if not self._same_bus(bus):
+                return None
+            return self._names.get((layout, variant))
+
+    def put(self, bus, layout, variant, name):
+        if not name:
+            return                      # never remember a miss
+        with self._lock:
+            if not self._same_bus(bus):
+                self._bind(bus)
+            self._names[(layout, variant)] = name
+
+    def reset(self):
+        with self._lock:
+            self._names = {}
+            self._bus_ref = self._bus_strong = None
+
+
+_ENGINE_NAMES = _EngineNameMemo()
+
+
 def _xkb_engine_for(bus, layout, variant):
     """Find the daemon's engine name for an XKB layout/variant pair.
 
@@ -131,7 +200,12 @@ def _xkb_engine_for(bus, layout, variant):
     `...:eng`. So ask the daemon what it actually has rather than constructing
     a name it may not know; setting a nonexistent engine is how you end up
     exactly where this function is trying to rescue you from.
+
+    Asked once per (bus, layout, variant); see `_EngineNameMemo`.
     """
+    cached = _ENGINE_NAMES.get(bus, layout, variant)
+    if cached:
+        return cached
     prefix = "xkb:%s:%s:" % (layout, variant)
     try:
         matches = sorted(e.get_name() for e in bus.list_engines()
@@ -141,18 +215,26 @@ def _xkb_engine_for(bus, layout, variant):
         matches = []
     if not matches:
         return None
+    chosen = None
     if len(matches) == 1:
-        return matches[0]
-    # Several languages share this layout; prefer the session's own.
-    lang = (os.environ.get("LANG") or "")[:2].lower()
-    if lang:
-        for name in matches:
-            if name.rsplit(":", 1)[-1].lower().startswith(lang[:2]):
-                return name
-    for name in matches:
-        if name.endswith(":eng"):
-            return name
-    return matches[0]
+        chosen = matches[0]
+    else:
+        # Several languages share this layout; prefer the session's own.
+        lang = (os.environ.get("LANG") or "")[:2].lower()
+        if lang:
+            for name in matches:
+                if name.rsplit(":", 1)[-1].lower().startswith(lang[:2]):
+                    chosen = name
+                    break
+        if chosen is None:
+            for name in matches:
+                if name.endswith(":eng"):
+                    chosen = name
+                    break
+        if chosen is None:
+            chosen = matches[0]
+    _ENGINE_NAMES.put(bus, layout, variant, chosen)
+    return chosen
 
 
 def derive_restore_target(bus=None):
@@ -482,6 +564,10 @@ class IbusInjector(Injector):
         self._lock = threading.RLock()
         self._prior = None
         self._active = False
+        # GetGlobalEngine answered "no global engine" on this bus. On GNOME
+        # that is the steady state, not a transient, and every further ask is
+        # a D-Bus round trip plus one IBUS-WARNING in the journal (#136).
+        self._global_engine_unset = False
         self._coalescer = _Coalescer()
         # Why the last acquire() said no: None | "secure" | "no_target" |
         # "unavailable". commit() falls back to ydotool for every reason but
@@ -525,6 +611,7 @@ class IbusInjector(Injector):
                     return False
                 self._factory = SpeaksFactory(bus, self._on_engine_created)
                 self._bus = bus
+                self._global_engine_unset = False   # a new bus gets asked afresh
                 self._registered = True
                 log.info("IBus component registered (engine %s, layout %s)",
                          ENGINE_NAME, ENGINE_LAYOUT)
@@ -586,16 +673,26 @@ class IbusInjector(Injector):
             if self._active:
                 return not self._is_secure()
             self._refusal = None
-            try:
-                prior = self._bus.get_global_engine()
-                prior_name = prior.get_name() if prior else None
-            except Exception:
-                # "No global engine" is the COMMON case on GNOME, not an
-                # error: the shell owns input sources and often leaves the
-                # daemon's global engine unset. Not a reason to give up on
-                # having somewhere to go back to.
-                log.debug("GetGlobalEngine unavailable", exc_info=True)
-                prior_name = None
+            prior_name = None
+            if not self._global_engine_unset:
+                try:
+                    prior = self._bus.get_global_engine()
+                    prior_name = prior.get_name() if prior else None
+                except Exception:
+                    # "No global engine" is the COMMON case on GNOME, not an
+                    # error: the shell owns input sources and often leaves
+                    # the daemon's global engine unset. Not a reason to give
+                    # up on having somewhere to go back to.
+                    log.debug("GetGlobalEngine unavailable", exc_info=True)
+                    prior_name = None
+                if not prior_name:
+                    # Asked, and the daemon has none. Do not ask again on this
+                    # bus: the answer comes from input-sources below either
+                    # way, and libibus g_warning()s on every empty reply --
+                    # one journal line per utterance before #136. A layout
+                    # switch still lands, because the input-sources read in
+                    # derive_restore_target() is not cached.
+                    self._global_engine_unset = True
             if prior_name == ENGINE_NAME:
                 prior_name = None  # never record ourselves as the way back
             if not prior_name:

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -68,6 +68,7 @@ tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
 | `chronicle-perf` | #22 / #27 | `6a1ecae` | derived (`merge^1`), not re-run |
 | `chronicle-perf/repro_audio_info_stall` | #135 | `025df92` | **verified** — 319 ms stall, probe on MainThread |
 | `injector-seam` | #24 | `ea47ff1` | derived (`merge^1`), not re-run |
+| `injector-seam/repro_derive_cache` | #136 | `a20afea` | **verified** — 6 fail: 5 acquires issue 5 `list_engines()` + 5 `GetGlobalEngine` (fixed: 1 + 1; a layout switch costs one more `list_engines()`, switching back costs none); the restore/breadcrumb/no-negative-cache/per-bus checks stay green on both sides |
 | `cancel-tokens` | #21 / #33 | `66edc79` | **verified** — 4 of 5 fail |
 | `cancel-tokens` `repro_e` | #132 | `025df92` | **verified** — E1, E3 fail; E2 stays green on both sides |
 | `cancel-tokens` `repro_f` | #132 / PR #146 review | `fd5c8cd` (PR head before revision), `0e014cc` | **verified** — F1 43/126 and 51/300 dictations hit, F2 1/1; 0/101 and clean with the fix. F1 lowers `sys.setswitchinterval` (GS_RACE_SWITCH, default 1e-5) — at CPython's 5 ms default it scored 0/300 on the unfixed tree |

--- a/tests/repros/injector-seam/repro_derive_cache.py
+++ b/tests/repros/injector-seam/repro_derive_cache.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Repro for #136: acquire() re-derived the IBus restore target every utterance.
+
+On GNOME the shell owns input sources and leaves the daemon's global engine
+unset, so `GetGlobalEngine` answers empty on EVERY acquire and the "fallback"
+`derive_restore_target()` is the normal path. Two costs rode along on each
+utterance, serial with the first keystroke:
+
+  * `bus.list_engines()` -- a synchronous D-Bus call that deserialises every
+    EngineDesc the daemon knows (974 on the desk it was measured on, 23 ms)
+    to find one name that never changes while the daemon is up;
+  * one `IBUS-WARNING ... No global engine` in the journal per utterance,
+    because libibus g_warning()s on the failed GetGlobalEngine.
+
+This script counts both against a fake bus across N acquire/end cycles, then
+changes the simulated input-sources setting and checks the cache notices --
+and that a miss is never remembered. Exit 0 = fixed, 1 = the defect is
+present, 2 = the check could not run.
+
+No real daemon, no SetGlobalEngine, XDG_RUNTIME_DIR redirected (the real
+breadcrumb is never read or written).
+"""
+
+import atexit
+import os
+import shutil
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+SVC_DEFAULT = os.path.join(REPO_ROOT, "gnome-speaks-service.py")
+SCRATCH_ROOT = os.path.join(REPO_ROOT, "tmp", "repros")
+
+SVC_PATH = os.environ.get("GS_SVC_PATH", SVC_DEFAULT)
+WT = os.environ.get("GS_WT") or os.path.dirname(os.path.abspath(SVC_PATH))
+RUNTIME = os.path.join(SCRATCH_ROOT, f"derive-cache-{os.getpid()}", "runtime")
+shutil.rmtree(RUNTIME, ignore_errors=True)
+os.makedirs(RUNTIME, exist_ok=True)
+os.environ["XDG_RUNTIME_DIR"] = RUNTIME          # never the real breadcrumb
+atexit.register(shutil.rmtree, os.path.dirname(RUNTIME), True)
+sys.path.insert(0, WT)
+
+try:
+    import ibus_injector as ib  # noqa: E402
+    from ibus_injector import IbusInjector  # noqa: E402
+except Exception as exc:  # pragma: no cover - setup, not the defect
+    print(f"!! SETUP FAILURE: cannot import ibus_injector from {WT}: {exc}")
+    sys.exit(2)
+
+if not ib.prior_engine_path().startswith(RUNTIME):
+    print(f"!! SETUP FAILURE: breadcrumb path escaped the sandbox: "
+          f"{ib.prior_engine_path()}")
+    sys.exit(2)
+
+FAILS = []
+
+
+def check(label, cond, detail=""):
+    if cond:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}  <- {detail}")
+        FAILS.append(label)
+
+
+# ---- fakes -----------------------------------------------------------------
+
+class FakeEngineDesc:
+    def __init__(self, name):
+        self._name = name
+
+    def get_name(self):
+        return self._name
+
+
+class CountingBus:
+    """GNOME's shape: no global engine, ever. Counts what it is asked."""
+
+    def __init__(self, engines):
+        self.engines = list(engines)
+        self.current = None
+        self.swaps = []
+        self.n_get_global = 0
+        self.n_list = 0
+
+    def is_connected(self):
+        return True
+
+    def get_global_engine(self):
+        self.n_get_global += 1
+        return None                      # libibus: NULL + an IBUS-WARNING
+
+    def set_global_engine(self, name):
+        self.swaps.append(name)
+        self.current = name
+        return True
+
+    def list_engines(self):
+        self.n_list += 1
+        return [FakeEngineDesc(n) for n in self.engines]
+
+
+class FakeSettings:
+    def __init__(self, mru, sources):
+        self._v = {"mru-sources": mru, "sources": sources}
+
+    def get_value(self, key):
+        class V:
+            def __init__(self, val):
+                self._val = val
+
+            def unpack(self):
+                return self._val
+        return V(self._v[key])
+
+
+class GioShim:
+    settings = None
+    n_new = 0
+
+    class Settings:
+        @staticmethod
+        def new(schema):
+            GioShim.n_new += 1
+            return GioShim.settings
+
+
+class FakeEngine:
+    """Same shape as verify_ibus_injector.FakeEngine: a focused, ordinary field."""
+
+    def __init__(self):
+        self.purpose = 0
+        self.focused = True
+        self.client = "gedit"
+        self.commits = []
+        self.preedits = []
+        self.cleared = 0
+
+    def is_secure(self):
+        return self.purpose in ib._SECURE_PURPOSES
+
+    def set_preedit(self, text):
+        if text:
+            self.preedits.append(text)
+        else:
+            self.clear_preedit()
+
+    def clear_preedit(self):
+        self.cleared += 1
+
+    def commit(self, text):
+        self.commits.append(text)
+        return True
+
+
+class FakeFallback:
+    name = "ydotool"
+
+    def prepare(self):
+        pass
+
+    def commit(self, text):
+        return True
+
+    def press_enter(self):
+        return True
+
+    def recover(self):
+        pass
+
+    def end(self):
+        pass
+
+    def cancel(self):
+        pass
+
+
+def wired(bus):
+    inj = IbusInjector(fallback=FakeFallback())
+    inj._bus = bus
+    inj._engine = FakeEngine()
+    inj._registered = True
+    return inj
+
+
+ENGINES = ["xkb:us::eng", "xkb:us:dvorak:eng", "xkb:de:neo:deu", "xkb:de:neo:eng"]
+
+
+def main():
+    print(f"XDG_RUNTIME_DIR redirected to {RUNTIME}")
+    print(f"ibus_injector from {WT}\n")
+
+    real_gio = getattr(ib, "Gio", None)
+    ib.Gio = GioShim
+    try:
+        # -- [1] N utterances, inputs unchanged ------------------------------
+        print("[1] N acquire/end cycles with input-sources unchanged")
+        N = 5
+        GioShim.settings = FakeSettings([], [("xkb", "us")])
+        bus = CountingBus(ENGINES)
+        inj = wired(bus)
+        crumbs = []
+        for _ in range(N):
+            ok = inj.acquire()
+            crumbs.append(ib.read_prior_engine())
+            inj.end()
+            if not ok:
+                break
+        print(f"  measured: acquires={N} list_engines={bus.n_list} "
+              f"get_global_engine={bus.n_get_global} Settings.new={GioShim.n_new}")
+        check("every acquire still succeeded", ok is True)
+        check("breadcrumb was the derived target on every cycle",
+              crumbs == ["xkb:us::eng"] * N, crumbs)
+        check("every cycle restored to the derived target",
+              bus.swaps == [ib.ENGINE_NAME, "xkb:us::eng"] * N, bus.swaps)
+        check("breadcrumb cleared after the last restore",
+              ib.read_prior_engine() is None)
+        check(f"list_engines() issued once for {N} utterances (was {N})",
+              bus.n_list == 1, f"n_list={bus.n_list}")
+        check(f"GetGlobalEngine asked once for {N} utterances (was {N}: "
+              "one IBUS-WARNING per utterance)",
+              bus.n_get_global == 1, f"n_get_global={bus.n_get_global}")
+
+        # -- [2] the user switches layout -------------------------------------
+        print("\n[2] input-sources changes between utterances")
+        GioShim.settings = FakeSettings([("xkb", "us+dvorak")], [("xkb", "us")])
+        inj.acquire()
+        crumb = ib.read_prior_engine()
+        inj.end()
+        check("next utterance restores to the NEW layout",
+              crumb == "xkb:us:dvorak:eng" and bus.swaps[-1] == "xkb:us:dvorak:eng",
+              f"crumb={crumb} last_swap={bus.swaps[-1]}")
+        check("list_engines() issued a second time for the new layout",
+              bus.n_list == 2, f"n_list={bus.n_list}")
+        check("the change did NOT re-trigger GetGlobalEngine (still empty on GNOME)",
+              bus.n_get_global == 1, f"n_get_global={bus.n_get_global}")
+
+        GioShim.settings = FakeSettings([], [("xkb", "us")])
+        inj.acquire()
+        crumb = ib.read_prior_engine()
+        inj.end()
+        check("switching back restores the ORIGINAL layout",
+              crumb == "xkb:us::eng", crumb)
+        check("...from memory, without a third list_engines()",
+              bus.n_list == 2, f"n_list={bus.n_list}")
+
+        # -- [3] never cache a miss --------------------------------------------
+        print("\n[3] a miss is not remembered")
+        GioShim.settings = FakeSettings([], [("xkb", "zz")])
+        before = bus.n_list
+        first = ib.derive_restore_target(bus)
+        second = ib.derive_restore_target(bus)
+        check("unknown layout still yields the unverified guess",
+              first == second == "xkb:zz::eng", (first, second))
+        check("...and the daemon is re-asked next time (no negative cache)",
+              bus.n_list == before + 2, f"n_list={bus.n_list} before={before}")
+
+        GioShim.settings = FakeSettings([], [])
+        check("no configured sources -> None, uncached",
+              ib.derive_restore_target(bus) is None)
+        GioShim.settings = FakeSettings([], [("xkb", "us")])
+        before = bus.n_list
+        check("a valid setting right after a None derives from memory",
+              ib.derive_restore_target(bus) == "xkb:us::eng" and bus.n_list == before,
+              f"n_list={bus.n_list}")
+
+        # -- [4] a different bus starts cold -----------------------------------
+        print("\n[4] the cache is per bus (reconnect / startup probe)")
+        probe = CountingBus(ENGINES)
+        name = ib.derive_restore_target(probe)
+        check("a fresh bus is asked itself, not served another bus's memory",
+              name == "xkb:us::eng" and probe.n_list == 1,
+              f"name={name} probe.n_list={probe.n_list}")
+        probe_de = CountingBus(["xkb:de:neo:deu"])
+        GioShim.settings = FakeSettings([], [("xkb", "de+neo")])
+        check("...and gets ITS daemon's answer (de+neo -> :deu here)",
+              ib.derive_restore_target(probe_de) == "xkb:de:neo:deu")
+
+        # -- [5] restore_prior_engine() stays dependency-free ------------------
+        print("\n[5] restore_prior_engine() still needs no config and no instance")
+        src = open(os.path.join(WT, "ibus_injector.py"), encoding="utf-8").read()
+        for tok in ("CONFIG", "load_config", "import state", "gnome_speaks_service"):
+            check(f"ibus_injector.py does not reference {tok!r}",
+                  tok not in src)
+        check("restore_prior_engine() is callable with no arguments",
+              callable(getattr(ib, "restore_prior_engine", None)))
+
+        # -- [6] the live session was never touched ----------------------------
+        print("\n[6] live session untouched")
+        check("no real prior-engine file outside the redirected runtime dir",
+              ib.prior_engine_path().startswith(RUNTIME), ib.prior_engine_path())
+    finally:
+        if real_gio is not None:
+            ib.Gio = real_gio
+
+    print()
+    if FAILS:
+        print(f"FAIL: {len(FAILS)} check(s) red -- #136 restore-target re-derivation")
+        for f in FAILS:
+            print(f"  - {f}")
+        return 1
+    print("PASS: restore target derived once per bus/layout, "
+          "input-sources changes still honoured, misses never cached")
+    return 0
+
+
+if __name__ == "__main__":
+    # A harness crash is NOT "the defect is present": exit 3 so the runner
+    # labels it HARNESS INCOMPLETE instead of counting a red it never measured.
+    try:
+        sys.exit(main())
+    except SystemExit:
+        raise
+    except Exception:  # pragma: no cover
+        import traceback
+        traceback.print_exc()
+        print("!! HARNESS DID NOT COMPLETE")
+        sys.exit(3)

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -128,7 +128,8 @@ run dead-recorder  repro_e_single_shot_turn_end.py repro_f_text_survives_yank.py
                    repro_i_healthy_loop.py
 run pin-lifecycle  repro_pin_lifecycle.py repro_compound_pin_x_deadmic.py \
                    repro_compound_reply_pin.py
-run injector-seam  verify_injector_seam.py verify_ibus_injector.py repro_fallback_retry.py repro_fake_context_fallback.py
+run injector-seam  verify_injector_seam.py verify_ibus_injector.py repro_fallback_retry.py repro_fake_context_fallback.py \
+                   repro_derive_cache.py
 run version-cache  verify_version_cache.py repro_a_fork_storm.py
 run spellbook      verify_spellbook.py
 # Static: prefs.js keys vs speech-to-cli's load_config() whitelist vs


### PR DESCRIPTION
Closes #136

## Root cause

On GNOME the shell owns input sources and leaves the daemon's global engine unset, so `GetGlobalEngine` answers empty on **every** `acquire()` and the "fallback" `derive_restore_target()` is the normal path. Two costs rode along on each utterance, serial with the first keystroke:

- `bus.list_engines()` deserialising every `EngineDesc` the daemon knows (974 on the desk it was measured on, 23 ms) to find one name that never changes while the daemon is up;
- one `IBUS-WARNING … No global engine` in the journal per utterance — libibus `g_warning()`s on each empty reply.

`_restore()` repeated the derivation whenever `_prior` was None.

## Fix (`ibus_injector.py`)

1. **`_EngineNameMemo`** — `(layout, variant) → engine name`, bound to one bus object by `weakref`. A different bus (reconnect, or the probe `restore_prior_engine()` opens at startup) starts cold, so the dependency-free path is never handed a name learned over another connection. **Only a found name is stored** — a miss (unknown layout → unverified guess) re-asks the daemon next time.
2. **`acquire()` stops asking `GetGlobalEngine` after one empty answer on the current bus** (`_global_engine_unset`, reset when `_bus` is assigned). A non-empty first answer is used verbatim, as before.

**Deliberately NOT cached: the `Gio.Settings` input-sources read** (~0.5 ms). It is the authority the shell writes, and re-reading it per call *is* the invalidation — a layout switch lands on the next utterance. I chose this over a `changed`-signal cache because GSettings delivers `changed` to the main context of the thread that created the object: created on the STT worker (which iterates no loop) the signal would never arrive and the restore would silently go to the *old* layout; and `restore_prior_engine()` runs before any loop exists. The issue's other alternative — re-derive only when `GetGlobalEngine` returns a differing non-empty value — cannot invalidate on a GSettings change while `GetGlobalEngine` stays empty, which is the GNOME steady state.

`restore_prior_engine()` is untouched: no config, no instance (the repro greps for it).

## Measured (fake bus, `tests/repros/injector-seam/repro_derive_cache.py`)

| | acquires | `list_engines()` | `GetGlobalEngine` |
|---|---|---|---|
| merge base `a20afea` | 5 | 5 | 5 |
| this PR | 5 | **1** | **1** |
| + layout switch us → us+dvorak | 6 | 2 | 1 |
| + switch back to us | 7 | 2 (memo hit) | 1 |

- Repro against the merge base (`git archive a20afea`): **exit 1, 6 red** — exactly the caching checks; the restore / breadcrumb / no-negative-cache / per-bus checks are green on both sides. A harness crash exits 3, not 1.
- Registered in `run_all.sh`; README baseline row added; one CLAUDE.md gotcha.

## Gates (bare, on the rebased head)

- `tests/repros/run_all.sh` → **66 checks: 66 pass** (main is 65; +1 is this repro). All existing IBus checks green incl. breadcrumb and crash-restore paths.
- `python3 verify_wake_gate.py` → all checks passed
- `py_compile` service + injector OK
- leak scan (the roster's five-term pattern: LAN hostnames, LAN subnet, site domain, home path) on the commit = 0
- No live touch: no `SetGlobalEngine`, no real daemon, `XDG_RUNTIME_DIR` redirected per PID; `weakref`-ability verified on a plain `GObject.Object()`, not on a real `IBus.Bus`.

## Hedges

- 23 ms/utterance is small next to `FOCUS_WAIT = 0.4 s`; the journal noise is the part JP notices (issue author's hedge, carried verbatim). 974 engines is this machine's count.
- After one empty answer, a manual `ibus engine X` that does **not** change input-sources is not seen as the restore target on GNOME; the shell re-asserts its own source anyway, and every shell-driven switch still lands via the uncached read.
- `Gio.Settings.new` per call still subscribes/unsubscribes a dconf watch per utterance — pre-existing, unchanged, measured cheap by the issue author; out of scope.
- Nothing measured against the live daemon (brief forbids it); all counts are on the verifier-style fakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
