### PR TITLE
feat(prefs): warn when Local speech backend has no Wyoming server address

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -351,13 +351,54 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
             icon_name: 'audio-speakers-symbolic',
         });
 
-        // ── Voices ──
+        // ── Speech Backend ──
         const backendGroup = new Adw.PreferencesGroup({title: 'Speech Backend'});
         page.add(backendGroup);
-        this._addComboRow(backendGroup, 'Primary Provider', 'speech_backend', [
+        const backendOptions = [
             ['azure', 'Azure (cloud) — your local Wyoming server only as fallback'],
             ['local', 'Local (Piper / Parakeet on your Wyoming server) — Azure only as fallback'],
-        ], 'azure');
+        ];
+        const backendRow = this._addComboRow(backendGroup, 'Primary Provider',
+            'speech_backend', backendOptions, 'azure');
+        // Name the dependency where the choice is made (#116): the service
+        // honours Local only when wyoming_host is set, and used to say nothing.
+        // Plain text, assigned AFTER construction (same shape as the shortcut
+        // rows): the page is literally "Wake & Spells", and whether a ComboRow
+        // subtitle is parsed as markup differs by libadwaita version --
+        // measured on 1.9 it is NOT, so `&amp;` would show verbatim.
+        backendRow.use_markup = false;
+        backendRow.subtitle = 'Local needs a Wyoming server address (Wake & Spells → Offline Server). ' +
+            'Without one, Azure stays primary';
+
+        // Inline warning for the silent case: Local chosen, no address to
+        // reach. Lives inside the group so a hidden banner costs no space.
+        // Construct-then-assign for the title, and keep it free of '<' / '&':
+        // AdwBanner's markup handling varies by version too.
+        const backendWarn = new Adw.Banner({
+            button_label: 'Set Server Address',
+            revealed: false,
+        });
+        backendWarn.title = 'Local is selected, but no Wyoming server address is set — ' +
+            'Azure stays primary until you add one';
+        backendGroup.add(backendWarn);
+
+        // The address the SERVICE sees is the applied one, so track applies,
+        // not keystrokes: a half-typed hostname must not clear the warning.
+        this._wyomingHostApplied = String(this._config['wyoming_host'] ?? '').trim();
+        this._refreshBackendWarning = () => {
+            const chosen = backendOptions[backendRow.get_selected()]?.[0];
+            backendWarn.revealed = chosen === 'local' && this._wyomingHostApplied === '';
+        };
+        backendRow.connect('notify::selected', () => this._refreshBackendWarning());
+        this._refreshBackendWarning();
+
+        // Jump to the field that fixes it. Focusing the row also scrolls it
+        // into view (GtkViewport scroll-to-focus), so no manual scrolling.
+        backendWarn.connect('button-clicked', () => {
+            if (this._offlineServerPage)
+                window.set_visible_page(this._offlineServerPage);
+            this._wyomingHostRow?.grab_focus();
+        });
 
         const voiceGroup = new Adw.PreferencesGroup({title: 'Voices'});
         page.add(voiceGroup);
