### PR TITLE
refactor(repros): per-suite manifests -- suite.list + BASELINE.md + generated README table (#169)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,16 @@ hand and no default that can silently point at a tree that no longer exists.
 Per-suite detail, the pinned baseline SHA each suite discriminates against, and
 why `version-cache` is expected red are in `tests/repros/README.md`.
 
+**Adding a suite = a directory with `suite.list` + `BASELINE.md`; then run
+`tests/repros/gen_readme.sh`** (#169). The runner discovers `tests/repros/*/suite.list`
+(one check per line, `label: cmd` optional, suite dir as cwd) and the README's baseline
+table is GENERATED from the `BASELINE.md` files -- the runner's first check
+(`manifests`) goes red if the block is stale or a suite dir lacks a manifest, and its
+fix is always the generator. Lanes adding suites therefore touch disjoint files; a rebase
+conflict inside the generated block is resolved by re-running `gen_readme.sh`, never by
+hand. Only `prefs-rig` (own invocation shape) and `shell-rig` (not collected) are wired by
+hand.
+
 Two hazards these suites are built to avoid, both measured on 2026-09-06 --
 keep them in mind before adding a suite, and read `tests/repros/README.md`
 before changing one:

--- a/tests/repros/README.md
+++ b/tests/repros/README.md
@@ -65,6 +65,47 @@ Two rules the suites enforce on themselves, both learned the hard way on
   book in `__init__`. A service whose `spellbook.py` has no seam is refused
   (setup failure), the same way an unset `CHRONICLE_PATH` is.
 
+## Adding a suite (three files, none of them shared)
+
+Every suite is a directory under `tests/repros/` that owns its own manifest,
+so two lanes adding suites in the same night touch **disjoint** files (#169 —
+before this, every PR appended a row to the table below and a `run` line to
+`run_all.sh` at the same spot, and three consecutive PRs conflicted there):
+
+1. `tests/repros/<suite>/suite.list` — one **check** per line, in run order.
+   `run_all.sh` discovers every `*/suite.list` (LC_ALL=C order of the directory
+   name) and runs each line with the suite directory as cwd. Two shapes:
+
+   ```
+   repro_x.py              # label = the script;  python3 repro_x.py
+   case A: repro_x.py A    # label "case A";       python3 repro_x.py A
+   ```
+
+   An optional `label: ` prefix (split at the first `: `), then the command,
+   split on whitespace (no quoting). A `*.py` first token runs under `python3`
+   with stderr discarded and a 300 s timeout; anything else is executed
+   directly (resolved relative to the suite dir — `../../leak-scan.sh` is how
+   `leak-scan/` reaches the repo-level script) with stderr merged and a 60 s
+   timeout. Blank lines and `#` comments are skipped — put the *why* next to
+   the lines it governs (see `offline-handoff/suite.list` for one-process-per-
+   case). No order file exists: no suite depends on another, and the runner is
+   serial anyway.
+2. `tests/repros/<suite>/BASELINE.md` — the suite's row(s) for the table below:
+   pinned SHA, what fails there, verified or derived. Any line starting with
+   `| ` (except the `| suite |` header) is collected verbatim.
+3. Run `tests/repros/gen_readme.sh`. It rewrites the marked block below from
+   every `BASELINE.md` and is the **only** writer of that block. `run_all.sh`
+   runs `gen_readme.sh --check` as its first check (`manifests`), which goes
+   red when the block is stale, when a suite directory has no `suite.list`
+   (the runner would silently skip it — a gate green on a test that never ran)
+   or no `BASELINE.md`. **On a rebase conflict inside the block, re-run the
+   generator; never resolve the hunk by hand.**
+
+Two directories are wired by hand and have no `suite.list`, on purpose:
+`prefs-rig` (its own invocation shape — merge-base baseline, `gjs` probe, SKIP
+lines — stays in `run_all.sh`) and `shell-rig` (a headless gnome-shell, not
+collected at all). `gen_readme.sh` knows both by name (`HAND_WIRED`).
+
 ## Baselines are pinned SHAs, never branch names
 
 A suite that diffs against a moving ref goes vacuous the moment its fix merges:
@@ -77,38 +118,43 @@ git archive <baseline-sha> | tar -x -C /tmp/base   # disposable
 tests/repros/run_all.sh /tmp/base/gnome-speaks-service.py
 ```
 
+The table is **generated** from `tests/repros/*/BASELINE.md` by
+`tests/repros/gen_readme.sh` — edit the suite's file, then re-run it.
+
+<!-- BEGIN GENERATED: baselines -- written by tests/repros/gen_readme.sh from tests/repros/*/BASELINE.md; edit those, then re-run it. Never edit this block by hand. -->
 | suite | issue / PR | baseline | expected there |
 |---|---|---|---|
-| `service-audit` | #18–#20, #110, #124 (c8 config-watch), #130 | `7899ccb` | derived (`merge^1`), not re-run; c8 batch-error-toast verified against `025df92` (E1 fails) |
-| `service-audit/repro_c9_loop_error_cap` | #117 | `a20afea` | **verified** — S1 fails (streaming: 98 cycles in 4 s, zero Errors — the silent forever-loop), B1/B2/B3 fail (batch: 1 cycle, toast on the first error, no route words — the issue's "re-enters forever" premise is *false* for batch on the baseline; it stopped, but after one hiccup). Controls B5, S2 green on both sides. B4 was re-pointed by #166 (batch silence must keep the loop ALIVE, the twin of S2) and is red on `a20afea` and `5dde4b4` for that reason |
-| `service-audit/repro_c10_batch_loop_silence` | #166 | `5dde4b4` | **verified** — 7 of 8 fail: L1 (batch loop, silence ×3 then text: 1 cycle, nothing typed, idle — the loop ended at the first quiet cycle; fixed: 35 cycles in 1.5 s, text typed, still listening), L2/L3 (tap and panic stop never got a 2nd/3rd cycle to act in), L4a/L4b (silence-then-errors: no cap toast because the silence had already ended the run), L5a/L5b (`NoAudio` read as silence — silent idle, no toast). L6 (loop OFF, one silent cycle) is the control and stays green on both sides |
-| `service-audit/repro_c11_loop_gap_busy` | #173 | `683b0be` | **verified** — 3 of 5 fail: G1 (text cycle, the speech queue claims the idle gap: 1 cycle, idle, no toast — `start_listening(quick=True)` answered `error: busy (speaking)` and the restart callback dropped it; fixed: re-armed after the item, 5 cycles, listening), G3 (the #117 cap never got its error cycles because the run was already dead), G4 (a queue that never goes quiet: silent on the baseline; fixed: ONE toast after `LOOP_RESTART_RETRIES` bounded waits, the repro pins `LOOP_RESTART_WAIT_SECONDS=0.3`). G2 (stop() during the wait) and G5 (loop OFF) are controls and stay green on both sides. The gap is opened deterministically: `GLib.idle_add` is a gated pump, so the restart sits queued while an item is enqueued and claimed |
-| `chronicle-perf` | #22 / #27 | `6a1ecae` | derived (`merge^1`), not re-run |
-| `chronicle-perf/repro_audio_info_stall` | #135 | `025df92` | **verified** — 319 ms stall, probe on MainThread |
-| `injector-seam` | #24 | `ea47ff1` | derived (`merge^1`), not re-run |
-| `injector-seam/repro_derive_cache` | #136 | `a20afea` | **verified** — 6 fail: 5 acquires issue 5 `list_engines()` + 5 `GetGlobalEngine` (fixed: 1 + 1; a layout switch costs one more `list_engines()`, switching back costs none); the restore/breadcrumb/no-negative-cache/per-bus checks stay green on both sides |
+| `begin-refused` | #79 / #84 | `15dd402`, `f290d7e` | j, k fail — **l stays green on both sides** |
 | `cancel-tokens` | #21 / #33 | `66edc79` | **verified** — 4 of 5 fail |
 | `cancel-tokens` `repro_e` | #132 | `025df92` | **verified** — E1, E3 fail; E2 stays green on both sides |
 | `cancel-tokens` `repro_f` | #132 / PR #146 review | `fd5c8cd` (PR head before revision), `0e014cc` | **verified** — F1 43/126 and 51/300 dictations hit, F2 1/1; 0/101 and clean with the fix. F1 lowers `sys.setswitchinterval` (GS_RACE_SWITCH, default 1e-5) — at CPython's 5 ms default it scored 0/300 on the unfixed tree |
 | `cancel-tokens` `repro_g` | #167 | `99e0214` | **verified** — G1 fails (3 checks: state idle with the STT thread alive, agent item spoken over the mic, item 'done'); G2, G3 green on both sides. This is repro_f's residual `state 'idle'` red made deterministic — no interrupt involved |
-| `dead-recorder` | #57, #48 / #72 | `e863b2c` | **verified** — e, f, h fail; g, i pass |
-| `offline-handoff` | #49 / #70 | `70ff468` | **verified** — pre-#70 *and* pre-#72 |
-| `wake-watcher` | #41, #48 / #121, #137 | `11c8f60`, `a20afea` | **verified** — pre-#41 `11c8f60`: B fails (25-spawn storm, zero sleeps). Pre-#137 `a20afea`: G fails (second recorder after 10 s of fake time, not 0.5) and H fails (a WARNING and a 10 s sleep logged *during shutdown* — the very lines #137 misread as start-time failures); B, C, F fail there too because they assert the bounded ramp before the unchanged 10 s / 60 s steady cadence. A, D, E green on every side. The fake `time.sleep` is scoped to the watcher thread by identity — the constructor also starts `tts-queue-dispatcher`, whose 0.2 s hold-polls were being recorded and stopped (A doubles as that guard: ~240 ms window, dispatcher must survive) |
-| `subtitle-token` | #42 / #78 | `65bd57b` | e1–e4 fail |
-| `begin-refused` | #79 / #84 | `15dd402`, `f290d7e` | j, k fail — **l stays green on both sides** |
-| `tts-prefetch` | #134 (×#146 for p4) | `a20afea` | **verified** — p1 fails (wall 3.01 s serial vs 2.21 s pipelined, S=0.4/P=0.6); **p2, p3, p4 report `2` (SETUP FAILURE) there, not `0`** — the prepared-ahead window they test does not exist on a service that never prefetches, and a suite that passed on it would be measuring nothing. p4 is a guard: `skip_current()` (the #146 interrupt path) is a no-op while a reply holds the queue, and the queue path has no prefetch — it goes red if either premise changes |
-| `sentence-split` | #154 | `5dde4b4` | **verified** — s1 fails (2 synthesis calls: `Beta two follows.Gamma three ends.` spoken and subtitled as one); s2 fails 7 of 13 rows — the issue's `. ` token, two boundaries in one token, `\n`, double space, `!`/`?`, an ellipsis, `e.g.` — every shape where the buffer ends in `[.!?]` + whitespace with a second boundary before it. Guards green on both sides: tokenizer-shaped tokens, `3.5`, fullwidth punctuation (not a boundary, unchanged), no terminal punctuation |
-| `pin-lifecycle` | #46 ×#57 | `15dd402` | compound X: X1 FAIL, X2 PASS, X3 FAIL |
-| `version-cache` | #53 / #85 | two-sided, below | `577a05f` passes, `7eaeb02` fails |
-| `prefs-rig` | #82 | merge base of the branch | more warnings than baseline = fail |
-| `spellbook` | #119, #152 | `025df92` / `a20afea` | **verified** — 8 fail on `025df92`: `cast stop`, `cast halt`, every punctuated trigger (`Cast, stop.`, `Cast - skip`, `Invoke... skip`, …); the denylist, overlay and op-table checks stay green on both sides. The #152 seam checks (`USER_SPELLBOOK_PATH` honours `GS_SPELLBOOK_USER_PATH`; the service reads the seam, not a literal) are red on `a20afea` |
-| `spellbook` | #119 | `025df92` | **verified** — 8 fail: `cast stop`, `cast halt`, every punctuated trigger (`Cast, stop.`, `Cast - skip`, `Invoke... skip`, …); the denylist, overlay and op-table checks stay green on both sides |
-| `spellbook/verify_ha_token` | #129 | `a20afea` | **verified** — 7 of 8 fail (H1 default returns a token / calls `bw`, H3–H6 the config keys are ignored, H7 not synced, H8 personal literals present); H2 (env wins) green on both sides. Token values are never printed: on the maintainer's machine the baseline's personal cache file exists and the default path returns a REAL token |
-| `leak-scan` | #126 | `025df92` | **verified** — 4 hits (tracked unit ×2, two plans) |
-| `shell-rig` | #113 | `3c70314` | **verified** — t0 fails 8 checks: state `idle`, no service row; every later step green on both sides |
+| `chronicle-perf` | #22 / #27 | `6a1ecae` | derived (`merge^1`), not re-run |
+| `chronicle-perf/repro_audio_info_stall` | #135 | `025df92` | **verified** — 319 ms stall, probe on MainThread |
 | `config-keys` | #120 #127 | `025df92` | **verified** — B fails: 8 keys against speech-to-cli before its #21 (`language`, `voice_commands` + 6 shell-only `show_*`), 6 after; D fails: the same 6 `show_*` (no Python reader); A, C pass |
+| `dead-recorder` | #57, #48 / #72 | `e863b2c` | **verified** — e, f, h fail; g, i pass |
 | `deprecations` | #114 | `a20afea` | **verified** — 3 deprecation lines at service start (`GLib.unix_signal_add` ×2, `Gio.DBusConnection.register_object` ×1 — PyGObject warns once per deprecated GI function per process, so two register sites make one line); `GetState` and the Spiel `Name` property answer on both sides. Runs the real `main()` on a private `dbus-run-session` bus the suite re-execs itself under; `register_object` also leaked ~1.5 kB per D-Bus method call (measured; flat through `register_object_with_closures2`) |
+| `injector-seam` | #24 | `ea47ff1` | derived (`merge^1`), not re-run |
+| `injector-seam/repro_derive_cache` | #136 | `a20afea` | **verified** — 6 fail: 5 acquires issue 5 `list_engines()` + 5 `GetGlobalEngine` (fixed: 1 + 1; a layout switch costs one more `list_engines()`, switching back costs none); the restore/breadcrumb/no-negative-cache/per-bus checks stay green on both sides |
 | `install-dropins` | #115 / #103 | `a20afea` | **not re-run, by design** — that `install.sh` ignores unknown flags and would perform a full install (and restart the live service) when handed `--check-dropins`; the suite refuses any installer without the flag (SETUP FAILURE 2, verified against `a20afea`), so discrimination is by construction |
+| `leak-scan` | #126 | `025df92` | **verified** — 4 hits (tracked unit ×2, two plans) |
+| `offline-handoff` | #49 / #70 | `70ff468` | **verified** — pre-#70 *and* pre-#72 |
+| `pin-lifecycle` | #46 ×#57 | `15dd402` | compound X: X1 FAIL, X2 PASS, X3 FAIL |
+| `prefs-rig` | #82 | merge base of the branch | more warnings than baseline = fail |
+| `sentence-split` | #154 | `5dde4b4` | **verified** — s1 fails (2 synthesis calls: `Beta two follows.Gamma three ends.` spoken and subtitled as one); s2 fails 7 of 13 rows — the issue's `. ` token, two boundaries in one token, `
+`, double space, `!`/`?`, an ellipsis, `e.g.` — every shape where the buffer ends in `[.!?]` + whitespace with a second boundary before it. Guards green on both sides: tokenizer-shaped tokens, `3.5`, fullwidth punctuation (not a boundary, unchanged), no terminal punctuation |
+| `service-audit` | #18–#20, #110, #124 (c8 config-watch), #130 | `7899ccb` | derived (`merge^1`), not re-run; c8 batch-error-toast verified against `025df92` (E1 fails) |
+| `service-audit/repro_c9_loop_error_cap` | #117 | `a20afea` | **verified** — S1 fails (streaming: 98 cycles in 4 s, zero Errors — the silent forever-loop), B1/B2/B3 fail (batch: 1 cycle, toast on the first error, no route words — the issue's "re-enters forever" premise is *false* for batch on the baseline; it stopped, but after one hiccup). Controls B5, S2 green on both sides. B4 was re-pointed by #166 (batch silence must keep the loop ALIVE, the twin of S2) and is red on `a20afea` and `5dde4b4` for that reason |
+| `service-audit/repro_c10_batch_loop_silence` | #166 | `5dde4b4` | **verified** — 7 of 8 fail: L1 (batch loop, silence ×3 then text: 1 cycle, nothing typed, idle — the loop ended at the first quiet cycle; fixed: 35 cycles in 1.5 s, text typed, still listening), L2/L3 (tap and panic stop never got a 2nd/3rd cycle to act in), L4a/L4b (silence-then-errors: no cap toast because the silence had already ended the run), L5a/L5b (`NoAudio` read as silence — silent idle, no toast). L6 (loop OFF, one silent cycle) is the control and stays green on both sides |
+| `service-audit/repro_c11_loop_gap_busy` | #173 | `683b0be` | **verified** — 3 of 5 fail: G1 (text cycle, the speech queue claims the idle gap: 1 cycle, idle, no toast — `start_listening(quick=True)` answered `error: busy (speaking)` and the restart callback dropped it; fixed: re-armed after the item, 5 cycles, listening), G3 (the #117 cap never got its error cycles because the run was already dead), G4 (a queue that never goes quiet: silent on the baseline; fixed: ONE toast after `LOOP_RESTART_RETRIES` bounded waits, the repro pins `LOOP_RESTART_WAIT_SECONDS=0.3`). G2 (stop() during the wait) and G5 (loop OFF) are controls and stay green on both sides. The gap is opened deterministically: `GLib.idle_add` is a gated pump, so the restart sits queued while an item is enqueued and claimed |
+| `shell-rig` | #113 | `3c70314` | **verified** — t0 fails 8 checks: state `idle`, no service row; every later step green on both sides |
+| `spellbook` | #119, #152 | `025df92` / `a20afea` | **verified** — 8 fail on `025df92`: `cast stop`, `cast halt`, every punctuated trigger (`Cast, stop.`, `Cast - skip`, `Invoke... skip`, …); the denylist, overlay and op-table checks stay green on both sides. The #152 seam checks (`USER_SPELLBOOK_PATH` honours `GS_SPELLBOOK_USER_PATH`; the service reads the seam, not a literal) are red on `a20afea` |
+| `spellbook/verify_ha_token` | #129 | `a20afea` | **verified** — 7 of 8 fail (H1 default returns a token / calls `bw`, H3–H6 the config keys are ignored, H7 not synced, H8 personal literals present); H2 (env wins) green on both sides. Token values are never printed: on the maintainer's machine the baseline's personal cache file exists and the default path returns a REAL token |
+| `subtitle-token` | #42 / #78 | `65bd57b` | e1–e4 fail |
+| `tts-prefetch` | #134 (×#146 for p4) | `a20afea` | **verified** — p1 fails (wall 3.01 s serial vs 2.21 s pipelined, S=0.4/P=0.6); **p2, p3, p4 report `2` (SETUP FAILURE) there, not `0`** — the prepared-ahead window they test does not exist on a service that never prefetches, and a suite that passed on it would be measuring nothing. p4 is a guard: `skip_current()` (the #146 interrupt path) is a no-op while a reply holds the queue, and the queue path has no prefetch — it goes red if either premise changes |
+| `version-cache` | #53 / #85 | two-sided, below | `577a05f` passes, `7eaeb02` fails |
+| `wake-watcher` | #41, #48 / #121, #137 | `11c8f60`, `a20afea` | **verified** — pre-#41 `11c8f60`: B fails (25-spawn storm, zero sleeps). Pre-#137 `a20afea`: G fails (second recorder after 10 s of fake time, not 0.5) and H fails (a WARNING and a 10 s sleep logged *during shutdown* — the very lines #137 misread as start-time failures); B, C, F fail there too because they assert the bounded ramp before the unchanged 10 s / 60 s steady cadence. A, D, E green on every side. The fake `time.sleep` is scoped to the watcher thread by identity — the constructor also starts `tts-queue-dispatcher`, whose 0.2 s hold-polls were being recorded and stopped (A doubles as that guard: ~240 ms window, dispatcher must survive) |
+<!-- END GENERATED: baselines -->
 
 Two suites are bash and ignore `GS_SVC_PATH`, so pointing the runner at an
 extracted SHA does not re-test that SHA — run them from a checkout of it:
@@ -288,7 +334,8 @@ reaper, not the service. Run it when touching the probe or the reaper.
 
 `tests/repros/shell-rig/run.sh [checkout]` is the other non-python suite and,
 like prefs-rig, is **not** collected by `run_all.sh` (a headless shell is
-~15 s of startup and needs `gnome-shell` on the machine). It installs a
+~15 s of startup and needs `gnome-shell` on the machine) — it has a
+`BASELINE.md` but no `suite.list`, and `gen_readme.sh` lists it as `HAND_WIRED`. It installs a
 checkout's `extension.js` + `stylesheet.css` into a sandboxed
 `XDG_DATA_HOME`, boots `gnome-shell --headless --virtual-monitor 1280x720`
 on a private bus with **no service activation**, and reads the badge from
@@ -323,7 +370,10 @@ reads a false negative.
 
 `prefs-rig/` is a GJS/bash rig (`run.sh` → `gjs` + `gtk4-broadwayd`) testing
 `prefs.js`: 10 files, zero `.py`, by design. A `*.py` inventory returns a false
-negative on it and a python collector must never try to import it. Its exit
+negative on it and a python collector must never try to import it. It has no
+`suite.list` either: its `run_all.sh` block is hand-written (it needs a
+merge-base baseline and a `gjs` probe) and `gen_readme.sh` lists it as
+`HAND_WIRED`. Its exit
 contract is its own: **0** = both runs completed; **1** = a run did not
 complete, or the branch emits *more* warnings than the baseline. A **differing
 stderr is not a failure** — a fix is supposed to change stderr.

--- a/tests/repros/begin-refused/BASELINE.md
+++ b/tests/repros/begin-refused/BASELINE.md
@@ -1,0 +1,11 @@
+# `begin-refused` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `begin-refused` | #79 / #84 | `15dd402`, `f290d7e` | j, k fail — **l stays green on both sides** |

--- a/tests/repros/begin-refused/suite.list
+++ b/tests/repros/begin-refused/suite.list
@@ -1,0 +1,4 @@
+repro_j_first_sentence.py
+repro_k_remainder.py
+# l is a regression GUARD and is green on both sides of its baseline -- see README.
+repro_l_healthy_reply.py

--- a/tests/repros/cancel-tokens/BASELINE.md
+++ b/tests/repros/cancel-tokens/BASELINE.md
@@ -1,0 +1,14 @@
+# `cancel-tokens` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `cancel-tokens` | #21 / #33 | `66edc79` | **verified** — 4 of 5 fail |
+| `cancel-tokens` `repro_e` | #132 | `025df92` | **verified** — E1, E3 fail; E2 stays green on both sides |
+| `cancel-tokens` `repro_f` | #132 / PR #146 review | `fd5c8cd` (PR head before revision), `0e014cc` | **verified** — F1 43/126 and 51/300 dictations hit, F2 1/1; 0/101 and clean with the fix. F1 lowers `sys.setswitchinterval` (GS_RACE_SWITCH, default 1e-5) — at CPython's 5 ms default it scored 0/300 on the unfixed tree |
+| `cancel-tokens` `repro_g` | #167 | `99e0214` | **verified** — G1 fails (3 checks: state idle with the STT thread alive, agent item spoken over the mic, item 'done'); G2, G3 green on both sides. This is repro_f's residual `state 'idle'` red made deterministic — no interrupt involved |

--- a/tests/repros/cancel-tokens/suite.list
+++ b/tests/repros/cancel-tokens/suite.list
@@ -1,0 +1,8 @@
+repro_a_outcome_mislabel.py
+repro_b_transcript_after_stop.py
+repro_c_streaming_after_stop.py
+repro_d_mic_disconnect.py
+repro_e_interrupt_vs_dictation.py
+repro_f_interrupt_race.py
+repro_g_gate_vs_listen.py
+verify_cancel_invariants.py

--- a/tests/repros/chronicle-perf/BASELINE.md
+++ b/tests/repros/chronicle-perf/BASELINE.md
@@ -1,0 +1,12 @@
+# `chronicle-perf` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `chronicle-perf` | #22 / #27 | `6a1ecae` | derived (`merge^1`), not re-run |
+| `chronicle-perf/repro_audio_info_stall` | #135 | `025df92` | **verified** — 319 ms stall, probe on MainThread |

--- a/tests/repros/chronicle-perf/suite.list
+++ b/tests/repros/chronicle-perf/suite.list
@@ -1,0 +1,6 @@
+repro_chronicle_stall.py
+repro_audio_info_stall.py
+verify_archive.py
+verify_chronicle_contract.py
+verify_endpoints.py
+verify_http_envelope.py

--- a/tests/repros/config-keys/BASELINE.md
+++ b/tests/repros/config-keys/BASELINE.md
@@ -1,0 +1,11 @@
+# `config-keys` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `config-keys` | #120 #127 | `025df92` | **verified** — B fails: 8 keys against speech-to-cli before its #21 (`language`, `voice_commands` + 6 shell-only `show_*`), 6 after; D fails: the same 6 `show_*` (no Python reader); A, C pass |

--- a/tests/repros/config-keys/suite.list
+++ b/tests/repros/config-keys/suite.list
@@ -1,0 +1,4 @@
+# Static: prefs.js keys vs speech-to-cli's load_config() whitelist vs
+# _SYNC_FLAGS vs service CONFIG reads. Reads state.py from SPEECH_ENGINE_PATH
+# (~/Projects/speech-to-cli), so a sibling-repo whitelist gap is red HERE.
+verify_config_key_contract.py

--- a/tests/repros/dead-recorder/BASELINE.md
+++ b/tests/repros/dead-recorder/BASELINE.md
@@ -1,0 +1,11 @@
+# `dead-recorder` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `dead-recorder` | #57, #48 / #72 | `e863b2c` | **verified** — e, f, h fail; g, i pass |

--- a/tests/repros/dead-recorder/suite.list
+++ b/tests/repros/dead-recorder/suite.list
@@ -1,0 +1,5 @@
+repro_e_single_shot_turn_end.py
+repro_f_text_survives_yank.py
+repro_g_ws_init_unbound.py
+repro_h_stale_prewarm.py
+repro_i_healthy_loop.py

--- a/tests/repros/deprecations/BASELINE.md
+++ b/tests/repros/deprecations/BASELINE.md
@@ -1,0 +1,11 @@
+# `deprecations` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `deprecations` | #114 | `a20afea` | **verified** — 3 deprecation lines at service start (`GLib.unix_signal_add` ×2, `Gio.DBusConnection.register_object` ×1 — PyGObject warns once per deprecated GI function per process, so two register sites make one line); `GetState` and the Spiel `Name` property answer on both sides. Runs the real `main()` on a private `dbus-run-session` bus the suite re-execs itself under; `register_object` also leaked ~1.5 kB per D-Bus method call (measured; flat through `register_object_with_closures2`) |

--- a/tests/repros/deprecations/suite.list
+++ b/tests/repros/deprecations/suite.list
@@ -1,0 +1,6 @@
+# deprecations (#114): runs the REAL main() on a private dbus-run-session bus
+# (the suite re-execs itself under one), so it needs no live service to be
+# absent and touches nothing on the desktop. Owns org.gnome.Speaks there,
+# round-trips GetState and the Spiel Name property, then SIGTERMs itself
+# through the signal source under test.
+repro_114_startup_deprecations.py

--- a/tests/repros/gen_readme.sh
+++ b/tests/repros/gen_readme.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Generate the baseline/verdict table in tests/repros/README.md from every
+# suite's own tests/repros/<suite>/BASELINE.md, and validate the manifests.
+#
+#   tests/repros/gen_readme.sh           # rewrite the generated block in place
+#   tests/repros/gen_readme.sh --check   # exit 1 if the block is stale; write nothing
+#
+# WHY (#169): the table used to be hand-edited, and every PR that added a suite
+# appended a row at the same spot -- three consecutive PRs conflicted there in
+# one night. Now each suite owns its rows in its own directory and this script
+# is the ONLY writer of the shared block. Two lanes adding suites touch disjoint
+# files; a conflict in the generated block is resolved by re-running this
+# script, never by hand.
+#
+# The block is delimited by two HTML comments (BEGIN/END markers). Everything
+# outside them is prose and is left alone. Rows are collected from every
+# BASELINE.md in LC_ALL=C order of the suite directory name: every line that
+# starts with `| ` except the header row (`| suite |`); the `|---|` separator
+# does not match `^| ` so it needs no rule.
+#
+# --check also validates the manifests, because a suite directory nobody
+# collects is the "instrument that cannot see" trap: a lane adds a suite, the
+# runner never runs it, the gate stays green.
+#   * every suite directory has a BASELINE.md;
+#   * every suite directory has a suite.list, except the two wired by hand
+#     (prefs-rig has its own invocation shape in run_all.sh; shell-rig is a
+#     headless gnome-shell and is deliberately not collected).
+#
+# Exit contract, shared with tests/repros/run_all.sh:
+#   0 clean · 1 stale block / manifest gap (the defect is present) · 2 SETUP FAILURE
+set -u
+set -o pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+README="$HERE/README.md"
+BEGIN='<!-- BEGIN GENERATED: baselines -- written by tests/repros/gen_readme.sh from tests/repros/*/BASELINE.md; edit those, then re-run it. Never edit this block by hand. -->'
+END='<!-- END GENERATED: baselines -->'
+# Suites collected by hand in run_all.sh (or deliberately not at all). A
+# directory listed here needs no suite.list; every other one does.
+HAND_WIRED="prefs-rig shell-rig"
+
+[ -f "$README" ] || { echo "!! SETUP FAILURE: no $README"; exit 2; }
+check=0
+[ "${1:-}" = "--check" ] && check=1
+
+rc=0
+gap() { printf '!! %s\n' "$1"; rc=1; }
+
+# --- manifests -------------------------------------------------------------
+suites=$(cd "$HERE" && for d in */; do d="${d%/}"; [ "$d" = "__pycache__" ] && continue; echo "$d"; done | LC_ALL=C sort)
+[ -n "$suites" ] || { echo "!! SETUP FAILURE: no suite directories under $HERE"; exit 2; }
+for s in $suites; do
+    [ -f "$HERE/$s/BASELINE.md" ] || gap "$s/: no BASELINE.md (every suite pins its baseline SHA and verdict there)"
+    case " $HAND_WIRED " in *" $s "*) continue ;; esac
+    [ -f "$HERE/$s/suite.list" ] || gap "$s/: no suite.list -- run_all.sh will NOT collect it (one check per line; see README, Adding a suite)"
+done
+
+# --- generated block -------------------------------------------------------
+# Rows are validated in THIS shell (gap() must reach rc), then emitted. A gap()
+# inside `$(gen)` would run in a subshell: its rc lost, its `!!` line spliced
+# into the README as a table row -- measured while writing the control for it.
+rows_of() { grep -E '^\| ' "$1" | grep -vE '^\| suite \|'; }
+for s in $suites; do
+    f="$HERE/$s/BASELINE.md"
+    [ -f "$f" ] || continue
+    [ -n "$(rows_of "$f")" ] || gap "$s/BASELINE.md has no table rows (a row is a line starting with '| ')"
+done
+gen() {
+    printf '%s\n' "$BEGIN"
+    printf '| suite | issue / PR | baseline | expected there |\n|---|---|---|---|\n'
+    for s in $suites; do
+        f="$HERE/$s/BASELINE.md"
+        [ -f "$f" ] || continue
+        rows=$(rows_of "$f")
+        [ -n "$rows" ] && printf '%s\n' "$rows"
+    done
+    printf '%s\n' "$END"
+}
+block=$(gen)
+
+n_begin=$(grep -cF -- "$BEGIN" "$README" || true)
+n_end=$(grep -cF -- "$END" "$README" || true)
+if [ "$n_begin" != 1 ] || [ "$n_end" != 1 ]; then
+    echo "!! SETUP FAILURE: expected exactly one BEGIN and one END marker in $README (found $n_begin / $n_end)"
+    exit 2
+fi
+
+# Splice: prose before BEGIN, the block, prose after END. awk prints only
+# outside the markers; the block is inserted where BEGIN was.
+spliced=$(awk -v begin="$BEGIN" -v end="$END" -v block="$block" '
+    $0 == begin { print block; skip = 1; next }
+    $0 == end   { skip = 0; next }
+    !skip       { print }
+' "$README")
+current=$(cat "$README")
+
+if [ "$spliced" = "$current" ]; then
+    [ $rc -eq 0 ] && echo "README generated block up to date ($(printf '%s\n' "$block" | grep -cE '^\| `') rows)"
+    exit $rc
+fi
+if [ $check -eq 1 ]; then
+    echo "!! README STALE: the generated block in tests/repros/README.md does not match tests/repros/*/BASELINE.md"
+    echo "   fix: run tests/repros/gen_readme.sh (never edit the block by hand); on a rebase conflict, re-run it instead of resolving the hunk"
+    diff <(printf '%s\n' "$current") <(printf '%s\n' "$spliced") | grep -E '^[<>]' | cut -c1-100 | head -20
+    exit 1
+fi
+printf '%s\n' "$spliced" > "$README"
+echo "README generated block rewritten ($(printf '%s\n' "$block" | grep -cE '^\| `') rows)"
+exit $rc

--- a/tests/repros/injector-seam/BASELINE.md
+++ b/tests/repros/injector-seam/BASELINE.md
@@ -1,0 +1,12 @@
+# `injector-seam` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `injector-seam` | #24 | `ea47ff1` | derived (`merge^1`), not re-run |
+| `injector-seam/repro_derive_cache` | #136 | `a20afea` | **verified** — 6 fail: 5 acquires issue 5 `list_engines()` + 5 `GetGlobalEngine` (fixed: 1 + 1; a layout switch costs one more `list_engines()`, switching back costs none); the restore/breadcrumb/no-negative-cache/per-bus checks stay green on both sides |

--- a/tests/repros/injector-seam/suite.list
+++ b/tests/repros/injector-seam/suite.list
@@ -1,0 +1,5 @@
+verify_injector_seam.py
+verify_ibus_injector.py
+repro_fallback_retry.py
+repro_fake_context_fallback.py
+repro_derive_cache.py

--- a/tests/repros/install-dropins/BASELINE.md
+++ b/tests/repros/install-dropins/BASELINE.md
@@ -1,0 +1,11 @@
+# `install-dropins` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `install-dropins` | #115 / #103 | `a20afea` | **not re-run, by design** — that `install.sh` ignores unknown flags and would perform a full install (and restart the live service) when handed `--check-dropins`; the suite refuses any installer without the flag (SETUP FAILURE 2, verified against `a20afea`), so discrimination is by construction |

--- a/tests/repros/install-dropins/suite.list
+++ b/tests/repros/install-dropins/suite.list
@@ -1,0 +1,5 @@
+# install-dropins (#115) is bash and tests install.sh, not the service:
+# `--check-dropins` against a SCRATCH $HOME under tmp/repros/ -- planted
+# offline.conf must WARN (positive control first), .conf.disabled and an
+# empty home must not. Nothing is installed and no systemctl call is made.
+verify_dropin_warning.sh

--- a/tests/repros/leak-scan/BASELINE.md
+++ b/tests/repros/leak-scan/BASELINE.md
@@ -1,0 +1,11 @@
+# `leak-scan` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `leak-scan` | #126 | `025df92` | **verified** — 4 hits (tracked unit ×2, two plans) |

--- a/tests/repros/leak-scan/suite.list
+++ b/tests/repros/leak-scan/suite.list
@@ -1,0 +1,7 @@
+# leak-scan is bash and scans the TRACKED TREE of this repo, not GS_SVC_PATH:
+# the repo is public and the maintainer's home path, LAN names and the HA
+# domain must never be committed (#126). It is excluded from its own scan and
+# proves the pattern matches a planted string before it believes a zero.
+# The script lives at tests/leak-scan.sh (it is a repo gate, not only a suite);
+# this directory holds its manifest and baseline so the runner discovers it.
+leak-scan.sh (tracked tree): ../../leak-scan.sh

--- a/tests/repros/offline-handoff/BASELINE.md
+++ b/tests/repros/offline-handoff/BASELINE.md
@@ -1,0 +1,11 @@
+# `offline-handoff` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `offline-handoff` | #49 / #70 | `70ff468` | **verified** — pre-#70 *and* pre-#72 |

--- a/tests/repros/offline-handoff/suite.list
+++ b/tests/repros/offline-handoff/suite.list
@@ -1,0 +1,20 @@
+# ONE PROCESS PER CASE, on purpose.
+#
+# (1) A red must name its scenario. This suite caught
+#     `[FAIL] D azure-healthy-unchanged` on a trial merge while every other
+#     suite was green, because nothing else exercises the ordinary
+#     healthy-Azure dictation path; a single rc=1 line would not have said so.
+# (2) Case ordering is load bearing. Case H replaces stt.wyoming.transcribe and
+#     never restores it, and is safe only because build() re-stubs it on every
+#     call; case G restores _rest_stt_fallback explicitly because build() does
+#     NOT re-stub that one. A process per case makes this irrelevant instead of
+#     merely currently-true.
+case A: repro_offline_handoff.py A
+case B: repro_offline_handoff.py B
+case C: repro_offline_handoff.py C
+case D: repro_offline_handoff.py D
+case E: repro_offline_handoff.py E
+case F: repro_offline_handoff.py F
+case G: repro_offline_handoff.py G
+case H: repro_offline_handoff.py H
+case I: repro_offline_handoff.py I

--- a/tests/repros/pin-lifecycle/BASELINE.md
+++ b/tests/repros/pin-lifecycle/BASELINE.md
@@ -1,0 +1,11 @@
+# `pin-lifecycle` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `pin-lifecycle` | #46 ×#57 | `15dd402` | compound X: X1 FAIL, X2 PASS, X3 FAIL |

--- a/tests/repros/pin-lifecycle/suite.list
+++ b/tests/repros/pin-lifecycle/suite.list
@@ -1,0 +1,3 @@
+repro_pin_lifecycle.py
+repro_compound_pin_x_deadmic.py
+repro_compound_reply_pin.py

--- a/tests/repros/prefs-rig/BASELINE.md
+++ b/tests/repros/prefs-rig/BASELINE.md
@@ -1,0 +1,11 @@
+# `prefs-rig` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `prefs-rig` | #82 | merge base of the branch | more warnings than baseline = fail |

--- a/tests/repros/run_all.sh
+++ b/tests/repros/run_all.sh
@@ -7,6 +7,10 @@
 #
 # Exits non-zero if any suite fails. One line per check.
 #
+# Suites are DISCOVERED from tests/repros/<suite>/suite.list (#169) -- adding a
+# suite never edits this file. See the DISCOVERY block below and
+# tests/repros/README.md, "Adding a suite".
+#
 # NO TEST FRAMEWORK, by project rule: these are plain scripts that exit 0 (clean),
 # 1 (the defect is present) or 2 (SETUP FAILURE -- the repro could not create the
 # window it needed, so it is reporting neither a pass nor a bug).
@@ -102,97 +106,56 @@ line() {
         "$(summarise "$4" "$1/$2" "$3" | cut -c1-80)"
 }
 
-run() {   # run <suite> <script>...
-    suite="$1"; shift
-    for f in "$@"; do
-        out=$(cd "$HERE/$suite" && timeout 300 python3 "$f" 2>/dev/null); st=$?
-        line "$suite" "$f" "$st" "$out"
-    done
-}
-
-run service-audit  repro_c1_dispatch_gate.py repro_c2_hold.py repro_c3_config.py \
-                   repro_c4_timer.py repro_c5_ydotoold_unit.py repro_c6_speech_backend.py repro_c7_loop_tap_stops_vad.py \
-                   repro_c8_batch_error_toast.py repro_c8_config_watch.py repro_c8_keyless_local.py \
-                   repro_c9_loop_error_cap.py repro_c10_batch_loop_silence.py repro_c11_loop_gap_busy.py \
-                   smoke_queue_ops.py verify_queue_invariants.py
-run chronicle-perf repro_chronicle_stall.py repro_audio_info_stall.py verify_archive.py \
-                   verify_chronicle_contract.py verify_endpoints.py verify_http_envelope.py
-run cancel-tokens  repro_a_outcome_mislabel.py repro_b_transcript_after_stop.py \
-                   repro_c_streaming_after_stop.py repro_d_mic_disconnect.py \
-                   repro_e_interrupt_vs_dictation.py repro_f_interrupt_race.py \
-                   repro_g_gate_vs_listen.py verify_cancel_invariants.py
-run subtitle-token repro_e1_stale_complete_frame.py repro_e2_foreign_cancel_freeze.py \
-                   repro_e3_streaming_reply_subtitle.py repro_e4_compound_cycle_then_reply.py
-run begin-refused  repro_j_first_sentence.py repro_k_remainder.py repro_l_healthy_reply.py
-run tts-prefetch   repro_p1_one_ahead.py repro_p2_stop_after_first.py \
-                   repro_p3_claim_window_prefetched.py repro_p4_skip_cannot_reach_reply.py
-# sentence-split (#154): what TEXT the AI reply spoke. Real worker, the fake
-# records the full text handed to synthesis and the GLib spy the subtitle
-# frames; every row asserts speech == reply joined by single spaces.
-run sentence-split repro_s1_token_fusion.py repro_s2_edge_table.py
-run dead-recorder  repro_e_single_shot_turn_end.py repro_f_text_survives_yank.py \
-                   repro_g_ws_init_unbound.py repro_h_stale_prewarm.py \
-                   repro_i_healthy_loop.py
-run pin-lifecycle  repro_pin_lifecycle.py repro_compound_pin_x_deadmic.py \
-                   repro_compound_reply_pin.py
-run injector-seam  verify_injector_seam.py verify_ibus_injector.py repro_fallback_retry.py repro_fake_context_fallback.py \
-                   repro_derive_cache.py
-run version-cache  verify_version_cache.py repro_a_fork_storm.py
-run spellbook      verify_spellbook.py verify_ha_token.py
-# Static: prefs.js keys vs speech-to-cli's load_config() whitelist vs
-# _SYNC_FLAGS vs service CONFIG reads. Reads state.py from SPEECH_ENGINE_PATH
-# (~/Projects/speech-to-cli), so a sibling-repo whitelist gap is red HERE.
-run config-keys    verify_config_key_contract.py
-# deprecations (#114): runs the REAL main() on a private dbus-run-session bus
-# (the suite re-execs itself under one), so it needs no live service to be
-# absent and touches nothing on the desktop. Owns org.gnome.Speaks there,
-# round-trips GetState and the Spiel Name property, then SIGTERMs itself
-# through the signal source under test.
-run deprecations   repro_114_startup_deprecations.py
-
-# leak-scan is bash and scans the TRACKED TREE of this repo, not GS_SVC_PATH:
-# the repo is public and the maintainer's home path, LAN names and the HA
-# domain must never be committed (#126). It is excluded from its own scan and
-# proves the pattern matches a planted string before it believes a zero.
-out=$(timeout 60 "$REPO/tests/leak-scan.sh" 2>&1); st=$?
-line leak-scan "leak-scan.sh (tracked tree)" "$st" "$out"
-
-# install-dropins (#115) is bash too and tests install.sh, not the service:
-# `--check-dropins` against a SCRATCH $HOME under tmp/repros/ -- planted
-# offline.conf must WARN (positive control first), .conf.disabled and an
-# empty home must not. Nothing is installed and no systemctl call is made.
-out=$(timeout 60 "$HERE/install-dropins/verify_dropin_warning.sh" 2>&1); st=$?
-line install-dropins "verify_dropin_warning.sh" "$st" "$out"
-
 # ---------------------------------------------------------------------------
-# offline-handoff: ONE PROCESS PER CASE, on purpose.
+# DISCOVERY (#169). Suites are collected from tests/repros/<suite>/suite.list,
+# in LC_ALL=C order of the directory name, so lanes adding suites touch DISJOINT
+# files -- the hand-maintained `run <suite> ...` list here conflicted on every
+# concurrent PR. No order file: every suite is its own process with per-PID
+# scratch and none depends on another (verified 2026-09-08 by diffing the
+# per-check verdict lines of the hand-ordered runner against this one).
 #
-# (1) A red must name its scenario. This suite caught
-#     `[FAIL] D azure-healthy-unchanged` on a trial merge while every other
-#     suite was green, because nothing else exercises the ordinary
-#     healthy-Azure dictation path; a single rc=1 line would not have said so.
-# (2) Case ordering is load bearing. Case H replaces stt.wyoming.transcribe and
-#     never restores it, and is safe only because build() re-stubs it on every
-#     call; case G restores _rest_stt_fallback explicitly because build() does
-#     NOT re-stub that one. A process per case makes this irrelevant instead of
-#     merely currently-true.
+# suite.list: one CHECK per line, in run order. Blank lines and `#` comments
+# are skipped. Two shapes:
+#     repro_x.py                     label = the script; python3 repro_x.py
+#     case A: repro_x.py A           label "case A"; python3 repro_x.py A
+# i.e. an optional `label: ` prefix (first ": "), then the command, which is
+# split on whitespace (no quoting). The first token is resolved relative to the
+# suite directory and the check runs WITH THAT DIRECTORY AS CWD. A `*.py` token
+# runs under python3 with stderr discarded and a 300 s timeout (the shape the
+# python suites always had); anything else is executed directly with stderr
+# merged and a 60 s timeout (the shape leak-scan and install-dropins had).
+#
+# ONE PROCESS PER CASE (offline-handoff, wake-watcher) is expressed as one line
+# per case -- the reasons are in each suite.list, next to the lines they govern.
+#
+# The manifest/README check runs FIRST: gen_readme.sh --check fails when a
+# suite directory has no suite.list (the runner would silently skip it -- a
+# gate green on a test that never ran), no BASELINE.md, or when the generated
+# table in README.md is stale. Its fix is always "run tests/repros/gen_readme.sh".
 # ---------------------------------------------------------------------------
-for c in A B C D E F G H I; do
-    out=$(cd "$HERE/offline-handoff" && timeout 300 python3 repro_offline_handoff.py "$c" 2>/dev/null)
-    st=$?
-    line offline-handoff "case $c" "$st" "$out"
-done
+out=$(timeout 60 "$HERE/gen_readme.sh" --check 2>&1); st=$?
+line manifests "gen_readme.sh --check" "$st" "$out"
 
-# wake-watcher (#121): same shape, same reason. The watcher is a daemon thread
-# the SERVICE CONSTRUCTOR starts, so one process per case guarantees exactly one
-# watcher per verdict and no case inherits a thread the previous one armed.
-# B discriminates the pre-#41 baseline (11c8f60); G and H discriminate the
-# pre-#137 baseline (a20afea), and B, C, F go red there too (they assert the
-# start-up ramp). A, D, E are guards.
-for c in A B C D E F G H; do
-    out=$(cd "$HERE/wake-watcher" && timeout 300 python3 repro_wake_watcher.py "$c" 2>/dev/null)
-    st=$?
-    line wake-watcher "case $c" "$st" "$out"
+for list in $(cd "$HERE" && ls -d -- */suite.list 2>/dev/null | LC_ALL=C sort); do
+    suite="${list%/suite.list}"
+    while IFS= read -r raw || [ -n "$raw" ]; do
+        # strip comments and surrounding whitespace
+        raw="${raw%%#*}"
+        raw="$(printf '%s' "$raw" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+        [ -n "$raw" ] || continue
+        case "$raw" in
+            *": "*) label="${raw%%: *}"; cmd="${raw#*: }" ;;
+            *)      label="$raw";        cmd="$raw" ;;
+        esac
+        # shellcheck disable=SC2086  -- word splitting is the contract
+        set -- $cmd
+        first="$1"; shift
+        case "$first" in
+            *.py) out=$(cd "$HERE/$suite" && timeout 300 python3 "$first" "$@" 2>/dev/null); st=$? ;;
+            *)    out=$(cd "$HERE/$suite" && timeout 60 "$HERE/$suite/$first" "$@" 2>&1); st=$? ;;
+        esac
+        line "$suite" "$label" "$st" "$out"
+    done < "$HERE/$list"
 done
 
 # ---------------------------------------------------------------------------

