### PR TITLE
docs(repros): README invokes tests/run-repros.sh, which does not exist (#123)

### DIFF
--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -7,14 +7,14 @@ the injector and the network stubbed, so a run touches no device, no port and
 nothing on the developer's live desktop.
 
 ```sh
-tests/run-repros.sh                       # the service in this repo
-tests/run-repros.sh /path/to/service.py   # a worktree, or an extracted SHA
+tests/repros/run_all.sh                   # the service in this repo
+tests/repros/run_all.sh /path/to/service.py   # a worktree, or an extracted SHA
 ```
 
 ## Env contract
 
 `GS_SVC_PATH` — the `gnome-speaks-service.py` under test — is the **only** input
-a suite needs, and `run-repros.sh` sets it. Everything else is derived:
+a suite needs, and `run_all.sh` sets it. Everything else is derived:
 
 ⚠️ **It must be ABSOLUTE.** Each suite runs via `cd "$HERE/<suite>"`, so a
 relative path resolves against the *suite* directory and every suite dies with


### PR DESCRIPTION
Closes #123

`tests/repros/README.md` told the reader to run `tests/run-repros.sh` (lines 10, 11) and said "`run-repros.sh` sets it" (line 17). That file does not exist; the runner is `tests/repros/run_all.sh`, as CLAUDE.md and the runner's own header say. Three occurrences, fixed. `git grep run-repros` over the tracked tree → 0.

## Every path the README names was checked, not just these three

A small audit (scratch script, not committed — it is a one-off, and the README is prose) extracts every backticked token / fenced-command word that looks like a path and resolves it against the repo root, `tests/repros/`, and each suite dir, trying `.py` appended for bare case labels.

**Branch:** 16 resolve, 2 unresolved — both legitimate: `*.py` is a glob in prose, and `state.py` is speech-to-cli's whitelist file in the sibling checkout (exists there; the README says so).

**Positive control — the same audit on `origin/main`'s README** flags exactly the two stale forms on top of those:
```
MISSING  run-repros.sh
MISSING  tests/run-repros.sh
```
So the instrument sees the defect, and the branch has none of it.

## Gates

- Markdown only; no shell edits (`bash -n` n/a)
- leak scan on the diff: 0 hits
- `tests/repros/run_all.sh` bare on the pushed head: `67 checks: 67 pass, 0 fail` · `ALL SUITES GREEN` on head 76896a7 (rebased on 7dbf981)

Independent of #157 (#115), which touches other lines of the same file; #164 is rebased on `7dbf981`; GitHub reports it `clean`.