@@ -560,8 +601,16 @@ export default class GnomeSpeaksPreferences extends ExtensionPreferences {
         const offlineGroup = new Adw.PreferencesGroup({title: 'Offline Server'});
         page.add(offlineGroup);
 
-        this._addEntryRow(offlineGroup, 'Server Address', 'wyoming_host', '',
+        const hostRow = this._addEntryRow(offlineGroup, 'Server Address', 'wyoming_host', '',
             'LAN hostname or IP of your Wyoming server — speech falls back here when the cloud is unreachable. Empty = off');
+        this._wyomingHostRow = hostRow;
+        this._offlineServerPage = page;
+        // Connected AFTER _addEntryRow's own handler, so the config write has
+        // landed by the time the Speech Backend warning re-reads the address.
+        hostRow.connect('apply', () => {
+            this._wyomingHostApplied = hostRow.get_text().trim();
+            this._refreshBackendWarning?.();
+        });
 
         this._addSpinRow(offlineGroup, 'Voice Port', 'wyoming_tts_port',
             1, 65535, 1, 0, 10200,

--- a/tests/repros/prefs-rig/README.md
+++ b/tests/repros/prefs-rig/README.md
@@ -53,6 +53,36 @@ judge only the delta.
 3. **A row must not lie while loading.** With `speaker_sink` set in config, the
    synchronous snapshot must show that device *selected*, not "System Default".
 
+## The #116 probe — Local without a server address must warn
+
+`run.sh` also runs `probe_backend_warning.js` against the **branch** file, on a
+second rig-owned fixture (`home-local/`: the same pinned keys plus
+`speech_backend=local`, `wyoming_host` deliberately absent). Baseline is
+skipped on purpose — it predates the feature and would be red by construction,
+gating nothing. It asserts on **rendered** label text, never properties:
+
+- the `Primary Provider` subtitle names the dependency and renders;
+- exactly one `Adw.Banner` mentioning the Wyoming address exists, is revealed,
+  renders, and has a button;
+- building the window wrote nothing;
+- provider flips hide/show it (those writes are user choices and are asserted
+  exactly); typing into `Server Address` alone does **not** clear it, `apply`
+  does, clearing it again re-shows it;
+- the banner button switches to the page holding the field and focuses it.
+
+Verdict line is `BACKEND_WARN_RESULT ok|FAIL <n>`; a FAIL is a `!! REGRESSION`
+(exit 1), a probe that never prints `EXIT_CLEAN` is exit 3. Its stderr is
+folded into the branch warning count. Control (measured): against the merge
+base before the fix it reports `banner_present FAIL found=0` and exit 1.
+
+Two measured facts it depends on, worth knowing before editing prefs.js:
+`Adw.ComboRow` and `Adw.Banner` do **not** parse markup on libadwaita 1.9
+(`&amp;` renders verbatim) while `Adw.ActionRow` does — so the subtitle sets
+`use_markup = false` explicitly and is assigned after construction, and the
+banner title stays free of `<`/`&`. Read `win.get_visible_page()` in a probe,
+not the `visible_page` property: the property fast path logs a Gjs-WARNING
+about Adw's introspection that the branch itself never emits.
+
 ## Failure paths worth re-running
 
 - **Window closed mid-probe** — `sed 's|^win.present();|&\nwin.close();|'` on

--- a/tests/repros/prefs-rig/probe_backend_warning.js
+++ b/tests/repros/prefs-rig/probe_backend_warning.js
@@ -1,0 +1,152 @@
+// Probe for #116: Speech Backend → Primary Provider = Local must WARN when no
+// Wyoming server address is set, and the warning must track both inputs.
+//
+// Runs against a fixture with speech_backend=local and NO wyoming_host (run.sh
+// writes it to a second sandbox HOME). Everything is asserted on RENDERED text
+// -- a markup failure keeps the property and blanks the label, so a property
+// snapshot would pass a warning nobody can read.
+//
+// Usage (run.sh does this): gjs -m probe_backend_warning.js <ABSOLUTE prefs.js>
+// Prints one `BACKEND_WARN <check> PASS|FAIL …` line per check, then
+// `BACKEND_WARN_RESULT ok|FAIL <n>` and `EXIT_CLEAN`.
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Gtk from 'gi://Gtk?version=4.0';
+import Adw from 'gi://Adw?version=1';
+import system from 'system';
+
+Gio.resources_register(Gio.resource_load(
+    '/usr/share/gnome-shell/org.gnome.Shell.Extensions.src.gresource'));
+
+const PREFS = system.programArgs[0];
+if (!PREFS || !GLib.path_is_absolute(PREFS)) {
+    printerr(`probe_backend_warning.js: need an ABSOLUTE path to prefs.js, got "${PREFS ?? ''}".`);
+    system.exit(2);
+}
+const EXTDIR = GLib.getenv('GS_PREFS_EXTDIR') ||
+    (GLib.get_current_dir() + '/fakeext');
+
+Gtk.init();
+Adw.init();
+
+const {default: Prefs} = await import(`file://${PREFS}`);
+
+const rows = new Map();
+const writes = [];
+const origCombo = Prefs.prototype._addComboRow;
+Prefs.prototype._addComboRow = function (group, title, ...rest) {
+    const row = origCombo.call(this, group, title, ...rest);
+    rows.set(title, row);
+    return row;
+};
+Prefs.prototype._setConfigValue = function (k, v) { writes.push(`set ${k}=${v}`); };
+Prefs.prototype._deleteConfigKey = function (k) { writes.push(`delete ${k}`); };
+
+const dir = Gio.File.new_for_path(EXTDIR);
+const metadata = JSON.parse(new TextDecoder().decode(
+    GLib.file_get_contents(`${EXTDIR}/metadata.json`)[1]));
+metadata.dir = dir;
+metadata.path = EXTDIR;
+
+const prefs = new Prefs(metadata);
+const win = new Adw.PreferencesWindow();
+prefs.fillPreferencesWindow(win);
+win.present();
+
+function* walk(w) {
+    if (!w) return;
+    yield w;
+    let c = w.get_first_child();
+    while (c) { yield* walk(c); c = c.get_next_sibling(); }
+}
+const rendered = w => [...walk(w)].filter(x => x instanceof Gtk.Label).map(x => x.get_text());
+const unescape = s => s.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+
+let fails = 0;
+const check = (name, ok, detail) => {
+    if (!ok) fails++;
+    print(`BACKEND_WARN ${name} ${ok ? 'PASS' : 'FAIL'} ${detail}`);
+};
+
+// Fixture sanity: this probe means nothing against the wrong config.
+check('fixture', prefs._config.speech_backend === 'local' && !prefs._config.wyoming_host,
+    `speech_backend=${prefs._config.speech_backend} wyoming_host=${JSON.stringify(prefs._config.wyoming_host ?? null)}`);
+
+const loop = new GLib.MainLoop(null, false);
+GLib.timeout_add(GLib.PRIORITY_DEFAULT, 600, () => {
+    const combo = rows.get('Primary Provider');
+    check('combo_row', !!combo, combo ? `selected=${combo.get_selected()}` : '<missing row>');
+
+    // 1. The combo's subtitle names the dependency, and RENDERS.
+    const sub = combo?.subtitle ?? '';
+    const subShown = combo ? rendered(combo) : [];
+    const subHit = subShown.find(t => t === sub || t === unescape(sub));
+    check('subtitle_names_dependency', /Offline Server/.test(sub) && /Wyoming server address/i.test(sub),
+        `property="${sub}"`);
+    check('subtitle_rendered', subHit !== undefined,
+        subHit !== undefined ? `get_text()="${subHit}"` : `get_text()="" <<BLANK>> (labels: ${subShown.map(t => JSON.stringify(t)).join(',')})`);
+
+    // 2. Exactly one revealed banner mentions the Wyoming address, and RENDERS.
+    const banners = [...walk(win)].filter(w => w instanceof Adw.Banner && /Wyoming/.test(w.title));
+    check('banner_present', banners.length === 1, `found=${banners.length}`);
+    const banner = banners[0];
+    if (banner) {
+        check('banner_revealed_local_nohost', banner.revealed === true, `revealed=${banner.revealed}`);
+        const shown = rendered(banner);
+        const hit = shown.find(t => t === banner.title || t === unescape(banner.title));
+        check('banner_rendered', hit !== undefined,
+            hit !== undefined ? `get_text()="${hit}"` : `get_text()="" <<BLANK>> (labels: ${shown.map(t => JSON.stringify(t)).join(',')})`);
+        check('banner_has_button', !!banner.button_label, `button_label="${banner.button_label}"`);
+    }
+    // 3. Building the window wrote NOTHING.
+    check('no_writes_on_build', writes.length === 0, writes.length ? writes.join(', ') : 'none');
+
+    if (combo && banner) {
+        // 4. Provider flips hide/show it. These ARE user choices, so the
+        //    writes they produce are expected and asserted exactly.
+        const before = writes.length;
+        combo.set_selected(0);            // azure
+        check('hides_on_azure', banner.revealed === false, `revealed=${banner.revealed}`);
+        combo.set_selected(1);            // local
+        check('shows_on_local', banner.revealed === true, `revealed=${banner.revealed}`);
+        check('toggle_writes_exact',
+            writes.slice(before).join(', ') === 'set speech_backend=azure, set speech_backend=local',
+            writes.slice(before).join(', ') || 'none');
+
+        // 5. The address row: typing alone must NOT clear it; apply must.
+        const host = [...walk(win)].find(w => w instanceof Adw.EntryRow && w.title === 'Server Address');
+        check('host_row', !!host, host ? 'found Server Address' : '<missing row>');
+        if (host) {
+            host.set_text('wyoming.example');
+            check('typing_alone_keeps_warning', banner.revealed === true, `revealed=${banner.revealed}`);
+            host.emit('apply');
+            check('hides_on_host_apply', banner.revealed === false, `revealed=${banner.revealed}`);
+            host.set_text('   ');
+            host.emit('apply');
+            check('shows_on_host_cleared', banner.revealed === true, `revealed=${banner.revealed}`);
+
+            // 6. The button jumps to the page that holds the field.
+            const pageOf = w => { for (let p = w; p; p = p.get_parent()) if (p instanceof Adw.PreferencesPage) return p; return null; };
+            const hostPage = pageOf(host);
+            banner.emit('button-clicked');
+            // get_visible_page(), not the property: GJS's property fast path
+            // logs a Gjs-WARNING about Adw's visible-page introspection, and
+            // a probe must not manufacture stderr the branch did not.
+            const vis = win.get_visible_page();
+            check('button_switches_page', vis === hostPage,
+                `visible_page="${vis?.title}" host_page="${hostPage?.title}"`);
+            const focus = win.get_focus();
+            let focusInHost = false;
+            for (let p = focus; p; p = p.get_parent()) if (p === host) { focusInHost = true; break; }
+            check('button_focuses_host_row', focusInHost,
+                `focus=${focus ? focus.constructor.$gtype.name : 'null'}`);
+        }
+    }
+
+    print(`BACKEND_WARN_RESULT ${fails === 0 ? 'ok' : 'FAIL ' + fails}`);
+    win.close();
+    loop.quit();
+    return GLib.SOURCE_REMOVE;
+});
+loop.run();
+print('EXIT_CLEAN');

--- a/tests/repros/prefs-rig/run.sh
+++ b/tests/repros/prefs-rig/run.sh
@@ -101,7 +101,8 @@ cleanup() {
     else echo "run dir kept for diagnosis: $RUN"; fi
 }
 trap cleanup EXIT
-mkdir -p "$RUN/home/.config/speech-to-cli" "$RUN/fakeext/schemas"
+mkdir -p "$RUN/home/.config/speech-to-cli" "$RUN/home-local/.config/speech-to-cli" \
+         "$RUN/fakeext/schemas"
 
 # --baseline-rev: extract into the run dir, so no caller-supplied path is
 # written to and nothing survives the run.
@@ -167,6 +168,14 @@ json.dump(cfg, open(sys.argv[1] + '/home/.config/speech-to-cli/config.json', 'w'
 print(f"FIXTURE rig-owned, {len(cfg)} pinned keys "
       f"(speaker_sink={cfg.get('speaker_sink')} mic_source={cfg.get('mic_source')} "
       f"from live wpctl); JP's config NOT read")
+# Variant for probe_backend_warning.js (#116): Local chosen, NO wyoming_host.
+# Same pinned keys, one more, one deliberately absent -- a separate HOME so the
+# main harness run never sees it.
+local_cfg = dict(cfg, speech_backend='local')
+local_cfg.pop('wyoming_host', None)
+json.dump(local_cfg, open(sys.argv[1] + '/home-local/.config/speech-to-cli/config.json', 'w'),
+          indent=2)
+print("FIXTURE-LOCAL rig-owned, speech_backend=local, wyoming_host ABSENT")
 PY
 
 # ── Per-PID broadway display ─────────────────────────────────────────────────
@@ -305,6 +314,32 @@ fi
 echo "=== BRANCH $BRANCH ==="; run "$BRANCH" "$RUN/branch.stderr" || exit 3
 echo "--- stderr ---"; cat "$RUN/branch.stderr"
 rc=0
+
+# ── #116 probe: Local without a server address must warn, visibly ────────────
+# BRANCH only -- the baseline predates the feature, so it would be red by
+# construction and gate nothing. Same exit contract: a probe that did not reach
+# EXIT_CLEAN is 3, a FAIL verdict is a REGRESSION (1). Its stderr is folded
+# into the warning count below so a banner that logs Gtk-WARNINGs is caught.
+echo "=== PROBE backend-warning (fixture-local) $BRANCH ==="
+pout=$( cd "$RUN" && GI_TYPELIB_PATH=/usr/lib/gnome-shell/girepository-1.0 \
+  LD_LIBRARY_PATH=/usr/lib/gnome-shell HOME="$RUN/home-local" \
+  GS_PREFS_EXTDIR="$RUN/fakeext" \
+  GSETTINGS_BACKEND=memory GDK_BACKEND=broadway BROADWAY_DISPLAY=$DISP \
+  timeout 60 gjs -m "$HERE/probe_backend_warning.js" "$BRANCH" 2>"$RUN/probe.stderr" )
+echo "$pout"
+case "$pout" in
+    *EXIT_CLEAN*) ;;
+    *) echo "!! HARNESS DID NOT COMPLETE for probe_backend_warning.js"
+       cat "$RUN/probe.stderr" >&2; exit 3 ;;
+esac
+case "$pout" in
+    *"BACKEND_WARN_RESULT ok"*) ;;
+    *) echo "!! REGRESSION: backend-warning probe failed (see BACKEND_WARN FAIL lines)"; rc=1 ;;
+esac
+if [ -s "$RUN/probe.stderr" ]; then
+    echo "--- probe stderr ---"; cat "$RUN/probe.stderr"
+    cat "$RUN/probe.stderr" >> "$RUN/branch.stderr"
+fi
 if [ -n "$BASE" ]; then
     bl=$(grep -c 'Gtk-WARNING\|Adw-WARNING' "$RUN/base.stderr")
     br=$(grep -c 'Gtk-WARNING\|Adw-WARNING' "$RUN/branch.stderr")


### PR DESCRIPTION
Closes #116

**Voice & Sound → Speech Backend → Primary Provider = Local** silently did nothing when **Wake & Spells → Offline Server → Server Address** (`wyoming_host`) was empty: the service's `prefer_local()` needs the host, Azure stayed primary, and prefs said nothing.

> The issue text says "Advanced → Offline"; the Offline Server group actually lives on the **Wake & Spells** page. Wording follows the real page.

## prefs.js
- `Primary Provider` **subtitle names the dependency**: *"Local needs a Wyoming server address (Wake & Spells → Offline Server). Without one, Azure stays primary"*. Plain text with explicit `use_markup = false`, assigned after construction — **measured on libadwaita 1.9: `Adw.ComboRow` does NOT parse its subtitle as markup** (`&amp;` renders verbatim), `Adw.ActionRow` does. The explicit flag (Adw ≥ 1.2) makes the version difference irrelevant.
- **Inline `Adw.Banner`** in the same group (no space when hidden): *"Local is selected, but no Wyoming server address is set — Azure stays primary until you add one"*, button **Set Server Address**. Revealed iff combo == `local` **and** the *applied* address is empty. Tracks the combo's `notify::selected` and the Server Address row's `apply` — not keystrokes, because the service only ever sees the applied value.
- Button → `set_visible_page(Wake & Spells)` + `grab_focus()` on the Server Address row (viewport scroll-to-focus brings it into view).
- No new config keys; no direct `this._config` mutation; every write still goes through `_addComboRow` / `_addEntryRow` → `_setConfigValue`.

## prefs-rig
New `probe_backend_warning.js`, run by `run.sh` against the **branch** on a second rig-owned fixture (`speech_backend=local`, `wyoming_host` absent). Asserts on **rendered** label text, never properties. `BACKEND_WARN_RESULT FAIL` → `!! REGRESSION` (exit 1); no `EXIT_CLEAN` → exit 3; probe stderr folds into the warning count. **Control:** against the merge base it reports `banner_present FAIL found=0` → exit 1.

## Verification (merge base 2ccd171)
```
=== BASELINE ===  BLANK_RENDERED none   WRITES none   EXIT_CLEAN
=== BRANCH   ===  BLANK_RENDERED none   WRITES none   EXIT_CLEAN
=== PROBE backend-warning (fixture-local) ===
BACKEND_WARN subtitle_rendered PASS get_text()="Local needs a Wyoming server address (Wake & Spells → Offline Server). Without one, Azure stays primary"
BACKEND_WARN banner_revealed_local_nohost PASS revealed=true
BACKEND_WARN banner_rendered PASS get_text()="Local is selected, but no Wyoming server address is set — Azure stays primary until you add one"
BACKEND_WARN no_writes_on_build PASS none
BACKEND_WARN hides_on_azure PASS / shows_on_local PASS / toggle_writes_exact PASS set speech_backend=azure, set speech_backend=local
BACKEND_WARN typing_alone_keeps_warning PASS / hides_on_host_apply PASS / shows_on_host_cleared PASS
BACKEND_WARN button_switches_page PASS visible_page="Wake & Spells" / button_focuses_host_row PASS focus=GtkText
BACKEND_WARN_RESULT ok
EXIT_CLEAN
=== Gtk/Adw warning counts ===  baseline=0  branch=0
NONE — stderr identical to baseline        rc=0
```
`tests/repros/run_all.sh` (bare): **65 checks: 65 pass — ALL SUITES GREEN**. Leak scan 0. Ancestry gate: yes.

prefs.js is loaded by the separate prefs process — takes effect the next time the Preferences window is opened; no shell or service restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