--- a/tests/repros/sentence-split/BASELINE.md
+++ b/tests/repros/sentence-split/BASELINE.md
@@ -1,0 +1,11 @@
+# `sentence-split` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `sentence-split` | #154 | `5dde4b4` | **verified** — s1 fails (2 synthesis calls: `Beta two follows.Gamma three ends.` spoken and subtitled as one); s2 fails 7 of 13 rows — the issue's `. ` token, two boundaries in one token, `\n`, double space, `!`/`?`, an ellipsis, `e.g.` — every shape where the buffer ends in `[.!?]` + whitespace with a second boundary before it. Guards green on both sides: tokenizer-shaped tokens, `3.5`, fullwidth punctuation (not a boundary, unchanged), no terminal punctuation |

--- a/tests/repros/sentence-split/suite.list
+++ b/tests/repros/sentence-split/suite.list
@@ -1,0 +1,5 @@
+# sentence-split (#154): what TEXT the AI reply spoke. Real worker, the fake
+# records the full text handed to synthesis and the GLib spy the subtitle
+# frames; every row asserts speech == reply joined by single spaces.
+repro_s1_token_fusion.py
+repro_s2_edge_table.py

--- a/tests/repros/service-audit/BASELINE.md
+++ b/tests/repros/service-audit/BASELINE.md
@@ -1,0 +1,14 @@
+# `service-audit` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `service-audit` | #18–#20, #110, #124 (c8 config-watch), #130 | `7899ccb` | derived (`merge^1`), not re-run; c8 batch-error-toast verified against `025df92` (E1 fails) |
+| `service-audit/repro_c9_loop_error_cap` | #117 | `a20afea` | **verified** — S1 fails (streaming: 98 cycles in 4 s, zero Errors — the silent forever-loop), B1/B2/B3 fail (batch: 1 cycle, toast on the first error, no route words — the issue's "re-enters forever" premise is *false* for batch on the baseline; it stopped, but after one hiccup). Controls B5, S2 green on both sides. B4 was re-pointed by #166 (batch silence must keep the loop ALIVE, the twin of S2) and is red on `a20afea` and `5dde4b4` for that reason |
+| `service-audit/repro_c10_batch_loop_silence` | #166 | `5dde4b4` | **verified** — 7 of 8 fail: L1 (batch loop, silence ×3 then text: 1 cycle, nothing typed, idle — the loop ended at the first quiet cycle; fixed: 35 cycles in 1.5 s, text typed, still listening), L2/L3 (tap and panic stop never got a 2nd/3rd cycle to act in), L4a/L4b (silence-then-errors: no cap toast because the silence had already ended the run), L5a/L5b (`NoAudio` read as silence — silent idle, no toast). L6 (loop OFF, one silent cycle) is the control and stays green on both sides |
+| `service-audit/repro_c11_loop_gap_busy` | #173 | `683b0be` | **verified** — 3 of 5 fail: G1 (text cycle, the speech queue claims the idle gap: 1 cycle, idle, no toast — `start_listening(quick=True)` answered `error: busy (speaking)` and the restart callback dropped it; fixed: re-armed after the item, 5 cycles, listening), G3 (the #117 cap never got its error cycles because the run was already dead), G4 (a queue that never goes quiet: silent on the baseline; fixed: ONE toast after `LOOP_RESTART_RETRIES` bounded waits, the repro pins `LOOP_RESTART_WAIT_SECONDS=0.3`). G2 (stop() during the wait) and G5 (loop OFF) are controls and stay green on both sides. The gap is opened deterministically: `GLib.idle_add` is a gated pump, so the restart sits queued while an item is enqueued and claimed |

