### PR TITLE
fix(quiet-hours): name the weekday when the override ends on another day

### DIFF
--- a/gnome-speaks-service.py
+++ b/gnome-speaks-service.py
@@ -5089,11 +5089,20 @@ class GnomeSpeaksService:
         until = self._quiet_next_boundary(now) or (now + datetime.timedelta(hours=24))
         self._quiet_override = (new, until)
         log.info("Quiet hours %s by override until %s", "ON" if new else "OFF",
-                 until.strftime("%H:%M"))
+                 self._fmt_until(until, now))
         return new
 
     def get_quiet_hours(self):
         return self.quiet_hours_active()
+
+    @staticmethod
+    def _fmt_until(t, now):
+        """HH:MM, prefixed with the weekday when it is not today -- an
+        override with no schedule lasts 24 h, and "until 21:17" alone reads
+        as a few minutes from now."""
+        if t.date() == now.date():
+            return t.strftime("%H:%M")
+        return t.strftime("%a %H:%M")
 
     def quiet_hours_info(self, now=None):
         """GET /status: the verdict and how it was reached."""
@@ -5106,10 +5115,10 @@ class GnomeSpeaksService:
                                                   end_min // 60, end_min % 60),
                 "override": self._quiet_override is not None}
         if self._quiet_override is not None:
-            info["override_until"] = self._quiet_override[1].strftime("%H:%M")
+            info["override_until"] = self._fmt_until(self._quiet_override[1], now)
         if active:
             end = self._quiet_override[1] if self._quiet_override else self._quiet_next_boundary(now)
-            info["until"] = end.strftime("%H:%M") if end else None
+            info["until"] = self._fmt_until(end, now) if end else None
         return info
 
     def _quiet_hours_refusal(self, now=None):

--- a/tests/repros/quiet-hours/repro_quiet_hours.py
+++ b/tests/repros/quiet-hours/repro_quiet_hours.py
@@ -133,8 +133,8 @@ def main():
     new = svc.toggle_quiet_hours(now=t)
     info = svc.quiet_hours_info(t)
     check("Q3", new is False and not svc.quiet_hours_active(t) and info["override"]
-          and info["override_until"] == "08:00",
-          f"toggle inside the window -> off until the scheduled end (info={info})")
+          and info["override_until"] == "Wed 08:00",
+          f"toggle inside the window -> off until the scheduled end, next day named (info={info})")
     check("Q3", not svc.quiet_hours_active(T(7, 59, day=2)) and not svc.quiet_hours_active(T(8, 1, day=2))
           and svc._quiet_override is None,
           "override holds to 07:59, expires at 08:00, then the schedule (now outside) applies")
@@ -155,6 +155,8 @@ def main():
     window(False, "22:00", "08:00")
     t = T(12)
     new = svc.toggle_quiet_hours(now=t)
+    until = svc.quiet_hours_info(t).get("until")
+    check("Q4", until == "Wed 12:00", f"a next-day end names the weekday (until={until!r})")
     check("Q4", new is True and svc.quiet_hours_active(t + dt.timedelta(hours=23))
           and not svc.quiet_hours_active(t + dt.timedelta(hours=25)),
           "schedule off: override lasts 24 h")


### PR DESCRIPTION
Follow-up to #183. With no schedule the override lasts 24 h, and `until 21:17` alone reads as a few minutes from now (seen live right after merging). `quiet_hours_info()`, the 503 text and the log line now say `Sun 21:17` when the end is not today. quiet-hours Q3/Q4 assert it; suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)