### PR TITLE
fix: keep the sentence boundary when the streamed buffer ends in ". " (#154)

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -4974,18 +4974,34 @@ class GnomeSpeaksService:
         r'(?<=[.!?])'   # lookbehind for sentence-ending punctuation
         r'(?:\s+|$)'    # followed by whitespace or end-of-string
     )
+    # The buffer ENDS on a boundary: punctuation then whitespace. Split above
+    # consumes that whitespace, so it must be recognised before splitting or
+    # the last part comes back looking like an unfinished sentence (#154).
+    _SENTENCE_TAIL_RE = re.compile(r'[.!?]\s+$')
 
     def _split_sentences(self, buffer):
         """Split buffer into (complete_sentences_list, remaining_buffer).
 
-        A sentence is considered complete when it ends with . ! or ?
-        followed by whitespace (or end of string, but only if the stream
-        has finished — callers should only pass is_final=True at the end).
-        Returns (list_of_sentences, leftover_buffer).
+        A sentence is complete when it ends with . ! or ? followed by
+        whitespace. The last part is the leftover ONLY when the buffer does
+        not end on such a boundary; the split consumes the boundary
+        whitespace, so a leftover taken from a buffer ending in ". " came
+        back as "Beta two follows." and the next token fused onto it
+        ("follows.Gamma" -- spoken and subtitled as one sentence, #154).
+        Whitespace is never part of a returned sentence, and the boundary
+        it marked is never carried into the leftover: the caller strips and
+        joins, so the spoken text is the reply with single spaces between
+        sentences. Returns (list_of_sentences, leftover_buffer).
         """
         parts = self._SENTENCE_BOUNDARY_RE.split(buffer)
         # Filter out empty strings from split
         parts = [p for p in parts if p.strip()]
+        if not parts:
+            return [], buffer
+        if self._SENTENCE_TAIL_RE.search(buffer):
+            # Every part is complete -- including the last one, whose
+            # boundary whitespace the split just ate. Nothing to hold back.
+            return parts, ""
         if len(parts) <= 1:
             return [], buffer  # no complete sentence yet
         # All but the last part are complete sentences

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -94,6 +94,7 @@ tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
 | `subtitle-token` | #42 / #78 | `65bd57b` | e1–e4 fail |
 | `begin-refused` | #79 / #84 | `15dd402`, `f290d7e` | j, k fail — **l stays green on both sides** |
 | `tts-prefetch` | #134 (×#146 for p4) | `a20afea` | **verified** — p1 fails (wall 3.01 s serial vs 2.21 s pipelined, S=0.4/P=0.6); **p2, p3, p4 report `2` (SETUP FAILURE) there, not `0`** — the prepared-ahead window they test does not exist on a service that never prefetches, and a suite that passed on it would be measuring nothing. p4 is a guard: `skip_current()` (the #146 interrupt path) is a no-op while a reply holds the queue, and the queue path has no prefetch — it goes red if either premise changes |
+| `sentence-split` | #154 | `5dde4b4` | **verified** — s1 fails (2 synthesis calls: `Beta two follows.Gamma three ends.` spoken and subtitled as one); s2 fails 7 of 13 rows — the issue's `. ` token, two boundaries in one token, `\n`, double space, `!`/`?`, an ellipsis, `e.g.` — every shape where the buffer ends in `[.!?]` + whitespace with a second boundary before it. Guards green on both sides: tokenizer-shaped tokens, `3.5`, fullwidth punctuation (not a boundary, unchanged), no terminal punctuation |
 | `pin-lifecycle` | #46 ×#57 | `15dd402` | compound X: X1 FAIL, X2 PASS, X3 FAIL |
 | `version-cache` | #53 / #85 | two-sided, below | `577a05f` passes, `7eaeb02` fails |
 | `prefs-rig` | #82 | merge base of the branch | more warnings than baseline = fail |

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -126,6 +126,10 @@ run subtitle-token repro_e1_stale_complete_frame.py repro_e2_foreign_cancel_free
 run begin-refused  repro_j_first_sentence.py repro_k_remainder.py repro_l_healthy_reply.py
 run tts-prefetch   repro_p1_one_ahead.py repro_p2_stop_after_first.py \
                    repro_p3_claim_window_prefetched.py repro_p4_skip_cannot_reach_reply.py