--- a/tests/repros/service-audit/suite.list
+++ b/tests/repros/service-audit/suite.list
@@ -1,0 +1,16 @@
+# One check per line, in run order. See tests/repros/README.md, "Adding a suite".
+repro_c1_dispatch_gate.py
+repro_c2_hold.py
+repro_c3_config.py
+repro_c4_timer.py
+repro_c5_ydotoold_unit.py
+repro_c6_speech_backend.py
+repro_c7_loop_tap_stops_vad.py
+repro_c8_batch_error_toast.py
+repro_c8_config_watch.py
+repro_c8_keyless_local.py
+repro_c9_loop_error_cap.py
+repro_c10_batch_loop_silence.py
+repro_c11_loop_gap_busy.py
+smoke_queue_ops.py
+verify_queue_invariants.py

--- a/tests/repros/shell-rig/BASELINE.md
+++ b/tests/repros/shell-rig/BASELINE.md
@@ -1,0 +1,11 @@
+# `shell-rig` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `shell-rig` | #113 | `3c70314` | **verified** — t0 fails 8 checks: state `idle`, no service row; every later step green on both sides |

--- a/tests/repros/spellbook/BASELINE.md
+++ b/tests/repros/spellbook/BASELINE.md
@@ -1,0 +1,12 @@
+# `spellbook` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `spellbook` | #119, #152 | `025df92` / `a20afea` | **verified** — 8 fail on `025df92`: `cast stop`, `cast halt`, every punctuated trigger (`Cast, stop.`, `Cast - skip`, `Invoke... skip`, …); the denylist, overlay and op-table checks stay green on both sides. The #152 seam checks (`USER_SPELLBOOK_PATH` honours `GS_SPELLBOOK_USER_PATH`; the service reads the seam, not a literal) are red on `a20afea` |
+| `spellbook/verify_ha_token` | #129 | `a20afea` | **verified** — 7 of 8 fail (H1 default returns a token / calls `bw`, H3–H6 the config keys are ignored, H7 not synced, H8 personal literals present); H2 (env wins) green on both sides. Token values are never printed: on the maintainer's machine the baseline's personal cache file exists and the default path returns a REAL token |

--- a/tests/repros/spellbook/suite.list
+++ b/tests/repros/spellbook/suite.list
@@ -1,0 +1,2 @@
+verify_spellbook.py
+verify_ha_token.py

--- a/tests/repros/subtitle-token/BASELINE.md
+++ b/tests/repros/subtitle-token/BASELINE.md
@@ -1,0 +1,11 @@
+# `subtitle-token` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `subtitle-token` | #42 / #78 | `65bd57b` | e1–e4 fail |

--- a/tests/repros/subtitle-token/suite.list
+++ b/tests/repros/subtitle-token/suite.list
@@ -1,0 +1,4 @@
+repro_e1_stale_complete_frame.py
+repro_e2_foreign_cancel_freeze.py
+repro_e3_streaming_reply_subtitle.py
+repro_e4_compound_cycle_then_reply.py

--- a/tests/repros/tts-prefetch/BASELINE.md
+++ b/tests/repros/tts-prefetch/BASELINE.md
@@ -1,0 +1,11 @@
+# `tts-prefetch` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `tts-prefetch` | #134 (×#146 for p4) | `a20afea` | **verified** — p1 fails (wall 3.01 s serial vs 2.21 s pipelined, S=0.4/P=0.6); **p2, p3, p4 report `2` (SETUP FAILURE) there, not `0`** — the prepared-ahead window they test does not exist on a service that never prefetches, and a suite that passed on it would be measuring nothing. p4 is a guard: `skip_current()` (the #146 interrupt path) is a no-op while a reply holds the queue, and the queue path has no prefetch — it goes red if either premise changes |