+# sentence-split (#154): what TEXT the AI reply spoke. Real worker, the fake
+# records the full text handed to synthesis and the GLib spy the subtitle
+# frames; every row asserts speech == reply joined by single spaces.
+run sentence-split repro_s1_token_fusion.py repro_s2_edge_table.py
 run dead-recorder  repro_e_single_shot_turn_end.py repro_f_text_survives_yank.py \
                    repro_g_ws_init_unbound.py repro_h_stale_prewarm.py \
                    repro_i_healthy_loop.py

--- a/tests/repros/sentence-split/repro_s1_token_fusion.py
+++ b/tests/repros/sentence-split/repro_s1_token_fusion.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Issue #154: a token ending ". " must not fuse the next sentence onto it.
+
+_split_sentences returned the LAST re.split part as the leftover buffer, but
+the split had already consumed the whitespace that followed it. So with the
+stream the issue measured --
+
+    "Alpha one is here. " | "Beta two follows. " | "Gamma three ends."
+
+-- the leftover after the second token was "Beta two follows." (space gone)
+and the third token was appended flush: "Beta two follows.Gamma three ends.",
+spoken as ONE sentence, subtitled as one, timed as one.
+
+This drives the real worker with exactly those tokens and asserts:
+  (a) three synthesis calls, one per sentence, in order
+  (b) each text is its own strip() -- no boundary whitespace leaked into TTS
+  (c) the spoken text is the reply joined by single spaces
+  (d) the subtitle overlay saw the same three texts
+
+exit 0 = three sentences; 1 = fused (the defect); 2 = setup.
+"""
+import sys
+
+import split_harness as sh
+
+TOKENS = ["Alpha one is here. ", "Beta two follows. ", "Gamma three ends."]
+WANT = ["Alpha one is here.", "Beta two follows.", "Gamma three ends."]
+
+
+def main():
+    print(f"service under test: {sh.SVC_PATH}")
+    mod, _tl, _inj = sh.load()
+    svc = sh.make_service(mod)
+
+    r = sh.speak_reply(mod, svc, TOKENS)
+    if not r.finished:
+        print("  ! SETUP FAILURE — the worker never finished")
+        return 2
+    if not r.tts_texts:
+        print("  ! SETUP FAILURE — nothing reached synthesis; nothing measured")
+        return 2
+
+    print(f"  tokens:    {TOKENS}")
+    print(f"  TTS texts: {r.tts_texts}")
+    print(f"  subtitles: {r.subtitle_texts}")
+    bad = r.problems()
+    if r.tts_texts != WANT:
+        bad.insert(0, f"{len(r.tts_texts)} synthesis call(s), expected 3: "
+                      f"{r.tts_texts!r}")
+    if r.leaked:
+        bad.append(f"leaked cancel tokens: {r.leaked}")
+    if bad:
+        print("\nFAIL: the ' . ' boundary was lost —")
+        for b in bad:
+            print(f"  - {b}")
+        return 1
+    print("\nPASS: three sentences, three synthesis calls, subtitles match, "
+          "no whitespace in any TTS text.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/sentence-split/repro_s2_edge_table.py
+++ b/tests/repros/sentence-split/repro_s2_edge_table.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Issue #154, the wider table: every token shape that puts a boundary at the
+END of the buffer, plus the shapes that must NOT change.
+
+Each row is one AI reply through the real worker. A row is red when the
+spoken text is not the reply joined by single spaces (a cut that lost its
+space, or a cut inside a word), when whitespace leaks into a TTS text, or
+when the subtitle texts differ from the TTS texts. Measured on the merge
+base 5dde4b4: 7 of 13 rows fuse -- not just the issue's ". " token, but any
+buffer holding two boundaries and ending in [.!?] + whitespace (newline,
+double space, "!" / "?", an ellipsis). The rows that pass there are the
+guards: decimals, tokenizer-shaped tokens, fullwidth punctuation (not a
+boundary today, not one after), and text with no terminal punctuation.
+
+exit 0 = every row clean; 1 = a row fused; 2 = setup (a worker hung or a row
+spoke nothing).
+"""
+import sys
+
+import split_harness as sh
+
+# (name, tokens). Names are what a red must print.
+CASES = [
+    ("issue: tokens end '. '",      ["Alpha one is here. ", "Beta two follows. ", "Gamma three ends."]),
+    ("tokenizer-shaped",            ["Alpha one is here.", " Beta two follows.", " Gamma three ends."]),
+    ("two sentences in one token",  ["Alpha one. Beta two. ", "Gamma three."]),
+    ("boundary then newline",       ["Alpha one.\n", "Beta two.\n", "Gamma three."]),
+    ("punct alone then space",      ["Alpha one", ".", " ", "Beta two", ".", " Gamma."]),
+    ("space alone token",           ["Alpha one.", " ", "Beta two.", " ", "Gamma."]),
+    ("decimal 3.5",                 ["Pi is about 3.", "5 today. ", "Really."]),
+    ("abbrev e.g.",                 ["Use a tool, e.g. ", "a hammer. ", "Done."]),
+    ("exclaim/question",            ["Wow! ", "Really? ", "Yes."]),
+    ("ellipsis",                    ["Wait... ", "for it. ", "Now."]),
+    ("unicode fullwidth",           ["日本語です。", "次の文。", "終わり"]),
+    ("double trailing space",       ["Alpha one.  ", "Beta two.  ", "Gamma."]),
+    ("no punctuation",              ["just some", " words with no end"]),
+]
+
+
+def main():
+    print(f"service under test: {sh.SVC_PATH}")
+    mod, _tl, _inj = sh.load()
+    svc = sh.make_service(mod)
+
+    failed, setup = [], []
+    print(f"  {'row':28} {'':4} TTS texts")
+    for name, tokens in CASES:
+        r = sh.speak_reply(mod, svc, tokens)
+        if not r.finished or not r.tts_texts:
+            setup.append(name)
+            print(f"  {name:28} !!   worker {'hung' if not r.finished else 'spoke nothing'}")
+            continue
+        bad = r.problems()
+        if r.leaked:
+            bad.append(f"leaked cancel tokens: {r.leaked}")
+        tag = "ok" if not bad else "BAD"
+        print(f"  {name:28} {tag:4} {r.tts_texts}")
+        for b in bad:
+            print(f"  {'':28}      - {b}")
+        if bad:
+            failed.append(name)
+
+    if setup:
+        print(f"\n!! SETUP FAILURE — {len(setup)} row(s) measured nothing: {setup}")
+        return 2
+    if failed:
+        print(f"\n[FAIL] {len(failed)}/{len(CASES)} rows fused: {', '.join(failed)}")
+        return 1
+    print(f"\n[PASS] {len(CASES)}/{len(CASES)} rows: speech == reply joined by "
+          "single spaces; subtitles match; no whitespace in TTS text.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/repros/sentence-split/split_harness.py
+++ b/tests/repros/sentence-split/split_harness.py
@@ -1,0 +1,117 @@
+"""Harness for the issue #154 repros: WHAT TEXT did the AI reply speak?
+
+Builds on tts-prefetch/prefetch_harness.py (the real worker, a two-phase fake
+speech_tts, per-PID scratch, isolated CONFIG) and adds the one instrument this
+question needs: the fake records the FULL TEXT handed to synthesis, not just
+the first word. subtitle-token's GLibSpy records the subtitle frames, so the
+text that reached the subtitle overlay is measured alongside, not inferred
+from the fact that both come from the same variable.
+
+speak_reply() drives _conversation_worker with a token list and returns a
+Reply: the TTS texts in synthesis order, the distinct subtitle texts in frame
+order, and the reply the worker would have chronicled ("".join(tokens)).
+
+The invariant the repros assert, stated once here:
+
+    " ".join(tts_texts) == " ".join(reply.split())
+
+i.e. the streamed speech is the whole reply with exactly one space between
+sentences -- no characters lost, no split inside a word, and no boundary
+whitespace leaked into a sentence (each text must equal its own strip()).
+It holds however the splitter chooses to cut, so a row cannot go red for
+splitting "e.g." on its own (which today's splitter does, and this fix does
+not make worse); it goes red only when a cut loses the space it stood on.
+
+exit codes follow the repo contract: 0 clean, 1 defect present, 2 SETUP
+FAILURE (the worker never finished / spoke nothing -- nothing measured).
+"""
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+sys.path.insert(0, os.path.join(_ROOT, "tts-prefetch"))
+
+import prefetch_harness as ph   # noqa: E402
+
+SVC_PATH = ph.SVC_PATH
+wait_for = ph.wait_for
+
+# Fast: the question is WHAT was spoken, not WHEN. p1 owns the timing.
+SYNTH, PLAY = 0.02, 0.03
+
+
+class Reply:
+    def __init__(self, tokens):
+        self.tokens = list(tokens)
+        self.reply = "".join(self.tokens)
+        self.expected = " ".join(self.reply.split())
+        self.tts_texts = []
+        self.subtitle_texts = []
+        self.finished = False
+        self.leaked = []
+
+    @property
+    def spoken(self):
+        return " ".join(self.tts_texts)
+
+    def problems(self):
+        """Every way this reply's speech differs from the reply. [] = clean."""
+        bad = []
+        if self.spoken != self.expected:
+            bad.append(f"spoken {self.spoken!r} != reply {self.expected!r}")
+        for t in self.tts_texts:
+            if t != t.strip() or not t:
+                bad.append(f"whitespace leaked into TTS text {t!r}")
+        if self.subtitle_texts != self.tts_texts:
+            bad.append(f"subtitles {self.subtitle_texts!r} != TTS {self.tts_texts!r}")
+        return bad
+
+
+def load():
+    """Import the service with the recording two-phase fake and the GLib spy."""
+    mod, tl, inj = ph.load(synth_seconds=SYNTH, play_seconds=PLAY)
+    ph.subtitle_spy.assert_isolated(mod)
+    spy = ph.subtitle_spy.install_spy(mod)
+    texts = []
+    prepare, play = mod.speech_tts.tts_prepare, mod.speech_tts.tts_play
+
+    def rec_prepare(text, **kw):
+        texts.append(text)
+        return prepare(text, **kw)
+
+    mod.speech_tts.tts_prepare = rec_prepare
+    # An older service (or a stubbed seam) takes tts(); record the same way.
+    mod.speech_tts.tts = lambda text, **kw: play(rec_prepare(text, **kw), **kw)
+    mod._154_texts = texts
+    mod._154_spy = spy
+    return mod, tl, inj
+
+
+def make_service(mod):
+    svc = ph.make_service(mod)
+    ph.subtitle_spy.scenario(mod, conversation_mode=True)
+    return svc
+
+
+def speak_reply(mod, svc, tokens, timeout=30.0):
+    """One AI reply through the real worker. Returns a Reply."""
+    r = Reply(tokens)
+    texts, spy = mod._154_texts, mod._154_spy
+    n_texts, n_frames = len(texts), len(spy.frames)
+    t = ph.run_reply(mod, svc, r.tokens)
+    t.join(timeout=timeout)
+    r.finished = not t.is_alive()
+    if not r.finished:
+        return r
+    # The speaker is joined before the worker returns, and the 100 % frame is
+    # emitted before the subtitle worker exits -- but its thread is joined
+    # with a 2 s timeout, so give the last frame a moment to land.
+    wait_for(lambda: svc.current_state == "idle", 5.0)
+    frames = [f[0] for f in spy.frames[n_frames:]]
+    r.tts_texts = list(texts[n_texts:])
+    for f in frames:                      # distinct, in first-seen order
+        if not r.subtitle_texts or r.subtitle_texts[-1] != f:
+            r.subtitle_texts.append(f)
+    r.leaked = list(svc._cancels.live())
+    return r


### PR DESCRIPTION
Closes #154

## Root cause

`_split_sentences` runs `re.split` on `(?<=[.!?])(?:\s+|$)` and returns `parts[:-1], parts[-1]`. The split **consumes the boundary whitespace**. When the buffer ends on a boundary (`[.!?]` + whitespace) and holds a second boundary before it, the last part comes back as the "leftover" with its space gone, and the next token is appended flush — `"Beta two follows." + "Gamma three ends."` — spoken as one sentence, subtitled as one, timed as one. A single-part buffer ending `". "` was never affected (returned whole), which is why the issue's stream fuses only from the second token on.

The scope is wider than the issue names: **7 of 13 measured token shapes fuse on `5dde4b4`** — `.`/`!`/`?`, `\n`, double space, an ellipsis, `e.g.`.

## Fix

One regex and one branch: `_SENTENCE_TAIL_RE = r'[.!?]\s+$'`. If the buffer ends on a boundary, every part is complete → `return parts, ""`. Otherwise unchanged. Boundary whitespace is never carried into the leftover and never into a sentence.

Side effect, measured: a lone sentence token ending `". "` is emitted immediately instead of one token later — the eventual cut is the same boundary, so the text is identical and latency is lower. `"e.g. "` still splits as its own sentence, exactly as today. Fullwidth `。！？` are not boundaries today and not after.

## Repro — `tests/repros/sentence-split/` (+2 checks)

Drives the **real worker** with a fake LLM stream; the fake records the full text handed to `tts_prepare` and the GLib spy records the subtitle frames. Every row asserts:

```
" ".join(tts_texts) == " ".join(reply.split())   # whole reply, single spaces, nothing lost, no cut inside a word
each tts_text == tts_text.strip()                # no boundary whitespace leaked into TTS
subtitle_texts == tts_texts                      # overlay saw what the speaker spoke
```

| row | tokens | merge base `5dde4b4` | branch |
|---|---|---|---|
| issue: tokens end `. ` | `Alpha one is here. ` / `Beta two follows. ` / `Gamma three ends.` | **FUSED** `Beta two follows.Gamma three ends.` (2 TTS calls; subtitle fused too) | 3 sentences |
| tokenizer-shaped | `Alpha one is here.` / ` Beta two follows.` / ` Gamma three ends.` | ok | ok |
| two sentences in one token | `Alpha one. Beta two. ` / `Gamma three.` | **FUSED** | ok |
| boundary then newline | `Alpha one.\n` / `Beta two.\n` / `Gamma three.` | **FUSED** | ok |
| punct alone then space | `Alpha one` / `.` / ` ` / `Beta two` / `.` / ` Gamma.` | ok | ok |
| space alone token | `Alpha one.` / ` ` / `Beta two.` / ` ` / `Gamma.` | ok | ok |
| decimal 3.5 | `Pi is about 3.` / `5 today. ` / `Really.` | ok (`3.5` intact) | ok |
| abbrev e.g. | `Use a tool, e.g. ` / `a hammer. ` / `Done.` | **FUSED** `a hammer.Done.` (`e.g.` alone on both sides) | ok |
| exclaim/question | `Wow! ` / `Really? ` / `Yes.` | **FUSED** `Really?Yes.` | ok |
| ellipsis | `Wait... ` / `for it. ` / `Now.` | **FUSED** `for it.Now.` | ok |
| unicode fullwidth | `日本語です。` / `次の文。` / `終わり` | ok (one sentence, unchanged) | ok |
| double trailing space | `Alpha one.  ` / `Beta two.  ` / `Gamma.` | **FUSED** | ok |
| no punctuation | `just some` / ` words with no end` | ok | ok |

Baseline verified red on the extracted merge base: `repro_s1` rc=1 (2 synthesis calls), `repro_s2` 7/13 rows. README table updated.

## Gates

- `tests/repros/run_all.sh` bare: 77 checks: 77 pass, 0 fail — ALL SUITES GREEN on the rebased head (was 76/76 before the rebase onto #165; the tracked-red `cancel-tokens/repro_f_interrupt_race.py`, #167, did not fire this run)
- `python3 verify_wake_gate.py`: all checks passed
- py_compile: ok
- leak scan (diff + new files, `<lan-host>|<wake-word>|<lan-ip>|<site-domain>|~`): 0, control 1

Hedge carried from the issue, verbatim: *How often real providers emit a token that ends in `". "` is not measured.* The fusion is certain whenever they do, and the two-boundaries-in-one-token row (`"Alpha one. Beta two. "`) fires regardless of tokenizer shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed sentence splitting when punctuation is followed by whitespace, preventing adjacent sentences from being merged during speech and subtitle generation.

- **Tests**
  - Added regression coverage for sentence-boundary handling across punctuation, whitespace, line breaks, ellipses, and related edge cases.
  - Added automated checks to verify spoken text and subtitles match the expected sentence segmentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->