--- a/tests/repros/tts-prefetch/suite.list
+++ b/tests/repros/tts-prefetch/suite.list
@@ -1,0 +1,4 @@
+repro_p1_one_ahead.py
+repro_p2_stop_after_first.py
+repro_p3_claim_window_prefetched.py
+repro_p4_skip_cannot_reach_reply.py

--- a/tests/repros/version-cache/BASELINE.md
+++ b/tests/repros/version-cache/BASELINE.md
@@ -1,0 +1,11 @@
+# `version-cache` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `version-cache` | #53 / #85 | two-sided, below | `577a05f` passes, `7eaeb02` fails |

--- a/tests/repros/version-cache/suite.list
+++ b/tests/repros/version-cache/suite.list
@@ -1,0 +1,2 @@
+verify_version_cache.py
+repro_a_fork_storm.py

--- a/tests/repros/wake-watcher/BASELINE.md
+++ b/tests/repros/wake-watcher/BASELINE.md
@@ -1,0 +1,11 @@
+# `wake-watcher` — baseline
+
+The pinned SHA(s) this suite discriminates against and what fails there.
+`tests/repros/gen_readme.sh` collects the table rows below (every line that
+starts with `| ` except the header and separator) into the generated block in
+`tests/repros/README.md` — edit THIS file, then run the generator. Pin SHAs,
+never branch names (see README, "Baselines are pinned SHAs").
+
+| suite | issue / PR | baseline | expected there |
+|---|---|---|---|
+| `wake-watcher` | #41, #48 / #121, #137 | `11c8f60`, `a20afea` | **verified** — pre-#41 `11c8f60`: B fails (25-spawn storm, zero sleeps). Pre-#137 `a20afea`: G fails (second recorder after 10 s of fake time, not 0.5) and H fails (a WARNING and a 10 s sleep logged *during shutdown* — the very lines #137 misread as start-time failures); B, C, F fail there too because they assert the bounded ramp before the unchanged 10 s / 60 s steady cadence. A, D, E green on every side. The fake `time.sleep` is scoped to the watcher thread by identity — the constructor also starts `tts-queue-dispatcher`, whose 0.2 s hold-polls were being recorded and stopped (A doubles as that guard: ~240 ms window, dispatcher must survive) |

--- a/tests/repros/wake-watcher/suite.list
+++ b/tests/repros/wake-watcher/suite.list
@@ -1,0 +1,15 @@
+# wake-watcher (#121): one process per case, same reason as offline-handoff.
+# The watcher is a daemon thread the SERVICE CONSTRUCTOR starts, so one process
+# per case guarantees exactly one watcher per verdict and no case inherits a
+# thread the previous one armed.
+# B discriminates the pre-#41 baseline (11c8f60); G and H discriminate the
+# pre-#137 baseline (a20afea), and B, C, F go red there too (they assert the
+# start-up ramp). A, D, E are guards.
+case A: repro_wake_watcher.py A
+case B: repro_wake_watcher.py B
+case C: repro_wake_watcher.py C
+case D: repro_wake_watcher.py D
+case E: repro_wake_watcher.py E
+case F: repro_wake_watcher.py F
+case G: repro_wake_watcher.py G
+case H: repro_wake_watcher.py H


### PR DESCRIPTION
Closes #169

`tests/repros/README.md`'s baseline table and `run_all.sh`'s hand-maintained `run <suite> …` lines were a serial merge bottleneck: every PR adding a suite appended at the same spot (three conflicts in one night; #171 landed one more while this branch was open, and was folded in by running the generator, not by hand).

## Now

Adding a suite touches **disjoint** files:

1. `tests/repros/<suite>/suite.list` — one check per line, run order (`label: cmd` optional; `*.py` → python3, else exec; suite dir is cwd).
2. `tests/repros/<suite>/BASELINE.md` — the suite's baseline row(s): pinned SHA, what fails there, verified/derived.
3. `tests/repros/gen_readme.sh` — regenerates the marked block in the README. `run_all.sh`'s first check (`manifests`) runs `gen_readme.sh --check`: red if the block is stale, a suite dir has no `suite.list` (the runner would silently skip it) or no `BASELINE.md`. The fix is always the generator; a rebase conflict inside the block is resolved by re-running it.

`run_all.sh` discovers `*/suite.list` in `LC_ALL=C` order. `prefs-rig` keeps its hand-written block (merge-base baseline, `gjs` probe, SKIP lines); `shell-rig` stays uncollected; both are `HAND_WIRED` in the generator. The `leak-scan/` dir holds only a manifest + baseline — the script stays at `tests/leak-scan.sh`.

## Behaviour-preserving

- Bare runner before (b2d6f17, hand-ordered): **77 checks: 77 pass**. After: see the gate section — same per-check verdict lines (elapsed/pids/timings normalised, compared sorted), plus the one new `manifests` line. Same exit contract, `!!`/SETUP FAILURE/HARNESS INCOMPLETE tallies unchanged. 0 dirty files after a run (`--check` never writes).
- The 26 table rows were split from the README programmatically (first cell → directory), not retyped. One row dropped: the second `spellbook | #119 | 025df92` row was a strict subset of the `#119, #152` row above it.
- `gen_readme.sh --check` controls, each watched to fail first: stale block → 1; dir without `suite.list` → 1; `BASELINE.md` with zero rows → 1 (the first draft passed this for the wrong reason — a `gap()` inside `$(gen)` lost its rc in the subshell; fixed); missing marker → 2.

## Gates

- Bare `tests/repros/run_all.sh` on the rebased head (8068b6c + this): **79 checks: 79 pass** (77 on b2d6f17 + `manifests` + #171's `repro_c10`). Normalised per-check verdict diff vs the 77-line baseline: exactly those two added lines; two `offline-handoff` frame counts jitter by 1 (rc=0 both sides). One run mid-way showed `chronicle-perf/verify_endpoints.py` red on `POST /respeak enqueued playback` — 5/5 green standalone; its `qsize() > before or _queue_current is not None` is read *after* the dispatcher may have drained and finished the instant fake TTS. Pre-existing race, reported separately, not touched here.
- `python3 verify_wake_gate.py` → 0. `bash -n` on every tracked `*.sh` → clean. Leak grep (the standing pattern from `tests/leak-scan.sh`'s external source) over the diff → 0 hits, pattern proven on a planted string.
- `git merge-base --is-ancestor origin/main HEAD` → yes. 0 dirty files after a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of reproduction test suites from suite manifests.
  * Added validation and generation of the consolidated reproduction baseline table.
  * Added multiple new reproduction suites and expanded coverage across cancellation, configuration, service auditing, installation, and other scenarios.

* **Documentation**
  * Documented how to create suites, define baselines, pin reference revisions, and regenerate the shared results table.
  * Updated baseline documentation and consolidated suite results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->